### PR TITLE
Fix log group permission and typo.

### DIFF
--- a/sfn-apigw/template.yaml
+++ b/sfn-apigw/template.yaml
@@ -10,7 +10,7 @@ Resources:
   StateMachinetoAPIGW:
     Type: AWS::Serverless::StateMachine # More info about State Machine Resource: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html
     Properties:
-      DefinitionUri: statemachine/StateMachine.asl.json
+      DefinitionUri: statemachine/stateMachine.asl.json
       DefinitionSubstitutions:
          DefaultPath: '/'
          APIEndPoint: !Sub "${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com"
@@ -62,7 +62,6 @@ Resources:
             Action: "sts:AssumeRole"
       Path: "/"
       Policies:
-
         - PolicyName: LambdaExecute
           PolicyDocument:
             Version: "2012-10-17"
@@ -71,6 +70,15 @@ Resources:
                 Action:
                   - "lambda:InvokeFunction"
                 Resource: !GetAtt ExampleLambdaFunction.Arn
+        -  PolicyName: LogPermissions
+           PolicyDocument:
+             Version: "2012-10-17"
+             Statement:
+              - Effect: Allow
+                Action:
+                  - "cloudwatch:*"
+                  - "logs:*"
+                Resource: "*"
 ##########################################################################
 #   Outputs                                                              #
 ##########################################################################


### PR DESCRIPTION
- Typo in the reference to the state machine file.
- State Machine missing log permissions. That would cause the following error:

[StateMachinetoAPIGW]. Rollback requested by user.

ResourceStatus| ResourceType | LogicalResourceId | ResourceStatusReason
-----------------|-------------------------------------|-----------------------|-------------------------------------
CREATE_FAILED | AWS::StepFunctions::StateMachine  | StateMachinetoAPIGW | Resource handler returned message: "The state machine IAM Role is not authorized to access the Log Destination (Service: AWSStepFunctions; Status Code: 400; Error Code: AccessDeniedException; Request ID: 2264351c-57e7-408b-91d9-f0f5984eb7b3; Proxy: null)" (RequestToken: ccf5ac0c-3790-7cf8-17bc-743ee3d73f2c,  HandlerErrorCode: AccessDenied)

### Testing done
- Changes are deployed with success after fix: `Successfully created/updated stack - sam-app in us-east-1`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
