### PR TITLE
fix link in README

### DIFF
--- a/apigw-http-api-lambda/README.md
+++ b/apigw-http-api-lambda/README.md
@@ -2,7 +2,7 @@
 
 This pattern creates an Amazon API Gateway HTTP API and an AWS Lambda function.
 
-Learn more about this pattern at Serverless Land Patterns: << Add the live URL here >>
+Learn more about this pattern at [Serverless Land Patterns](https://serverlessland.com/patterns/apigw-lambda).
 
 Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
 


### PR DESCRIPTION
Fixing the missing link the README file for the API Gateway HTTP API to Lambda pattern. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
