### PR TITLE
New serverless pattern - parallel-e2e-pipeline-cdk

### DIFF
--- a/parallel-e2e-pipeline-cdk/README.md
+++ b/parallel-e2e-pipeline-cdk/README.md
@@ -1,0 +1,85 @@
+# AWS CodePipeline with Parallel E2E Tests
+
+This pattern in CDK provides scaffolding for a CI/CD pipeline with parallelized End-to-End (E2E) tests.
+
+Learn more about this pattern at Serverless Land Patterns: << Add the live URL here >>
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [Node and NPM](https://nodejs.org/en/download/) installed
+* [AWS Cloud Development Kit](https://docs.aws.amazon.com/cdk/latest/guide/cli.html) (AWS CDK) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ```bash
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+2. Create an AWS CodeCommit repository and add it as a remote:
+    ```
+    git remote add << repository name >> << repository url >>
+    ```
+2. Change directory to the pattern directory:
+    ```bash
+    cd parallel-e2e-pipeline-cdk
+    ```
+3. Change directory to the pipeline directory:
+    ```bash
+    cd src/pipeline
+    ```
+4. From the command line, use npm to install the development dependencies:
+    ```bash
+    npm install
+    ```
+5. Configure the pipeline based on your environment. Navigate to pipeline-stack.ts and make changes based on the TODO comments.
+5. From the command line, configure environment variables for the AWS account you desire to deploy the pipeline to (the pipeline should be deployed in the same region as the AWS CodeCommit repo). For example:
+    ```bash
+    export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+    export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+    export AWS_DEFAULT_REGION=us-west-2
+    ```
+6. Navigate back to the pipeline directory and from the command line, use CDK to deploy the AWS resources for the pattern:
+    ```bash
+    cdk synth ParallelE2EPipelineCDK
+    cdk deploy ParallelE2EPipelineCDK
+    ```
+
+## How it works
+
+The provided pipeline consists of two stages: `Source` and `End_to_End_Tests`. The `Source` stage is linked to the AWS CodeCommit repository, so whenever any commit(s) is pushed to that repository, the pipeline will be triggered. Once the `Source` stage passes, the `End_to_End_Tests` stage will run. In this stage, two AWS CodeBuild servers are provisioned and each is assigned a group of test(s). The tests are then ran in parallel.
+
+The described pattern can be modified to meet your needs. For example:
+* Introduce a deployment stage before `End_to_End_Tests`
+* Provision N AWS CodeBuild servers
+* Run tests that use the framework you desire (e.g. Cypress, Puppeteer, Jest)
+
+## Testing
+
+Whenever a commit(s) is pushed to the AWS CodeCommit repository, it will automatically trigger the deployed pipeline. To manually trigger the pipeline follow the below steps:
+1. Log into your AWS account and navigate to the AWS CodePipeline console.
+2. Select ParallelE2EPipelineCDK and release a change.
+3. The pipeline execution should succeed. 
+4. To view build logs, click on `Details` under each action.
+
+## Cleanup
+ 
+1. From the command line, configure environment variables for the AWS account the pipeline is deployed in:
+    ```bash
+    export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+    export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+    export AWS_DEFAULT_REGION=us-west-2
+    ```
+2. Navigate to to the pipeline directory and delete the deployed pipeline by running:
+    ```bash
+    cdk destroy ParallelE2EPipelineCDK
+    ```
+3. Delete the AWS CodeCommit repository.
+----
+Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/parallel-e2e-pipeline-cdk/src/mock-e2e-tests/mock-e2e-1.ts
+++ b/parallel-e2e-pipeline-cdk/src/mock-e2e-tests/mock-e2e-1.ts
@@ -1,0 +1,1 @@
+console.log("RUNNING mock-e2e-1.ts");

--- a/parallel-e2e-pipeline-cdk/src/mock-e2e-tests/mock-e2e-2.ts
+++ b/parallel-e2e-pipeline-cdk/src/mock-e2e-tests/mock-e2e-2.ts
@@ -1,0 +1,1 @@
+console.log("RUNNING mock-e2e-2.ts");

--- a/parallel-e2e-pipeline-cdk/src/pipeline/.gitignore
+++ b/parallel-e2e-pipeline-cdk/src/pipeline/.gitignore
@@ -1,0 +1,7 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# compiled output
+/dist
+
+# dependencies
+/node_modules

--- a/parallel-e2e-pipeline-cdk/src/pipeline/app/constructs/end-to-end-tests.ts
+++ b/parallel-e2e-pipeline-cdk/src/pipeline/app/constructs/end-to-end-tests.ts
@@ -1,0 +1,103 @@
+import { Role } from "@aws-cdk/aws-iam";
+import { Construct } from "@aws-cdk/core";
+import { Artifact } from "@aws-cdk/aws-codepipeline";
+import { 
+  ComputeType, 
+  PipelineProject, 
+  BuildSpec, 
+  LinuxBuildImage 
+} from "@aws-cdk/aws-codebuild";
+import { CodeBuildAction } from "@aws-cdk/aws-codepipeline-actions";
+
+
+export const getEndToEndTestsActions = (
+  scope: Construct,
+  stageInput: Artifact,
+  codeBuildRole: Role,
+  installCommands: string[],
+): CodeBuildAction[] => {
+
+  // Names of the group of e2e tests to run. These values will be used in cdk/cloudformation ids.
+  const groupOne = "E2E_Tests_Group_One";
+  const groupTwo = "E2E_Tests_Group_Two";
+
+  const buildCommands = ["cd parallel-e2e-pipeline-cdk/src/mock-e2e-tests"];
+
+  const actions: CodeBuildAction[] = [
+    new CodeBuildAction({
+      actionName: groupOne,
+      project: getEndToEndTestProject(
+        scope,
+        groupOne,
+        codeBuildRole,
+        ComputeType.SMALL,
+        installCommands,
+        // The below cli command specifies what to run on this CodeBuild server.
+        [
+          ...buildCommands, 
+          `echo "Run additional commands for ${groupOne}"`,
+          "tsc mock-e2e-1.ts",
+          "node mock-e2e-1.ts"
+        ]
+      ),
+      input: stageInput,
+      outputs: [new Artifact(`${groupOne}_Ouput`)]
+    }),
+    new CodeBuildAction({
+      actionName: groupTwo,
+      project: getEndToEndTestProject(
+        scope,
+        groupTwo,
+        codeBuildRole,
+        ComputeType.SMALL,
+        installCommands,
+        // The below cli command specifies what to run on this CodeBuild server.
+        [
+          ...buildCommands, 
+          `echo "Run additional commands for ${groupTwo}"`,
+          "tsc mock-e2e-1.ts",
+          "node mock-e2e-2.ts"
+        ]
+      ),
+      input: stageInput,
+      outputs: [new Artifact(`${groupTwo}_Ouput`)]
+    }),
+  ];
+  return actions;
+}
+
+const getEndToEndTestProject = (
+  scope: Construct,
+  testGroupName: string,
+  codeBuildRole: Role,
+  computeType: ComputeType,
+  installCommands: string[],
+  buildCommands: string[],
+  preBuildCommands?: string[],
+  postBuildCommands?: string[],
+): PipelineProject => {
+  return new PipelineProject(scope, testGroupName, {
+    role: codeBuildRole,
+    buildSpec: BuildSpec.fromObject({
+      version: '0.2',
+      phases: {
+        install: {
+          commands: installCommands
+        },
+        pre_build: {
+          commands: preBuildCommands ?? []
+        },
+        build: {
+          commands: buildCommands
+        },
+        post_build: {
+          commands: postBuildCommands ?? []
+        }
+      }
+    }),
+    environment: {
+      buildImage: LinuxBuildImage.STANDARD_5_0,
+      computeType: computeType
+    }
+  });
+}

--- a/parallel-e2e-pipeline-cdk/src/pipeline/app/constructs/roles/e2e-code-build-role.ts
+++ b/parallel-e2e-pipeline-cdk/src/pipeline/app/constructs/roles/e2e-code-build-role.ts
@@ -1,0 +1,22 @@
+import { Construct } from "@aws-cdk/core";
+import { 
+  Role,
+  ServicePrincipal, 
+  ManagedPolicy
+} from "@aws-cdk/aws-iam";
+
+
+export class E2ECodeBuildRole extends Construct {
+  readonly role: Role;
+
+  public constructor(parent: Construct, id: string) {
+    super(parent, id);
+
+    this.role = new Role(this, "E2EStackRole", {
+      assumedBy: new ServicePrincipal("codebuild.amazonaws.com"),
+      managedPolicies: [
+        ManagedPolicy.fromAwsManagedPolicyName("AmazonS3FullAccess")
+      ]
+    });
+  }
+}

--- a/parallel-e2e-pipeline-cdk/src/pipeline/app/constructs/roles/index.ts
+++ b/parallel-e2e-pipeline-cdk/src/pipeline/app/constructs/roles/index.ts
@@ -1,0 +1,2 @@
+export * from "./pipeline-role";
+export * from "./e2e-code-build-role";

--- a/parallel-e2e-pipeline-cdk/src/pipeline/app/constructs/roles/pipeline-role.ts
+++ b/parallel-e2e-pipeline-cdk/src/pipeline/app/constructs/roles/pipeline-role.ts
@@ -1,0 +1,53 @@
+import {
+  PolicyDocument,
+  PolicyStatement,
+  Effect,
+  Role,
+  ServicePrincipal
+} from "@aws-cdk/aws-iam";
+import { Construct } from "@aws-cdk/core";
+
+
+interface PipelineRoleProps { 
+  roles: string[]
+}
+
+export class PipelineRole extends Construct {
+  readonly role: Role;
+  readonly policy: PolicyDocument;
+
+  public constructor(parent: Construct, id: string, props: PipelineRoleProps) {
+    super(parent, id);
+    this.policy = new PolicyDocument({
+      statements: [
+        new PolicyStatement({
+          actions: ["sts:*"],
+          effect: Effect.ALLOW,
+          resources: [...props.roles]
+        }),
+        new PolicyStatement({
+          actions: [
+            "codecommit:GetBranch",
+            "codecommit:GetCommit",
+            "codecommit:UploadArchive",
+            "codecommit:GetUploadArchiveStatus",
+            "codecommit:CancelUploadArchive",
+            "codebuild:BatchGetBuilds",
+            "codebuild:StartBuild",
+            "codedeploy:CreateDeployment",
+            "codedeploy:GetApplicationRevision",
+            "codedeploy:GetDeployment",
+            "codedeploy:GetDeploymentConfig",
+            "codedeploy:RegisterApplicationRevision"
+          ],
+          effect: Effect.ALLOW,
+          resources: ["*"]
+        })
+      ]
+    });
+    this.role = new Role(this, "PipelineRole", {
+      assumedBy: new ServicePrincipal("codepipeline.amazonaws.com"),
+      inlinePolicies: { base_policy: this.policy }
+    });
+  };
+};

--- a/parallel-e2e-pipeline-cdk/src/pipeline/app/pipeline-stack.ts
+++ b/parallel-e2e-pipeline-cdk/src/pipeline/app/pipeline-stack.ts
@@ -1,0 +1,75 @@
+import { App, Stack, StackProps } from "@aws-cdk/core";
+import * as codecommit from "@aws-cdk/aws-codecommit";
+import * as codepipeline from "@aws-cdk/aws-codepipeline";
+import * as codepipeline_actions from "@aws-cdk/aws-codepipeline-actions"
+
+import { PipelineRole, E2ECodeBuildRole } from "./constructs/roles";
+import { getEndToEndTestsActions } from "./constructs/end-to-end-tests";
+
+
+export interface PipelineStackProps extends StackProps {
+  readonly prefix: string;
+};
+
+export class PipelineStack extends Stack {
+  constructor(app: App, id: string, props: PipelineStackProps) {
+    super(app, id, props);
+
+    const repository = codecommit.Repository.fromRepositoryName(
+      this, 
+      "ImportedRepo", 
+      "serverless-patterns"  // TODO: Replace this with the name of your AWS CodeCommit repository
+    );
+
+    const sourceOutput = new codepipeline.Artifact();
+
+    const e2eBuildRole = new E2ECodeBuildRole(this, "E2EBuildRole").role;
+    const installCommands = [
+      `echo "Run install commands"`,
+      "npm install -g typescript"
+    ];
+    const stages = [
+      {
+        stageName: "Source",
+        actions: [
+          new codepipeline_actions.CodeCommitSourceAction({
+            actionName: "CodeCommit_Source",
+            repository: repository,
+            branch: "mainline", // TODO: Replace this with the name of your working branch
+            output: sourceOutput
+          })
+        ]
+      },
+      /**
+       * TODO (Optional for deploying pattern): Add a deployment stage for your application. The following
+       * "End_to_End_Tests" stage would run against this application.
+       */
+      {
+        stageName: "End_to_End_Tests",
+        actions: [
+          ...getEndToEndTestsActions(
+            this,
+            sourceOutput,
+            e2eBuildRole,
+            installCommands
+          )
+        ]
+      }
+    ];
+
+    const deployedPipelineRole = new PipelineRole(
+      this, 
+      "PipelineRole", 
+      { roles: [e2eBuildRole.roleArn] }
+    ).role;
+    const deployedPipeline = new codepipeline.Pipeline(
+      this,
+      `${props.prefix}Pipeline`,
+      {
+        pipelineName: id,
+        stages: stages,
+        role: deployedPipelineRole
+      }
+    );
+  }
+};

--- a/parallel-e2e-pipeline-cdk/src/pipeline/cdk.json
+++ b/parallel-e2e-pipeline-cdk/src/pipeline/cdk.json
@@ -1,0 +1,4 @@
+{
+  "app": "npx ts-node main.ts",
+  "output": "dist/cdk.out"
+}

--- a/parallel-e2e-pipeline-cdk/src/pipeline/main.ts
+++ b/parallel-e2e-pipeline-cdk/src/pipeline/main.ts
@@ -1,0 +1,12 @@
+import * as cdk from "@aws-cdk/core";
+import { PipelineStack } from "./app/pipeline-stack";
+
+const app = new cdk.App();
+
+new PipelineStack(app, "ParallelE2EPipelineCDK", {
+  prefix: "ServerlessLand",
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEFAULT_REGION
+  }
+});

--- a/parallel-e2e-pipeline-cdk/src/pipeline/package.json
+++ b/parallel-e2e-pipeline-cdk/src/pipeline/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "pipeline",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@aws-cdk/aws-codebuild": "^1.125.0",
+    "@aws-cdk/aws-codecommit": "^1.125.0",
+    "@aws-cdk/aws-codepipeline": "^1.125.0",
+    "@aws-cdk/aws-codepipeline-actions": "^1.125.0",
+    "@aws-cdk/aws-iam": "^1.125.0",
+    "@aws-cdk/core": "^1.125.0"
+  },
+  "devDependencies": {
+    "@types/node": "^16.10.2",
+    "aws-cdk": "^1.125.0",
+    "ts-node": "^10.2.1",
+    "typescript": "^4.4.3"
+  }
+}

--- a/parallel-e2e-pipeline-cdk/src/pipeline/tsconfig.json
+++ b/parallel-e2e-pipeline-cdk/src/pipeline/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "commonjs",
+    "lib": ["es2018"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": ["./node_modules/@types"]
+  },
+  "exclude": ["cdk.out"]
+}


### PR DESCRIPTION
*Issue #, if available:*
#219 

*Description of changes:*
Added a new serverless pattern (parallel-e2e-pipeline-cdk) that provides scaffolding for a CI/CD pipeline with a stage, which can be used to run End-to-End-Tests in parallel.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
