### PR TITLE
Serverless Pattern, API Gateway to Private (VPC) API Gateway

### DIFF
--- a/apigw-to-private-apig-cdk/README.md
+++ b/apigw-to-private-apig-cdk/README.md
@@ -1,0 +1,51 @@
+
+# Amazon Public (or private) API Gateway to Private API Gateway integration
+
+This pattern in CDK offers a example to generate an Amazon public API Gateway to Amazon Privare API Gateway integration.
+
+Learn more about this pattern at Serverless Land Patterns: https://serverlessland.com/patterns/apigw-to-private-apig-cdk
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [Node and NPM](https://nodejs.org/en/download/) installed
+* [AWS Cloud Development Kit](https://docs.aws.amazon.com/cdk/latest/guide/cli.html) (AWS CDK) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ```bash
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+2. Change directory to the pattern directory its source code folder:
+    ```bash
+      cd apigw-to-private-apig-cdk/src
+    ```
+3. From the command line, use npm to install the development dependencies:
+    ```bash
+      npm install
+    ```
+4. To deploy from the command line use the following:
+    ```bash
+      npx cdk bootstrap aws://accountnumber/region
+      npx cdk deploy --app 'ts-node .' --all
+    ```
+
+## Testing
+
+  * On the web shell run curl the output for APIGatewayApi.publicapiEndpoint
+  ```curl https://<api_id>.execute-api.<region>.amazonaws.com/prod```
+  * You should see: ```Success path: "/"```.
+ 
+
+## Cleanup
+ 
+1. From the command line, use the following in the source folder
+    ```bash
+    npx cdk destroy --app 'ts-node .' --all
+    ```
+2. Confirm the removal and wait for the resource deletion to complete.

--- a/apigw-to-private-apig-cdk/src/api/config.json
+++ b/apigw-to-private-apig-cdk/src/api/config.json
@@ -1,0 +1,14 @@
+{
+    "prefix": "APIGateway",
+    "description": "A VPC Lambda to get request from API Gateway Private API with CDK",
+    "api": {
+      "handler": "ProxyLambda"
+    },
+    "headers": {
+        "Content-Type": "text/plain;charset=utf-8"
+      },
+      "tags": [
+        {"key": "Key", "value": "Value"},
+        {"key": "Project", "value": "PrivateAPIGateway"}
+      ]
+  } 

--- a/apigw-to-private-apig-cdk/src/api/dist/index.js
+++ b/apigw-to-private-apig-cdk/src/api/dist/index.js
@@ -1,0 +1,43 @@
+var __defProp = Object.defineProperty;
+var __markAsModule = (target) => __defProp(target, "__esModule", {value: true});
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, {get: all[name], enumerable: true});
+};
+
+// api/lambda/index.ts
+__markAsModule(exports);
+__export(exports, {
+  ProxyLambda: () => handler
+});
+
+// api/config.json
+var prefix = "PrivateAPIGateway";
+var description = "A VPC Lambda to get request from API Gateway Private API with CDK";
+var api = {
+  handler: "ProxyLambda"
+};
+var headers = {
+  "Content-Type": "text/plain;charset=utf-8"
+};
+var tags = [
+  {key: "Key", value: "Value"},
+  {key: "Project", value: "PrivateAPIGateway"}
+];
+var config_default = {
+  prefix,
+  description,
+  api,
+  headers,
+  tags
+};
+
+// api/lambda/api-handler.ts
+var handler = async (event) => {
+  return {
+    body: `Success path: "${event.path}"`,
+    headers: config_default.headers,
+    statusCode: 200
+  };
+};
+//# sourceMappingURL=index.js.map

--- a/apigw-to-private-apig-cdk/src/api/dist/index.js.map
+++ b/apigw-to-private-apig-cdk/src/api/dist/index.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": ["../lambda/index.ts", "../lambda/api-handler.ts"],
+  "sourcesContent": ["export { handler as ProxyLambda } from \"./api-handler\";", "\nimport { Handler } from \"aws-lambda\";\nimport config from \"../config.json\";\n\nexport const handler: Handler = async (event) => {\n  return {\n    body: `Success path: \"${event.path}\"`,\n    headers: config.headers,\n    statusCode: 200,\n  };\n};"],
+  "mappings": ";;;;;;;;AAAA;AAAA;AAAA;AAAA;;;;;;;;;;;;;;;;;;;;;;;;ACIO,IAAM,UAAmB,OAAO,UAAU;AAC/C,SAAO;AAAA,IACL,MAAM,kBAAkB,MAAM;AAAA,IAC9B,SAAS,eAAO;AAAA,IAChB,YAAY;AAAA;AAAA;",
+  "names": []
+}

