### PR TITLE
Add s3-sqs-lambda pattern

### DIFF
--- a/s3-sqs-lambda/README.md
+++ b/s3-sqs-lambda/README.md
@@ -1,0 +1,82 @@
+# AWS Amazon S3 to SQS to AWS Lambda - Create a Lambda function that resizes images uploaded to S3 using SQS as a notification target
+
+The SAM template deploys a Lambda function, an SQS queue, 2 S3 buckets and the IAM resources required to run the application. An SQS Queue consumes <code>ObjectCreated</code> events from an Amazon S3 bucket if the file has .jpg extension. The SQS triggers a Lambda function. The Lambda code checks the uploaded file is an image and creates a thumbnail version of the image in another bucket.
+
+Learn more about this pattern at Serverless Land Patterns: [https://serverlessland.com/patterns/s3-sqs-lambda](https://serverlessland.com/patterns/s3-sqs-lambda)
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ```bash
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ```bash
+    cd s3-sqs-lambda
+    ```
+1. Install dependencies
+   ```bash
+   npm --prefix ./src install ./src
+   ```
+1. From the command line, use AWS SAM to build and deploy the AWS resources for the pattern as specified in the template.yml file:
+    ```bash
+    sam build
+    sam deploy --guided
+    ```
+1. During the prompts:
+   * Enter a stack name
+   * Enter a source bucket name
+   * Enter a destination bucket name
+   * Enter a queue name
+   * Enter the desired AWS Region
+   * Allow SAM CLI to create IAM roles with the required permissions.
+
+   Once you have run `sam deploy -guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+
+1. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## How it works
+
+* Use the AWS CLI or AWS console to upload an image to the source S3 Bucket
+* If the object is a .jpg the code creates a thumbnail and saves it to the target bucket.
+* The code assumes that the destination bucket exists and its name is a concatenation of the source bucket name followed by the string -resized
+
+==============================================
+
+## Testing
+
+Run the following S3 CLI  command to upload an image to the S3 bucket. Note, you must edit the {SourceBucketName} placeholder with the name of the source S3 Bucket. This is provided in the stack outputs.
+
+```bash
+aws s3 cp './events/exampleImage.png'  s3://{SourceBucketName}
+```
+
+Run the following command to check that a new version of the image has been created in the destination bucket.
+
+```bash
+aws s3 ls s3://{DestinationBucketName}
+```
+
+## Cleanup
+
+1. Delete the stack
+    ```bash
+    aws cloudformation delete-stack --stack-name STACK_NAME
+    ```
+1. Confirm the stack has been deleted
+    ```bash
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus"
+    ```
+----
+Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/s3-sqs-lambda/src/app.js
+++ b/s3-sqs-lambda/src/app.js
@@ -1,0 +1,55 @@
+/*! Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: MIT-0
+ */
+
+const AWS = require('aws-sdk')
+AWS.config.update({region: process.env.AWS_REGION})
+const s3 = new AWS.S3()
+
+const gm = require('gm')
+const NEW_SIZE_PX = 480
+
+// 1. Get S3 Event from SQS Event
+// 2. Load the image from S3.
+// 3. Transform the image.
+// 4. Save the new image in another S3 bucket.
+
+exports.handler = async (event) => {
+  // console.log(JSON.stringify(event, null, 2))
+
+  const s3Event = JSON.parse(event.Records[0].body)
+
+  const Key = decodeURIComponent(s3Event.Records[0].s3.object.key.replace(/\+/g, " "))
+
+  // Read the object from S3
+  const s3Object = await s3.getObject({
+    Bucket: s3Event.Records[0].s3.bucket.name,
+    Key
+  }).promise()
+
+  // Resize the image
+  const data = await resizeImage(s3Object.Body)
+
+  // Write to S3
+  const result = await s3.putObject({
+    Bucket: process.env.DESTINATION_BUCKETNAME,
+    Key,
+    ContentType: 'image/jpeg',
+    Body: data,
+    ACL: 'public-read'
+  }).promise()
+  console.log('Write result: ', result)
+}
+
+
+// Resize - takes and returns a image buffer
+const resizeImage = async (buffer) => {
+  return new Promise((resolve, reject) => {
+    gm(buffer)
+        .resize(NEW_SIZE_PX, NEW_SIZE_PX)
+        .toBuffer('jpg', function (err, data) {
+          if (err) return reject(err)
+          resolve(data)
+        })
+  })
+}

--- a/s3-sqs-lambda/src/package.json
+++ b/s3-sqs-lambda/src/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "resizer",
+  "version": "1.0.0",
+  "description": "",
+  "main": "app.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "Ahmed Mohamed",
+  "license": "MIT-0",
+  "dependencies": {
+    "gm": "^1.23.1"
+  }
+}

