### PR TITLE
lambda to dynamodb cdk

### DIFF
--- a/lambda-dynamodb-cdk/README.md
+++ b/lambda-dynamodb-cdk/README.md
@@ -1,0 +1,72 @@
+# AWS Lambda To Amazon DynamoDB
+
+This project contains a sample AWS Cloud Development Kit (AWS CDK) template for deploying a Lambda function that makes puts to a DynamoDB table.
+
+Learn more about this pattern at Serverless Land Patterns: https://serverlessland.com/patterns/lambda-dynamodb-cdk
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+- [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+- [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+- [AWS CDK](https://docs.aws.amazon.com/cdk/latest/guide/cli.html) installed and configured
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+   ```bash
+   git clone https://github.com/aws-samples/serverless-patterns
+   ```
+2. Change directory to the pattern directory:
+   ```bash
+   cd serverless-patterns/lambda-dynamodb-cdk/cdk
+   ```
+3. Install dependencies:
+   ```bash
+   npm install
+   ```
+4. From the command line, configure AWS CDK:
+   ```bash
+   cdk bootstrap ACCOUNT-NUMBER/REGION # e.g.
+   cdk bootstrap 1111111111/us-east-1
+   cdk bootstrap --profile test 1111111111/us-east-1
+   ```
+5. From the command line, use AWS CDK to deploy the AWS resources for the pattern as specified in the `lib/cdk-stack.ts` file:
+   ```bash
+   cdk deploy
+   ```
+6. Note the outputs from the CDK deployment process. This contains the Lambda function ARN which is used for testing.
+
+## How it works
+
+This is similar to the `lambda-dynamodb` example but is implemented in CDK.
+
+- A Lambda function is invoked by an event integration or CLI command
+- The Lambda function "stringifies" the event payload
+- The Function uses the AWS SDK to perform a `put` command on a DynamoDB table
+- The name of the DynamoDB table is passed to the Lambda function via an environment variable named `DatabaseTable`
+- The Lambda function is granted `PutItem` permissions, defined in CDK via `dynamoTable.grantWriteData(lambdaPutDynamoDB);`
+
+## Testing
+
+Run the following Lambda CLI invoke command to invoke the function. Note, you must edit the {LambdFunctionArn} placeholder with the ARN of the deployed Lambda function. This is provided in the stack outputs.
+
+```bash
+aws lambda invoke --function-name {LambdFunctionArn} --invocation-type Event \
+--payload '{ "Metadata": "Hello" }' \ response.json --cli-binary-format raw-in-base64-out
+```
+
+## Cleanup
+
+1. Delete the stack
+   ```bash
+   cdk destroy
+   ```
+
+---
+
+Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/lambda-dynamodb-cdk/cdk/.gitignore
+++ b/lambda-dynamodb-cdk/cdk/.gitignore
@@ -1,0 +1,8 @@
+*.js
+!jest.config.js
+*.d.ts
+node_modules
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/lambda-dynamodb-cdk/cdk/.npmignore
+++ b/lambda-dynamodb-cdk/cdk/.npmignore
@@ -1,0 +1,6 @@
+*.ts
+!*.d.ts
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/lambda-dynamodb-cdk/cdk/README.md
+++ b/lambda-dynamodb-cdk/cdk/README.md
@@ -1,0 +1,14 @@
+# Welcome to your CDK TypeScript project!
+
+This is a blank project for TypeScript development with CDK.
+
+The `cdk.json` file tells the CDK Toolkit how to execute your app.
+
+## Useful commands
+
+ * `npm run build`   compile typescript to js
+ * `npm run watch`   watch for changes and compile
+ * `npm run test`    perform the jest unit tests
+ * `cdk deploy`      deploy this stack to your default AWS account/region
+ * `cdk diff`        compare deployed stack with current state
+ * `cdk synth`       emits the synthesized CloudFormation template

--- a/lambda-dynamodb-cdk/cdk/bin/cdk.ts
+++ b/lambda-dynamodb-cdk/cdk/bin/cdk.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import 'source-map-support/register';
+import * as cdk from '@aws-cdk/core';
+import { CdkStack } from '../lib/cdk-stack';
+
+const app = new cdk.App();
+new CdkStack(app, 'CdkStack', {
+  /* If you don't specify 'env', this stack will be environment-agnostic.
+   * Account/Region-dependent features and context lookups will not work,
+   * but a single synthesized template can be deployed anywhere. */
+
+  /* Uncomment the next line to specialize this stack for the AWS Account
+   * and Region that are implied by the current CLI configuration. */
+  // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
+
+  /* Uncomment the next line if you know exactly what Account and Region you
+   * want to deploy the stack to. */
+  // env: { account: '123456789012', region: 'us-east-1' },
+
+  /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
+});

--- a/lambda-dynamodb-cdk/cdk/cdk.json
+++ b/lambda-dynamodb-cdk/cdk/cdk.json
@@ -1,0 +1,18 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/cdk.ts",
+  "context": {
+    "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
+    "@aws-cdk/core:enableStackNameDuplicates": "true",
+    "aws-cdk:enableDiffNoFail": "true",
+    "@aws-cdk/core:stackRelativeExports": "true",
+    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
+    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
+    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
+    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
+    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
+    "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
+    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
+    "@aws-cdk/aws-lambda:recognizeVersionProps": true,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true
+  }
+}

--- a/lambda-dynamodb-cdk/cdk/jest.config.js
+++ b/lambda-dynamodb-cdk/cdk/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  testEnvironment: 'node',
+  roots: ['<rootDir>/test'],
+  testMatch: ['**/*.test.ts'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest'
+  }
+};

--- a/lambda-dynamodb-cdk/cdk/lib/cdk-stack.ts
+++ b/lambda-dynamodb-cdk/cdk/lib/cdk-stack.ts
@@ -1,0 +1,9 @@
+import * as cdk from '@aws-cdk/core';
+
+export class CdkStack extends cdk.Stack {
+  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    // The code that defines your stack goes here
+  }
+}

