### PR TITLE
Fix typo for APIGW-SFN template

### DIFF
--- a/apigw-sfn/template.yaml
+++ b/apigw-sfn/template.yaml
@@ -11,7 +11,7 @@ Resources:
   StateMachineExpressSync:
     Type: AWS::Serverless::StateMachine # More info about State Machine Resource: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html
     Properties:
-      DefinitionUri: statemachine/StateMachine.asl.json
+      DefinitionUri: statemachine/stateMachine.asl.json
       Policies:
         -  Version: "2012-10-17"
            Statement:


### PR DESCRIPTION
*Description of changes:*

There's a small typo in the template.yaml file that causes the error:
```
"Error: Unable to upload artifact statemachine/StateMachine.asl.json referenced by DefinitionUri parameter
of StateMachineExpressSync resource. Parameter DefinitionUri of resource StateMachineExpressSync refers to a
file or folder that does not exist
serverless-patterns/apigw-sfn/statemachine/StateMachine.asl.json"
```

This change fix that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
