### PR TITLE
fix broken link

### DIFF
--- a/kinesis-lambda-efo/README.md
+++ b/kinesis-lambda-efo/README.md
@@ -2,7 +2,7 @@
 
 This pattern creates an AWS Kinesis Data Stream, a stream consumer, and an AWS Lambda function. When data is added to the stream, the Lambda function is invoked via a consumer.
 
-Learn more about this pattern at Serverless Land Patterns: [https://serverlessland.com/patterns/kinesis-to-lambda-enhanced-fan-out](https://serverlessland.com/patterns/kinesis-to-lambda-enhanced-fan-out)
+Learn more about this pattern at Serverless Land Patterns: [https://serverlessland.com/patterns/kinesis-lambda-efo](https://serverlessland.com/patterns/kinesis-lambda-efo)
 
 Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
 


### PR DESCRIPTION
Perm fix might be rename this dir (`kinesis-lambda-efo`) to (`kinesis-lambda-enhanced-fan-out`).  Not sure if this is generated via automation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
