### PR TITLE
New serverless pattern - IoT to SQS with custom authorizer

### DIFF
--- a/iot-mqttoverhttp-customauth/README.md
+++ b/iot-mqttoverhttp-customauth/README.md
@@ -1,0 +1,57 @@
+# AWS IoT rule with custom authorizer to SQS
+
+This SAM template deploys resources needed to send iot events to IoT Core service to forward these events through an IoT Rule to SQS Queue with bring-your-own custom authozier for device authentication.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+* [Node and NPM](https://nodejs.org/en/download/) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ```
+    cd iot-mqttoverhttp-customauth
+    ```
+1. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
+    ```
+    sam deploy --guided --capabilities CAPABILITY_NAMED_IAM
+    ```
+1. During the prompts:
+    * Enter a stack name
+    * Enter the desired AWS Region
+    * Allow SAM CLI to create IAM roles with the required permissions.
+
+    Once you have run `sam deploy --guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+
+1. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## How it works
+
+Explain how the service interaction works.
+
+## Testing
+
+Use your choise of http client for testing against this endpoint: POST ${IoT Core Data Endpoint}/topics/$aws/rules/device_events with json body and http header 'x-amz-customauthorizer-name: anonymous-authorizer'.
+
+## Cleanup
+ 
+1. Delete the stack
+    ```bash
+    aws cloudformation delete-stack --stack-name STACK_NAME
+    ```
+1. Confirm the stack has been deleted
+    ```bash
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus"
+    ```
+----
+Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/iot-mqttoverhttp-customauth/iot-rule-sqs-customauth-pattern.json
+++ b/iot-mqttoverhttp-customauth/iot-rule-sqs-customauth-pattern.json
@@ -1,0 +1,54 @@
+{
+  "title": "Iot Rule with custom authorizer",
+  "description": "Create an IoT rule that uses lambda custom authorizer to process iot events with lambda function",
+  "language": "Node.js",
+  "videoId": "",
+  "level":"100",
+  "framework": "SAM",
+  "services": {
+    "from": "iot",
+    "to": "sqs"
+  },
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "The SAM template deploys a Iot Rule that forwards events to SQS to be processed by a lambda function. It also deploys a custom lambda authorizer to create your own autorizer to send events to AWS IoT through mqtt over https."
+    ]
+  },
+  "deploy": {
+    "text": [
+      "sam deploy --guided"
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/iot-mqttoverhttp-customauth",
+      "templateURL": "https://raw.githubusercontent.com/aws-samples/serverless-patterns/main/liot-mqttoverhttp-customauth/template.yaml",
+      "readmeURL": ""
+    },
+    "payloads": [
+      {
+        "headline": "",
+        "payloadURL": ""
+      }
+    ]
+  },
+  "resources": {
+    "headline": "Additional resources",
+    "bullets": [
+      {
+        "text": "IoT Rule",
+        "link": "https://docs.aws.amazon.com/iot/latest/developerguide/iot-rules.html"
+      },
+      {
+        "text": "Understanding the custom authentication workflow",
+        "link": "https://docs.aws.amazon.com/iot/latest/developerguide/custom-authorizer.html"
+      }      
+    ]
+  },
+  "author": {
+    "headline": "Presented by Enoch Tsai, Cloud Adaption Advocate",
+    "name": "Enoch Tsai",
+    "bio": "Enoch Tsai is a cloud application architect advocate for Serverless Applications at Amazon Web Services based in the US. Prior to joining AWS Ben worked in a number of different technical roles specializing in native cloud development for enterprise system."
+  }
+}

--- a/iot-mqttoverhttp-customauth/src/app.js
+++ b/iot-mqttoverhttp-customauth/src/app.js
@@ -1,0 +1,10 @@
+/*! Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: MIT-0
+ */
+
+'use strict'
+
+exports.handler = async (event) => {
+  // Lambda handler code
+  console.log(JSON.stringify(event, 0, null))
+}

