### PR TITLE
New pattern - Rest API to EventBridge

### DIFF
--- a/apigw-rest-api-eventbridge-sam/README.md
+++ b/apigw-rest-api-eventbridge-sam/README.md
@@ -1,0 +1,60 @@
+# AWS Service 1 to AWS Service 2
+
+This pattern << explain usage >>
+
+Learn more about this pattern at Serverless Land Patterns: << Add the live URL here >>
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ```
+    cd serverless-patterns/apigw-rest-api-eventbridge-sam
+    ```
+1. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
+    ```
+    sam deploy --guided
+    ```
+1. During the prompts:
+    * Enter a stack name
+    * Enter the desired AWS Region
+    * Allow SAM CLI to create IAM roles with the required permissions.
+
+    Once you have run `sam deploy --guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+
+1. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## How it works
+
+Explain how the service interaction works.
+
+## Testing
+
+Provide steps to trigger the integration and show what should be observed if successful.
+
+## Cleanup
+ 
+1. Delete the stack
+    ```bash
+    aws cloudformation delete-stack --stack-name STACK_NAME
+    ```
+1. Confirm the stack has been deleted
+    ```bash
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus"
+    ```
+----
+Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/apigw-rest-api-eventbridge-sam/template.yaml
+++ b/apigw-rest-api-eventbridge-sam/template.yaml
@@ -1,0 +1,128 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  Serverless patterns - REST API Gateway to EventBridge
+
+Resources:
+##########################################################################
+#   EventBus                                                        #
+##########################################################################
+  MyCustomEventBus:
+    Type: AWS::Events::EventBus
+    Properties:
+      Name: MyCustomEventBus
+
+
+##########################################################################
+#   API GATEWAY ROLE WITH PERMISSIONS TO PUT EVENTS   #
+##########################################################################
+  ApiGatewayEventBridgeRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: !Join ["", ["/", !Ref "AWS::StackName", "/"]]
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowApiGatewayServiceToAssumeRole
+            Effect: Allow
+            Action:
+              - 'sts:AssumeRole'
+            Principal:
+              Service:
+                - apigateway.amazonaws.com
+      Policies:
+        - PolicyName: EBPutEvents
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'events:PutEvents'
+                Resource:
+                  - !GetAtt  MyCustomEventBus.Arn
+  
+##########################################################################
+#   REST API GATEWAY                                                     #
+##########################################################################
+  apiGateway:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      EndpointConfiguration:
+        Types:
+          - REGIONAL
+      Name: !Sub ${AWS::StackName}-api
+
+##########################################################################
+#   API GATEWAY METHOD                                                   #
+##########################################################################
+  apiGatewayRootMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: NONE
+      HttpMethod: POST
+      MethodResponses:
+        - StatusCode: 200
+          ResponseModels:
+            application/json: Empty
+      RequestParameters: 
+        method.request.header.X-Amz-Target: false
+        method.request.header.Content-Type: false
+      Integration:
+        IntegrationHttpMethod: POST
+        Type: AWS
+        Credentials: !GetAtt ApiGatewayEventBridgeRole.Arn 
+        Uri: !Sub arn:aws:apigateway:${AWS::Region}:events:action/PutEvents
+        PassthroughBehavior: WHEN_NO_TEMPLATES
+        RequestTemplates: 
+          application/json: !Sub 
+            - |- 
+              #set($context.requestOverride.header.X-Amz-Target = "AWSEvents.PutEvents")
+              #set($context.requestOverride.header.Content-Type = "application/x-amz-json-1.1")            
+              #set($inputRoot = $input.path('$')) 
+              { 
+                "Entries": [
+                  #foreach($elem in $inputRoot.items)
+                  {
+                    "Detail": "$util.escapeJavaScript($elem.Detail).replaceAll("\\'","'")",
+                    "DetailType": "$elem.DetailType",
+                    "EventBusName": "${EventBusName}",
+                    "Source":"$elem.Source"
+                  }#if($foreach.hasNext),#end
+                  #end
+                ]
+
+              }
+            - { EventBusName: !Ref MyCustomEventBus }
+        IntegrationResponses:
+          - StatusCode: 200
+            ResponseTemplates: 
+              application/json: !Sub 
+                - |- 
+                  #set($inputRoot = $input.path('$'))
+                  {
+                  }
+                - {}
+      ResourceId: !GetAtt apiGateway.RootResourceId
+      RestApiId: !Ref apiGateway
+
+##########################################################################
+#   API GATEWAY DEPLOYMENT                                               #
+##########################################################################
+  apiGatewayDeployment:
+    Type: AWS::ApiGateway::Deployment
+    DependsOn:
+      - apiGatewayRootMethod
+    Properties:
+      RestApiId: !Ref apiGateway
+      StageName: 'dev'
+      
+##########################################################################
+#   OUTPUTS                                                              #
+##########################################################################
+Outputs:
+  ApiEndpoint: 
+    Description: "API Gateway endpoint URL for Prod stage for Product api"
+    Value: !Sub "https://${apiGateway}.execute-api.${AWS::Region}.amazonaws.com/dev/"
+
+
+


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-samples/serverless-patterns/issues/94

*Description of changes:*
This template creates an API Gateway REST API that puts an event to Amazon EventBridge. This pattern addresses some nuances with defining the VTL template mapping when integrating with EventBridge. An IAM permission for putting events to EventBridge is created for API Gateway.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
