### PR TITLE
Improvement/fargate dynamodb add vpce

### DIFF
--- a/fargate-dynamodb-cdk/README.md
+++ b/fargate-dynamodb-cdk/README.md
@@ -2,6 +2,8 @@
 
 This project contains a sample AWS Cloud Development Kit (AWS CDK) template for deploying an AWS Fargate service running on an Amazon Elastic Container Service (ECS) cluster with an Application Load Balancer in-front. The AWS Fargate service makes puts to a DynamoDB table. This template uses a custom image without having to pre-push the image to Amazon Elastic Container Registry (ECR) or another container library. This makes use of the in-built `ecs.ContainerImage.fromAsset` method. The custom image has a base route `/` for health checks and `/additem` for adding items. Environment variables like the DynamoDB table name and AWS region are passed to the image to enable it to put items to the DynamoDB table.
 
+This project also shows how to set up a DynamoDB Gateway Endpoint to the VPC. A VPC Endpoint policy is created to only allow the Fargate task definition to perform `PutItem` actions through the VPC endpoint.
+
 Learn more about this pattern at Serverless Land Patterns: https://serverlessland.com/patterns/fargate-dynamodb-cdk.
 
 Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.

--- a/fargate-dynamodb-cdk/cdk/lib/cdk-stack.ts
+++ b/fargate-dynamodb-cdk/cdk/lib/cdk-stack.ts
@@ -3,6 +3,7 @@ import { Table, BillingMode, AttributeType } from '@aws-cdk/aws-dynamodb';
 import * as ec2 from '@aws-cdk/aws-ec2';
 import * as ecs from '@aws-cdk/aws-ecs';
 import * as ecs_patterns from '@aws-cdk/aws-ecs-patterns';
+import { AnyPrincipal, Effect, PolicyStatement } from '@aws-cdk/aws-iam';
 import path = require('path');
 
 export class CdkStack extends cdk.Stack {
@@ -40,6 +41,19 @@ export class CdkStack extends cdk.Stack {
       },
       memoryLimitMiB: 2048,
     });
+
+    // Gateway endpoint policy to allow only PutItem action
+    dynamoGatewayEndpoint.addToPolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        principals: [new AnyPrincipal()],
+        actions: [
+          'dynamodb:PutItem',
+        ],
+        resources: [
+          `${dynamoTable.tableArn}`
+        ]
+    }));
 
     // Write permissions for Fargate
     dynamoTable.grantWriteData(fargate.taskDefinition.taskRole);

--- a/fargate-dynamodb-cdk/cdk/lib/cdk-stack.ts
+++ b/fargate-dynamodb-cdk/cdk/lib/cdk-stack.ts
@@ -42,7 +42,7 @@ export class CdkStack extends cdk.Stack {
       memoryLimitMiB: 2048,
     });
 
-    // Gateway endpoint policy to allow only PutItem action
+    // Allow PutItem action from the Fargate Task Definition only
     dynamoGatewayEndpoint.addToPolicy(
       new PolicyStatement({
         effect: Effect.ALLOW,
@@ -52,7 +52,12 @@ export class CdkStack extends cdk.Stack {
         ],
         resources: [
           `${dynamoTable.tableArn}`
-        ]
+        ],
+        conditions: {
+          'ArnEquals': {
+            'aws:PrincipalArn': `${fargate.taskDefinition.taskRole.roleArn}`
+          }
+        }
     }));
 
     // Write permissions for Fargate

--- a/fargate-dynamodb-cdk/cdk/lib/cdk-stack.ts
+++ b/fargate-dynamodb-cdk/cdk/lib/cdk-stack.ts
@@ -11,7 +11,8 @@ export class CdkStack extends cdk.Stack {
 
     const dynamoTable = new Table(this, 'DynamoTable', {
       partitionKey: {name:'ID', type: AttributeType.STRING},
-      billingMode: BillingMode.PAY_PER_REQUEST
+      billingMode: BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.DESTROY
     });
 
     const vpc = new ec2.Vpc(this, 'MyVpc', {

--- a/fargate-dynamodb-cdk/cdk/lib/cdk-stack.ts
+++ b/fargate-dynamodb-cdk/cdk/lib/cdk-stack.ts
@@ -19,6 +19,10 @@ export class CdkStack extends cdk.Stack {
       maxAzs: 3
     });
 
+    const dynamoGatewayEndpoint = vpc.addGatewayEndpoint('dynamoGatewayEndpoint', {
+      service: ec2.GatewayVpcEndpointAwsService.DYNAMODB
+    });
+
     const cluster = new ecs.Cluster(this, 'MyCluster', {
       vpc: vpc
     });

--- a/fargate-dynamodb-cdk/cdk/lib/cdk-stack.ts
+++ b/fargate-dynamodb-cdk/cdk/lib/cdk-stack.ts
@@ -58,7 +58,8 @@ export class CdkStack extends Stack {
             'aws:PrincipalArn': `${fargate.taskDefinition.taskRole.roleArn}`
           }
         }
-    }));
+      })
+    );
 
     // Write permissions for Fargate
     dynamoTable.grantWriteData(fargate.taskDefinition.taskRole);

--- a/fargate-dynamodb-cdk/cdk/package.json
+++ b/fargate-dynamodb-cdk/cdk/package.json
@@ -25,6 +25,7 @@
     "@aws-cdk/aws-ec2": "^1.128.0",
     "@aws-cdk/aws-ecs": "^1.128.0",
     "@aws-cdk/aws-ecs-patterns": "^1.128.0",
+    "@aws-cdk/aws-iam": "^1.128.0",
     "@aws-cdk/core": "1.128.0",
     "source-map-support": "^0.5.16"
   }


### PR DESCRIPTION
*Issue #, if available:* 
- The original issue number is #157 

*Description of changes:*

My first iteration of this pattern was Fargate Service integrated with DynamoDB where a custom container was created to perform `PutItem` actions.
I realised I could **improve the design and security of the pattern** via the changes described below:

Improvements
- [improvement] Add DynamoDB Gateway endpoint to allow `PutItem` actions to traverse through the AWS network (does not need to go through the public internet)
- [improvement] Add a VPC Endpoint policy to only allow the Fargate task definition to perform `PutItem` actions through the VPC endpoint. This is useful for others to use it as a template to customise more policies using a VPC endpoint
- [improvement] Reduce the use of `*` imports to only import packages that are used in the cdk template
- [documentation addition] Update README to describe the addition of VPC Endpoint. The relevant paragraph is:
    > This project also shows how to set up a DynamoDB Gateway Endpoint to the VPC. A VPC Endpoint policy is created to only allow the Fargate task definition to perform `PutItem` actions through the VPC endpoint.

- [fix] Add `RemovalPolicy.DESTROY` to the DynamoDB table because I realised that it wasn't destroyed on `cdk destroy`

LinkedIn (Handle for Serverless Pattern website): https://www.linkedin.com/in/glenn-chia-291344142
Twitter (Handle for Twitter mentions): glenncjw

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