--- a/lambda-dynamodb-cdk/cdk/lib/cdk-stack.ts
+++ b/lambda-dynamodb-cdk/cdk/lib/cdk-stack.ts
@@ -1,5 +1,8 @@
 import * as cdk from '@aws-cdk/core';
 import { Table, BillingMode, AttributeType } from '@aws-cdk/aws-dynamodb';
+import { NodejsFunction } from '@aws-cdk/aws-lambda-nodejs';
+import * as lambda from '@aws-cdk/aws-lambda';
+import * as path from 'path';
 
 export class CdkStack extends cdk.Stack {
   constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
@@ -10,5 +13,18 @@ export class CdkStack extends cdk.Stack {
       partitionKey: {name:'ID', type: AttributeType.STRING},
       billingMode: BillingMode.PAY_PER_REQUEST
     });
+
+    // Lambda function
+    const lambdaPutDynamoDB = new NodejsFunction(
+      this,
+      'lambdaPutDynamoDBHandler',
+      {
+        runtime: lambda.Runtime.NODEJS_12_X,
+        memorySize: 1024,
+        timeout: cdk.Duration.seconds(3),
+        entry: path.join(__dirname, '../src/app.ts'),
+        handler: 'main',
+      }
+    );
   }
 }

--- a/lambda-dynamodb-cdk/cdk/lib/cdk-stack.ts
+++ b/lambda-dynamodb-cdk/cdk/lib/cdk-stack.ts
@@ -24,7 +24,13 @@ export class CdkStack extends cdk.Stack {
         timeout: cdk.Duration.seconds(3),
         entry: path.join(__dirname, '../src/app.ts'),
         handler: 'main',
+        environment: {
+          DatabaseTable: dynamoTable.tableName
+        }
       }
     );
+
+    // Write permissions for Lambda
+    dynamoTable.grantWriteData(lambdaPutDynamoDB);
   }
 }

