### PR TITLE
REST API to AWS Batch: locking the IAM permissions to batch:SubmitJob

### DIFF
--- a/apigw-rest-api-batch-sam/template.yaml
+++ b/apigw-rest-api-batch-sam/template.yaml
@@ -27,7 +27,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  - 'batch:*'
+                  - 'batch:SubmitJob'
                 Resource:
                   - !Ref JobQueue
                   - !Join


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
REST API to AWS Batch: Updating the IAM permissions to batch:SubmitJob

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
