### PR TITLE
Fix broken rule

### DIFF
--- a/sfn-eventbridge/template.yaml
+++ b/sfn-eventbridge/template.yaml
@@ -62,7 +62,7 @@ Resources:
           - prefix: ""
       State: ENABLED
       Targets:
-        - Arn: !GetAtt MyLogGroup.Arn
+        - Arn: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${MyLogGroup}"
           Id: CloudWatchLogTarget
     DependsOn: MyEventBus
 


### PR DESCRIPTION
It seems the log group arn has a trailing :* which deploys fine without errors but did not work and the event never reached the eventbus. Maybe there is a better workaround but constructing the arn without the * seems to resolve it. 

Related to the extra star in console clicking from the rule through to the target shows error message in the cloudwatch console "An error occurred while describing log groups.
1 validation error detected: Value '/aws/events/sfn-eventbridge:*' at 'logGroupNamePrefix' failed to satisfy constraint: Member must satisfy regular expression pattern: [\.\-_/#A-Za-z0-9]+"




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