--- a/lambda-dynamodb-cdk/cdk/lib/cdk-stack.ts
+++ b/lambda-dynamodb-cdk/cdk/lib/cdk-stack.ts
@@ -1,9 +1,14 @@
 import * as cdk from '@aws-cdk/core';
+import { Table, BillingMode, AttributeType } from '@aws-cdk/aws-dynamodb';
 
 export class CdkStack extends cdk.Stack {
   constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    // The code that defines your stack goes here
+    // DynamoDB Table
+    const dynamoTable = new Table(this, 'DynamoTable', {
+      partitionKey: {name:'ID', type: AttributeType.STRING},
+      billingMode: BillingMode.PAY_PER_REQUEST
+    });
   }
 }

--- a/lambda-dynamodb-cdk/cdk/lib/cdk-stack.ts
+++ b/lambda-dynamodb-cdk/cdk/lib/cdk-stack.ts
@@ -32,5 +32,9 @@ export class CdkStack extends cdk.Stack {
 
     // Write permissions for Lambda
     dynamoTable.grantWriteData(lambdaPutDynamoDB);
+
+    // Outputs
+    new cdk.CfnOutput(this, 'DynamoDbTableName', { value: dynamoTable.tableName });
+    new cdk.CfnOutput(this, 'LambdFunctionArn', { value: lambdaPutDynamoDB.functionArn });
   }
 }

--- a/lambda-dynamodb-cdk/cdk/package.json
+++ b/lambda-dynamodb-cdk/cdk/package.json
@@ -25,6 +25,7 @@
     "@aws-cdk/aws-lambda": "^1.124.0",
     "@aws-cdk/aws-lambda-nodejs": "^1.124.0",
     "@aws-cdk/core": "1.124.0",
+    "moment": "^2.29.1",
     "source-map-support": "^0.5.16"
   }
 }

--- a/lambda-dynamodb-cdk/cdk/package.json
+++ b/lambda-dynamodb-cdk/cdk/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "cdk",
+  "version": "0.1.0",
+  "bin": {
+    "cdk": "bin/cdk.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "test": "jest",
+    "cdk": "cdk"
+  },
+  "devDependencies": {
+    "@aws-cdk/assert": "1.124.0",
+    "@types/jest": "^26.0.10",
+    "@types/node": "10.17.27",
+    "jest": "^26.4.2",
+    "ts-jest": "^26.2.0",
+    "aws-cdk": "1.124.0",
+    "ts-node": "^9.0.0",
+    "typescript": "~3.9.7"
+  },
+  "dependencies": {
+    "@aws-cdk/core": "1.124.0",
+    "source-map-support": "^0.5.16"
+  }
+}

--- a/lambda-dynamodb-cdk/cdk/package.json
+++ b/lambda-dynamodb-cdk/cdk/package.json
@@ -22,6 +22,8 @@
   },
   "dependencies": {
     "@aws-cdk/aws-dynamodb": "^1.124.0",
+    "@aws-cdk/aws-lambda": "^1.124.0",
+    "@aws-cdk/aws-lambda-nodejs": "^1.124.0",
     "@aws-cdk/core": "1.124.0",
     "source-map-support": "^0.5.16"
   }

--- a/lambda-dynamodb-cdk/cdk/package.json
+++ b/lambda-dynamodb-cdk/cdk/package.json
@@ -21,6 +21,7 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
+    "@aws-cdk/aws-dynamodb": "^1.124.0",
     "@aws-cdk/core": "1.124.0",
     "source-map-support": "^0.5.16"
   }

--- a/lambda-dynamodb-cdk/cdk/src/app.ts
+++ b/lambda-dynamodb-cdk/cdk/src/app.ts
@@ -1,0 +1,6 @@
+export async function main( event: any ) {
+  return {
+    statusCode: 200,
+    body: 'OK!',
+  };
+}