--- a/apigw-to-private-apig-cdk/src/api/index.ts
+++ b/apigw-to-private-apig-cdk/src/api/index.ts
@@ -1,0 +1,126 @@
+import * as apigateway from "@aws-cdk/aws-apigateway";
+import * as lambda from "@aws-cdk/aws-lambda";
+import * as cdk from "@aws-cdk/core";
+import * as elb from '@aws-cdk/aws-elasticloadbalancingv2'
+import * as elbTarget from '@aws-cdk/aws-elasticloadbalancingv2-targets'
+import * as ec2 from '@aws-cdk/aws-ec2';
+import * as iam from '@aws-cdk/aws-iam';
+import * as customResource from '@aws-cdk/custom-resources'
+import path from "path";
+import config from "./config.json";
+
+export class ApiStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, vpc: ec2.Vpc) {
+    super(scope, id);
+
+/* Create Security group */
+    const apiGatewayEndpointSG = new ec2.SecurityGroup(this, "apiGatewayEndpointSG", {
+        description: "Security Group for Api Gateway Endpoint",
+        vpc: vpc
+    });
+    apiGatewayEndpointSG.addIngressRule(ec2.Peer.ipv4('10.0.0.0/8'), ec2.Port.tcp(443));
+
+/* Create API Gateway Interface VPC Endpoint */
+    const endpointAPIGateway = new ec2.InterfaceVpcEndpoint(this, "endpointAPIGateway", {
+        service: ec2.InterfaceVpcEndpointAwsService.APIGATEWAY,
+        vpc: vpc,
+        subnets: vpc.selectSubnets({
+            subnetType: ec2.SubnetType.PRIVATE
+        }),
+        privateDnsEnabled: true,
+        securityGroups: [apiGatewayEndpointSG]
+    });
+
+    const handler = new lambda.Function(this, "handler", {
+      code: new lambda.AssetCode(path.resolve(__dirname, "dist")),
+      handler: `index.${config.api.handler}`,
+      runtime: lambda.Runtime.NODEJS_14_X,
+      vpc: vpc,
+      vpcSubnets: vpc.selectSubnets({
+        subnetType: ec2.SubnetType.PRIVATE
+      })
+    });
+
+/* Grant api gateway invoke permission on lambda */
+    handler.grantInvoke(new iam.ServicePrincipal('apigateway.amazonaws.com'));
+    
+    const apiResourcePolicy = new iam.PolicyDocument({
+      statements: [
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: ['execute-api:Invoke'],
+          principals: [new iam.AnyPrincipal()],
+          resources: ['execute-api:/*/*/*'],
+        })
+      ]
+    });
+    
+    const restapi  = new apigateway.LambdaRestApi(this, config.prefix, {
+      handler,
+      description: config.description,
+      endpointConfiguration: {types: [apigateway.EndpointType.PRIVATE], vpcEndpoints: [endpointAPIGateway]},
+      policy: apiResourcePolicy
+    });
+
+/* Create Load Balancer Target Group */
+    const targetGroup = new elb.NetworkTargetGroup(this, 'TargetGroup', {
+      port: 443, 
+      vpc,
+      targetType: elb.TargetType.IP
+    });
+
+    for (let counter = 0; counter < vpc.availabilityZones.length; counter++) {
+      const getEndpointIp = new customResource.AwsCustomResource(this, `GetEndpointIp${counter}`, {
+          onUpdate: {
+              service: 'EC2',
+              action: 'describeNetworkInterfaces',
+              outputPath: `NetworkInterfaces.${counter}.PrivateIpAddress`,
+              parameters: { NetworkInterfaceIds: endpointAPIGateway.vpcEndpointNetworkInterfaceIds },
+              physicalResourceId:  customResource.PhysicalResourceId.of(`NetworkInterfaces.${counter}.PrivateIpAddress`)
+          },
+          policy: customResource.AwsCustomResourcePolicy.fromSdkCalls({resources: customResource.AwsCustomResourcePolicy.ANY_RESOURCE})
+      });
+      targetGroup.addTarget(new elbTarget.IpTarget(cdk.Token.asString(getEndpointIp.getResponseField(`NetworkInterfaces.${counter}.PrivateIpAddress`)), 443));
+  }
+/*  End Create Load Balancer Target Group */
+/*  Start Create Private Network Load Balancer */
+    let privateAPGNLB = new elb.NetworkLoadBalancer(this, 'internalAPIGNLB', { 
+                          vpc: vpc, 
+                          internetFacing: false,
+                        });
+
+    privateAPGNLB.addListener('listner',{
+        port: 443,
+        protocol: elb.Protocol.TCP,
+        defaultTargetGroups: [targetGroup]
+      }
+    );
+/*  End Create Private Network Load Balancer */
+/*  Create VPC Link in API Gateway */
+let vpcLink = new apigateway.VpcLink(this, 'vpclink', {
+    targets: [privateAPGNLB],
+    vpcLinkName: 'apigconnectvpclink'
+});
+/*  End Create VPC Link in API Gateway */
+/*  Create Public API Gateway */
+const publicapi = new apigateway.RestApi(this, 'public-api');
+const integration = new apigateway.Integration({
+  integrationHttpMethod: "ANY",
+  type: apigateway.IntegrationType.HTTP_PROXY,
+  uri: `https://${restapi.restApiId}-${endpointAPIGateway.vpcEndpointId}.execute-api.${this.region}.amazonaws.com/prod`,
+  options: {
+    connectionType: apigateway.ConnectionType.VPC_LINK,
+    vpcLink: vpcLink,
+  },
+});
+publicapi.root.addMethod('GET', integration);
+/*  End Create Public API Gateway */
+
+    const tags = config.tags
+
+    tags.forEach(tag => {
+      cdk.Tags.of(this).add(tag.key, tag.value)
+      cdk.Tags.of(handler).add(tag.key, tag.value)
+    })
+  }
+}