--- a/s3-sqs-lambda/template.yaml
+++ b/s3-sqs-lambda/template.yaml
@@ -1,0 +1,102 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Image resizing service through SQS
+
+Parameters:
+  SourceBucketName:
+    Type: String
+  QueueName:
+    Type: String
+  DestinationBucketName:
+    Type: String
+
+Resources:
+  ## S3 bucket
+  SourceBucket:
+    Type: AWS::S3::Bucket
+    DependsOn:
+      - ResizerQueueQueuePolicy
+    Properties:
+      BucketName: !Ref SourceBucketName
+      NotificationConfiguration:
+        QueueConfigurations:
+          - Event: "s3:ObjectCreated:*"
+            Queue: !GetAtt ResizerQueue.Arn
+            Filter:
+              S3Key:
+                Rules:
+                  - Name: suffix
+                    Value: '.jpg'
+
+  DestinationBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Ref DestinationBucketName
+
+  ## SQS Queue
+  ResizerQueue:
+    Type: "AWS::SQS::Queue"
+    Properties:
+      QueueName: !Ref QueueName
+
+  ## Policies
+  ResizerQueueQueuePolicy:
+    Type: "AWS::SQS::QueuePolicy"
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Id: QueuePolicy
+        Statement:
+          - Sid: Allow-SendMessage-To-Queue-From-S3-Event-Notification
+            Effect: Allow
+            Principal:
+              AWS: "*"
+            Action:
+              - "sqs:SendMessage"
+            Resource: !GetAtt ResizerQueue.Arn
+            Condition:
+              ArnLike:
+                "aws:SourceArn": !Join
+                  - ""
+                  - - "arn:aws:s3:::"
+                    - !Ref SourceBucketName
+      Queues:
+        - Ref: ResizerQueue
+
+  ## Lambda function
+  ResizerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: app.handler
+      Runtime: nodejs12.x
+      MemorySize: 2048
+      Layers:
+        - !Sub 'arn:aws:lambda:${AWS::Region}:175033217214:layer:graphicsmagick:2'
+      Policies:
+        - S3ReadPolicy:
+            BucketName: !Ref SourceBucketName
+        - S3CrudPolicy:
+            BucketName: !Ref DestinationBucketName
+      Environment:
+        Variables:
+          DESTINATION_BUCKETNAME: !Ref DestinationBucketName
+      Events:
+        MySQSEvent:
+          Type: SQS
+          Properties:
+            Queue: !GetAtt ResizerQueue.Arn
+
+Outputs:
+  SourceBucketName:
+    Value: !Ref SourceBucketName
+    Description: S3 Bucket for object storage
+  DestinationBucketName:
+    Value: !Ref DestinationBucketName
+    Description: S3 destination Bucket for object storage
+  QueueName:
+    Value: !Ref QueueName
+    Description: SQS Queue for queuing the s3 events
+  FunctionArn:
+    Value: !Ref ResizerFunction
+    Description: ResizerFunction function  Arn


### PR DESCRIPTION
*Issue #, if available:*
[https://github.com/aws-samples/serverless-patterns/issues/29](https://github.com/aws-samples/serverless-patterns/issues/29)

*Description of changes:*
S3 to SQS to Lambda
Create an S3 bucket that sends notifications for created objects to an SQS queue that triggers a lambda function that resizes the image and uploads it to another S3 bucket

<img width="804" alt="s3-sqs-lambda" src="https://user-images.githubusercontent.com/23076/113829213-2147ec80-977d-11eb-8263-a4b5ebe30d14.png">

This is an update to the [s3-lambda pattern](https://serverlessland.com/patterns/s3-lambda), for busy applications with high throughput to s3 buckets. Using SQS between S3 and Lambda enables scale by retaining the events in the SQS queue and throttling it for downstream services.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
