### PR TITLE
Updated Queue Policy, removed uneccessary DependsOn

### DIFF
--- a/s3-sqs/template.yaml
+++ b/s3-sqs/template.yaml
@@ -1,29 +1,26 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Transform: AWS::Serverless-2016-10-31
+Transform: 'AWS::Serverless-2016-10-31'
 Description: Sends notifications from S3 to SQS when an object is created
 
 Parameters:
   SourceBucketName:
     Type: String
-    
+
 Resources:
   ## S3 bucket
   SourceBucket:
-    Type: AWS::S3::Bucket
+    Type: 'AWS::S3::Bucket'
     DependsOn:
-      - StandardQueue
       - QueuePolicy
     Properties:
       BucketName: !Ref SourceBucketName
       NotificationConfiguration:
         QueueConfigurations:
-          - Event: s3:ObjectCreated:*
+          - Event: 's3:ObjectCreated:*'
             Queue: !GetAtt StandardQueue.Arn
-            
+
   QueuePolicy:
-    Type: AWS::SQS::QueuePolicy
-    DependsOn:
-      - StandardQueue
+    Type: 'AWS::SQS::QueuePolicy'
     Properties:
       PolicyDocument:
         Version: 2012-10-17
@@ -32,13 +29,15 @@ Resources:
             Principal:
               AWS: '*'
             Action:
-              - SQS:SendMessage
+              - 'SQS:SendMessage'
             Resource: !GetAtt StandardQueue.Arn
             Condition:
               ArnLike:
                 aws:SourceArn: !Join ["",['arn:aws:s3:::',!Ref SourceBucketName]]
+              StringEquals:
+                'aws:SourceAccount': !Ref 'AWS::AccountId'
       Queues:
         - !Ref StandardQueue
 
   StandardQueue:
-    Type: AWS::SQS::Queue
+    Type: 'AWS::SQS::Queue'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I updated the SQS Queue Policy to match internal AWS security requirements (StringEquals: 'aws:SourceAccount': !Ref 'AWS::AccountId').  Now this pattern can be deployed without generating a Sev 2 ticket.  I also removed the DependsOn attributes that were not needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