--- a/apigw-to-private-apig-cdk/src/api/lambda/api-handler.ts
+++ b/apigw-to-private-apig-cdk/src/api/lambda/api-handler.ts
@@ -1,0 +1,11 @@
+
+import { Handler } from "aws-lambda";
+import config from "../config.json";
+
+export const handler: Handler = async (event) => {
+  return {
+    body: `Success path: "${event.path}"`,
+    headers: config.headers,
+    statusCode: 200,
+  };
+};

--- a/apigw-to-private-apig-cdk/src/api/lambda/index.ts
+++ b/apigw-to-private-apig-cdk/src/api/lambda/index.ts
@@ -1,0 +1,1 @@
+export { handler as ProxyLambda } from "./api-handler";

--- a/apigw-to-private-apig-cdk/src/index.ts
+++ b/apigw-to-private-apig-cdk/src/index.ts
@@ -1,0 +1,22 @@
+import * as cdk from "@aws-cdk/core";
+import { ApiStack } from "./api/index";
+import { VpcStack } from "./vpc/index";
+import { buildSync } from "esbuild";
+import path from "path";
+import config from "./api/config.json"
+
+buildSync({
+  bundle: true,
+  entryPoints: [path.resolve(__dirname, "api", "lambda", "index.ts")],
+  external: ["aws-sdk"],
+  format: "cjs",
+  outfile: path.join(__dirname, "api", "dist", "index.js"),
+  platform: "node",
+  sourcemap: true,
+  target: "node14.2",
+});
+
+const app = new cdk.App();
+const idStack = config.prefix;
+const vpcStack = new VpcStack(app, `${idStack}Vpc`);
+new ApiStack(app, `${idStack}Api`, vpcStack.vpc);

