### PR TITLE
Removed reference to function execution role and updated error message

### DIFF
--- a/apigw-http-api-lambda/src/app.js
+++ b/apigw-http-api-lambda/src/app.js
@@ -33,6 +33,6 @@ exports.handler = async (event, context) => {
     return response;
   } catch (error) {
     console.error(error);
-    throw new Error("Function Error");
+    throw new Error(error);
   }
 };

--- a/apigw-http-api-lambda/template.yml
+++ b/apigw-http-api-lambda/template.yml
@@ -39,7 +39,6 @@ Resources:
     Properties:
       FunctionName: !Sub '${AppName}-function'
       Handler: app.handler
-      Role: !GetAtt FunctionExecutionRole.Arn
       # Example function environment variables
       Environment:
         Variables:


### PR DESCRIPTION
Function resource is using default Lambda execution role. Removed reference to function execution role in template.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
