### PR TITLE
HTTP API to Eventbridge using CDK

### DIFF
--- a/apigw-http-api-eventbridge-cdk/README.md
+++ b/apigw-http-api-eventbridge-cdk/README.md
@@ -1,0 +1,68 @@
+# Amazon API Gateway HTTP API to Amazon EventBridge
+
+This pattern creates an HTTP API endpoint that directly integrates with Amazon EventBridge
+
+Learn more about this pattern at Serverless Land Patterns: https://serverlessland/patterns/apigateway-http-eventbridge-cdk
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [Node and NPM](https://nodejs.org/en/download/) installed
+* [AWS Cloud Development Kit](https://docs.aws.amazon.com/cdk/latest/guide/cli.html) (AWS CDK) installed
+
+## Deployment Instructions
+
+1. Clone the project to your local working directory
+    ```
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+
+1. Change the working directory to this pattern's directory
+    ```
+    cd apigw-http-api-eventbridge-cdk/cdk
+    ```
+
+1. Install dependencies
+    ```
+    npm install
+    ```
+
+1. Deploy the stack to your default AWS account and region. The output of this command should give you the HTTP API URL.
+    ```
+    cdk deploy
+    ```
+
+## How it works
+
+This pattern creates an Amazon API gateway HTTP API endpoint. The endpoint uses service integrations to directly connect to Amazon EventBridge. An EventBridge rule sends all events to Cloudwatch Logs.
+
+## Testing
+
+To test the endpoint first send data using the following command. Be sure to update the endpoint with endpoint of your stack.
+
+```
+curl --location --request POST '<your api endpoint>' --header 'Content-Type: application/json' \
+--data-raw '{
+    "Detail":{
+        "message": "This is my test"
+    }
+}'
+```
+
+Then check the logs in Cloudwatch logs
+
+## Cleanup
+ 
+Run the given command to delete the resources that were created. It might take some time for the CloudFormation stack to get deleted.
+```
+cdk destroy
+```
+
+----
+Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/apigw-http-api-eventbridge-cdk/cdk/.gitignore
+++ b/apigw-http-api-eventbridge-cdk/cdk/.gitignore
@@ -1,0 +1,8 @@
+*.js
+!jest.config.js
+*.d.ts
+node_modules
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/apigw-http-api-eventbridge-cdk/cdk/.npmignore
+++ b/apigw-http-api-eventbridge-cdk/cdk/.npmignore
@@ -1,0 +1,6 @@
+*.ts
+!*.d.ts
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/apigw-http-api-eventbridge-cdk/cdk/bin/api-eventbridge.ts
+++ b/apigw-http-api-eventbridge-cdk/cdk/bin/api-eventbridge.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import 'source-map-support/register';
+import * as cdk from '@aws-cdk/core';
+import { ApiEventbridgeStack } from '../lib/api-eventbridge-stack';
+
+const app = new cdk.App();
+new ApiEventbridgeStack(app, 'ApiEventbridgeStack', {
+  /* If you don't specify 'env', this stack will be environment-agnostic.
+   * Account/Region-dependent features and context lookups will not work,
+   * but a single synthesized template can be deployed anywhere. */
+
+  /* Uncomment the next line to specialize this stack for the AWS Account
+   * and Region that are implied by the current CLI configuration. */
+  // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
+
+  /* Uncomment the next line if you know exactly what Account and Region you
+   * want to deploy the stack to. */
+  // env: { account: '123456789012', region: 'us-east-1' },
+
+  /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
+});

--- a/apigw-http-api-eventbridge-cdk/cdk/cdk.json
+++ b/apigw-http-api-eventbridge-cdk/cdk/cdk.json
@@ -1,0 +1,17 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/api-eventbridge.ts",
+  "context": {
+    "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
+    "@aws-cdk/core:enableStackNameDuplicates": "true",
+    "aws-cdk:enableDiffNoFail": "true",
+    "@aws-cdk/core:stackRelativeExports": "true",
+    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
+    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
+    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
+    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
+    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
+    "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
+    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
+    "@aws-cdk/aws-lambda:recognizeVersionProps": true
+  }
+}

--- a/apigw-http-api-eventbridge-cdk/cdk/lib/api-eventbridge-stack.ts
+++ b/apigw-http-api-eventbridge-cdk/cdk/lib/api-eventbridge-stack.ts
@@ -1,0 +1,78 @@
+import * as cdk from '@aws-cdk/core';
+import { EventBus, Rule } from '@aws-cdk/aws-events';
+import { CfnIntegration, CfnRoute, HttpApi } from '@aws-cdk/aws-apigatewayv2';
+import { Effect, PolicyStatement, Role, ServicePrincipal } from '@aws-cdk/aws-iam';
+import { LogGroup } from '@aws-cdk/aws-logs';
+import { CloudWatchLogGroup } from '@aws-cdk/aws-events-targets';
+
+
+export class ApiEventbridgeStack extends cdk.Stack {
+  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const eventBus = new EventBus(this, 'MyEventBus', {
+      eventBusName: 'MyEventBus'
+    });
+
+    /* LOGGING */
+    const eventLoggerRule = new Rule(this, "EventLoggerRule", {
+      description: "Log all events",
+      eventPattern: {
+        region: [ "ap-southeast-2" ]
+      },
+      eventBus: eventBus
+    });
+
+    const logGroup = new LogGroup(this, 'EventLogGroup', {
+      logGroupName: '/aws/events/MyEventBus',
+    });
+
+    eventLoggerRule.addTarget(new CloudWatchLogGroup(logGroup));
+  
+
+    /* API */
+    const httpApi = new HttpApi(this, 'MyHttpApi');
+
+    /* There's no Eventbridge integration available as CDK L2 yet, so we have to use L1 and create Role, Integration and Route */
+    const apiRole = new Role(this, 'EventBridgeIntegrationRole', {
+      assumedBy: new ServicePrincipal('apigateway.amazonaws.com'),
+    });
+
+    apiRole.addToPolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        resources: [eventBus.eventBusArn],
+        actions: ['events:PutEvents'],
+      })
+    );
+
+    const eventbridgeIntegration = new CfnIntegration(
+      this,
+      'EventBridgeIntegration',
+      {
+        apiId: httpApi.httpApiId,
+        integrationType: 'AWS_PROXY',
+        integrationSubtype: 'EventBridge-PutEvents',
+        credentialsArn: apiRole.roleArn,
+        requestParameters: {
+          Source: 'WebApp',
+          DetailType: 'MyDetailType', 
+          Detail: '$request.body.Detail',
+          EventBusName: eventBus.eventBusArn,
+        },
+        payloadFormatVersion: '1.0',
+        timeoutInMillis: 10000,
+      }
+    );
+
+    new CfnRoute(this, 'EventRoute', {
+      apiId: httpApi.httpApiId,
+      routeKey: 'POST /',
+      target: `integrations/${eventbridgeIntegration.ref}`,
+    });
+    
+    
+    new cdk.CfnOutput(this, 'apiUrl', { value: httpApi.url!, description: "HTTP API endpoint URL" });
+  }
+}
+

--- a/apigw-http-api-eventbridge-cdk/cdk/package.json
+++ b/apigw-http-api-eventbridge-cdk/cdk/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "api-eventbridge",
+  "version": "0.1.0",
+  "bin": {
+    "cdk": "bin/api-eventbridge.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "cdk": "cdk"
+  },
+  "devDependencies": {
+    "@types/node": "10.17.27",
+    "aws-cdk": "1.113.0",
+    "ts-node": "^9.0.0",
+    "typescript": "~3.9.7"
+  },
+  "dependencies": {
+    "@aws-cdk/aws-apigatewayv2": "1.113.0",
+    "@aws-cdk/aws-events": "1.113.0",
+    "@aws-cdk/aws-events-targets": "1.113.0",
+    "@aws-cdk/aws-iam": "1.113.0",
+    "@aws-cdk/aws-logs": "1.113.0",
+    "@aws-cdk/core": "1.113.0",
+    "source-map-support": "^0.5.16"
+  }
+}

--- a/apigw-http-api-eventbridge-cdk/cdk/tsconfig.json
+++ b/apigw-http-api-eventbridge-cdk/cdk/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "commonjs",
+    "lib": [
+      "es2018"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": [
+      "./node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "cdk.out"
+  ]
+}

--- a/apigw-http-api-eventbridge-cdk/pattern-apigateway-http-eventbridge-cdk.json
+++ b/apigw-http-api-eventbridge-cdk/pattern-apigateway-http-eventbridge-cdk.json
@@ -1,0 +1,53 @@
+{
+  "title": "HTTP API Gateway to EventBridge",
+  "description": "Create an HTTP API Gateway that sends events to EventBridge.",
+  "language": "Node.js",
+  "architectureURL": "",
+  "videoId": "",
+  "level":"100",
+  "framework": "CDK",
+  "services": {
+    "from": "apigatewayv2",
+    "to": "eventbridge"
+  },
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "The CDK project creates an Amazon API gateway HTTP API endpoint. The endpoint uses service integrations to directly connect to Amazon EventBridge. An EventBridge rule sends all events to Cloudwatch Logs."
+    ]
+  },
+  "deploy": {
+    "text": ["cdk deploy"]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/apigw-http-api-eventbridge-cdk",
+      "templateURL": "https://raw.githubusercontent.com/aws-samples/serverless-patterns/main/apigw-http-api-eventbridge-cdk/cdk/lib/api-eventbridge-stack.ts",
+      "readmeURL": "https://github.com/aws-samples/serverless-patterns/tree/main/apigw-http-api-eventbridge-cdk/README.md"
+    },
+    "payloads": [
+      {
+        "headline": "",
+        "payloadURL": ""
+      }
+    ]
+  },
+  "resources": {
+    "headline": "Additional resources",
+    "bullets": [
+      {
+        "text": "Integrating Amazon EventBridge into your serverless applications",
+        "link": "https://aws.amazon.com/blogs/compute/integrating-amazon-eventbridge-into-your-serverless-applications/"
+      },
+      {
+        "text": "Use Amazon EventBridge to Build Decoupled, Event-Driven Architectures",
+        "link": "https://serverlessland.com/learn/eventbridge"
+      }      
+    ]
+  },
+  "author": {
+    "headline": "Presented by Hugo Sterin",
+    "name": "Hugo Sterin",
+    "bio": "Solutions Architect @ AWS"
+  }
+}


### PR DESCRIPTION
Similar to the existing HTTP API to Eventbridge, but with CDK instead of SAM.
I also added an Eventbridge Rule targeting Cloudwatch Logs instead of a Lambda. 





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