--- a/apigw-to-private-apig-cdk/src/package.json
+++ b/apigw-to-private-apig-cdk/src/package.json
@@ -1,0 +1,22 @@
+{
+    "name": "apigw-lambda-cdk",
+    "scripts": {
+        "build": "ts-node ."
+    },
+    "dependencies": {
+        "@aws-cdk/aws-apigateway": "1.101.0",
+        "@aws-cdk/aws-lambda": "1.101.0",
+        "@aws-cdk/core": "1.101.0",
+        "@aws-cdk/aws-wafv2": "1.101.0",
+        "aws-cdk": "1.101.0",
+        "@aws-cdk/aws-elasticloadbalancingv2-targets": "1.101.0"
+    },
+    "devDependencies": {
+        "@types/aws-lambda": "^8.10.72",
+        "@types/node": "^14.14.25",
+        "aws-sdk": "^2.866.0",
+        "esbuild": "^0.8.44",
+        "ts-node": "^9.1.1",
+        "typescript": "^4.1.5"
+    }
+}

--- a/apigw-to-private-apig-cdk/src/tsconfig.json
+++ b/apigw-to-private-apig-cdk/src/tsconfig.json
@@ -1,0 +1,39 @@
+{
+    "compilerOptions": {
+        "alwaysStrict": true,
+        "downlevelIteration": true,
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "inlineSourceMap": true,
+        "lib": [
+            "es2020"
+        ],
+        "moduleResolution": "node",
+        "noEmitOnError": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "noImplicitReturns": true,
+        "noUncheckedIndexedAccess": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "resolveJsonModule": true,
+        "strict": true,
+        "strictBindCallApply": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "strictPropertyInitialization": true,
+        "stripInternal": true,
+        "target": "ES2020",
+        "typeRoots": [
+            "node_modules/@types"
+        ],
+        "useDefineForClassFields": true
+    },
+    "exclude": [
+        "node_modules"
+    ],
+    "include": [
+        "."
+    ]
+}

--- a/apigw-to-private-apig-cdk/src/vpc/index.ts
+++ b/apigw-to-private-apig-cdk/src/vpc/index.ts
@@ -1,0 +1,56 @@
+
+import * as cdk from "@aws-cdk/core";
+import {Vpc, SubnetType} from '@aws-cdk/aws-ec2';
+
+export class VpcStack extends cdk.Stack {
+  vpc: Vpc;
+
+  constructor(scope: cdk.App, id: string) {
+    super(scope, id);
+
+    this.vpc = new Vpc(this, 'priv-apigw-vpc', {
+      cidr: '10.0.0.0/16',
+      natGateways: 1,
+      maxAzs: 3,
+      subnetConfiguration: [
+        {
+          name: 'private-subnet-1',
+          subnetType: SubnetType.PRIVATE,
+          cidrMask: 24,
+        },
+        {
+          name: 'public-subnet-1',
+          subnetType: SubnetType.PUBLIC,
+          cidrMask: 24,
+        }
+      ],
+    });
+
+    // Update the Name tag for the VPC
+    cdk.Aspects.of(this.vpc).add(new cdk.Tag('Name', 'priv-apigw-vpc'));
+
+    // Update the Name tag for private subnets
+
+    for (const subnet of this.vpc.publicSubnets) {
+      cdk.Aspects.of(subnet).add(
+        new cdk.Tag(
+          'Name',
+          `${this.vpc.node.id}-${subnet.node.id.replace(/Subnet[0-9]$/, '')}-${
+            subnet.availabilityZone
+          }`,
+        ),
+      );
+    }
+    
+    for (const subnet of this.vpc.privateSubnets) {
+      cdk.Aspects.of(subnet).add(
+        new cdk.Tag(
+          'Name',
+          `${this.vpc.node.id}-${subnet.node.id.replace(/Subnet[0-9]$/, '')}-${
+            subnet.availabilityZone
+          }`,
+        ),
+      );
+    }
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This pattern in CDK offers an example to create  
a. Amazon API Gateway with a GET / api which invokes private API gateway backed by lambda 
b. Private API endpoint with a greedy proxy ("{proxy+}") and "ANY" method from the specified path, meaning it will accept by default any method and any path. The VPC Lambda function provided in JavaScript only returns the path
c. To make the connection possible following resources are also created
   i. VPC Endpoint for execute-api in your VPC
  ii. ELB target group using the private IPs created for each AZ as part of the VPC endpoint creation for TCP 443
 iii. Private NLB listening on TCP 443 configured to use the target group
 iv. VPC link in API Gateway linking NLB created above

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