--- a/iot-mqttoverhttp-customauth/template.yaml
+++ b/iot-mqttoverhttp-customauth/template.yaml
@@ -1,0 +1,127 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Serverless Pattern - IoT rule with custom lambda authorizer forwarding events to SQS for post iot event processing
+Parameters:
+  VPC:
+    Type: AWS::EC2::VPC::Id
+  Subnets:
+    Type: List<AWS::EC2::Subnet::Id>
+Resources:
+  IotEventQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: iot-events 
+  ProcessorSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: iot-events-processor
+      VpcId: !Ref VPC
+      SecurityGroupEgress:
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+  Processor:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: iot-events-processor
+      Handler: app.handler
+      Runtime: nodejs14.x
+      Timeout: 29
+      CodeUri: src/
+      Events:
+        IotEvent:
+          Type: SQS
+          Properties:
+            Queue: !GetAtt IotEventQueue.Arn
+            BatchSize: 10000
+            MaximumBatchingWindowInSeconds: 5
+      VpcConfig:
+        SecurityGroupIds:
+          - !Ref ProcessorSecurityGroup
+        SubnetIds: !Ref Subnets
+  TopicRuleRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: iot-topic-forwarder
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - iot.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      Path: /
+      Policies:
+      - PolicyName: iot-topic-forwarder-policy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+              - sqs:SendMessage
+            Resource: !GetAtt IotEventQueue.Arn 
+  SQSRule:
+    Type: AWS::IoT::TopicRule
+    Properties:
+      RuleName: device_events
+      TopicRulePayload:
+        Sql: SELECT * 
+        Actions:
+          - Sqs: 
+              QueueUrl: !Ref IotEventQueue
+              RoleArn: !GetAtt TopicRuleRole.Arn
+  LambdaAuthorizer:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: iot-publish-authorizer
+      Handler: index.handler
+      Runtime: nodejs14.x
+      InlineCode: |
+        exports.handler = function(event, context, callback) { 
+          var deviceId = event.protocolData.http.headers["x-device-id"];
+          callback(null, generateAuthResponse(deviceId)); 
+        };
+
+        var generateAuthResponse = function(deviceId) {
+          var response = {};
+          response.isAuthenticated = true;
+          response.principalId = deviceId;
+          var policy = {};
+          policy.Version = '2012-10-17';
+          policy.Statement = [];
+          var publishStatement = {}; 
+          var connectStatement = {};
+          connectStatement.Action = ["iot:Connect"];
+          connectStatement.Effect = 'Allow';
+          connectStatement.Resource = ["*"];
+          publishStatement.Action = ["iot:Publish"]; 
+          publishStatement.Effect = 'Allow'; 
+          publishStatement.Resource = ["arn:aws:iot:us-east-2:722442000886:topic/*"]; 
+          policy.Statement[0] = connectStatement;
+          policy.Statement[1] = publishStatement; 
+          response.policyDocuments = [policy];
+          response.disconnectAfterInSeconds = 3600;
+          response.refreshAfterInSeconds = 300;
+          
+          return response;
+        };
+
+  CustomAuthorizer:
+    Type: AWS::IoT::Authorizer
+    Properties:
+      AuthorizerName: anonymous-authorizer
+      Status: ACTIVE
+      SigningDisabled: true
+      AuthorizerFunctionArn: !GetAtt LambdaAuthorizer.Arn
+  IotLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt LambdaAuthorizer.Arn
+      Principal: iot.amazonaws.com
+      Action: lambda:InvokeFunction
+
+          
+      


### PR DESCRIPTION
Issue#: [206](https://github.com/aws-samples/serverless-patterns/issues/206)

Adding a new serverless pattern for IoT that uses rule to forward events received through data endpoint to a SQS queue to be processed by lambda function in batch. Along with this, this app also deploys a custom authorizer for IoT data endpoint to allow users to bring their own authentication as is.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