--- a/lambda-dynamodb-cdk/cdk/src/app.ts
+++ b/lambda-dynamodb-cdk/cdk/src/app.ts
@@ -3,6 +3,7 @@
 */
 
 const AWS = require('aws-sdk');
+const moment = require('moment');
 
 const documentClient = new AWS.DynamoDB.DocumentClient();
 
@@ -11,7 +12,7 @@ export async function main( event: any ) {
     TableName : process.env.DatabaseTable,
     Item: {
       ID: Math.floor(Math.random() * Math.floor(10000000)).toString(),
-      created: Date.now(),
+      created: moment().format('YYYYMMDD-hhmmss'),
       metadata:JSON.stringify(event),
     }
   }

--- a/lambda-dynamodb-cdk/cdk/src/app.ts
+++ b/lambda-dynamodb-cdk/cdk/src/app.ts
@@ -1,4 +1,27 @@
+/*! Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: MIT-0
+*/
+
+const AWS = require('aws-sdk');
+
+const documentClient = new AWS.DynamoDB.DocumentClient();
+
 export async function main( event: any ) {
+  let params = {
+    TableName : process.env.DatabaseTable,
+    Item: {
+      ID: Math.floor(Math.random() * Math.floor(10000000)).toString(),
+      created: Date.now(),
+      metadata:JSON.stringify(event),
+    }
+  }
+  try {
+    let data = await documentClient.put(params).promise();
+  }
+  catch (err) {
+    console.log(err);
+    return err;
+  }
   return {
     statusCode: 200,
     body: 'OK!',

--- a/lambda-dynamodb-cdk/cdk/test/cdk.test.ts
+++ b/lambda-dynamodb-cdk/cdk/test/cdk.test.ts
@@ -1,0 +1,13 @@
+import { expect as expectCDK, matchTemplate, MatchStyle } from '@aws-cdk/assert';
+import * as cdk from '@aws-cdk/core';
+import * as Cdk from '../lib/cdk-stack';
+
+test('Empty Stack', () => {
+    const app = new cdk.App();
+    // WHEN
+    const stack = new Cdk.CdkStack(app, 'MyTestStack');
+    // THEN
+    expectCDK(stack).to(matchTemplate({
+      "Resources": {}
+    }, MatchStyle.EXACT))
+});

--- a/lambda-dynamodb-cdk/cdk/test/cdk.test.ts
+++ b/lambda-dynamodb-cdk/cdk/test/cdk.test.ts
@@ -1,13 +1,11 @@
-import { expect as expectCDK, matchTemplate, MatchStyle } from '@aws-cdk/assert';
+import { expect as expectCDK, matchTemplate, MatchStyle, haveResource } from '@aws-cdk/assert';
 import * as cdk from '@aws-cdk/core';
-import * as Cdk from '../lib/cdk-stack';
+import { CdkStack } from '../lib/cdk-stack';
 
-test('Empty Stack', () => {
-    const app = new cdk.App();
-    // WHEN
-    const stack = new Cdk.CdkStack(app, 'MyTestStack');
-    // THEN
-    expectCDK(stack).to(matchTemplate({
-      "Resources": {}
-    }, MatchStyle.EXACT))
+test('Validate stack resources', () => {
+  const app = new cdk.App();
+  const stack = new CdkStack(app, 'MyTestStack');
+
+  expectCDK(stack).to(haveResource('AWS::DynamoDB::Table'));
+  expectCDK(stack).to(haveResource('AWS::Lambda::Function'));
 });

--- a/lambda-dynamodb-cdk/cdk/tsconfig.json
+++ b/lambda-dynamodb-cdk/cdk/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "commonjs",
+    "lib": [
+      "es2018"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": [
+      "./node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "cdk.out"
+  ]
+}


### PR DESCRIPTION
*Issue #, if available:* 

#120

*Description of changes:* 

CDK code describes the Lambda function and DynamoDB table with permissions granted for Lambda to write to DynamoDB using the in-built grantWriteData property. This is the CDK implementation of the lambda-dynamodb example. The function code and the tests remain the same from the SAM version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
