### PR TITLE
New serverless pattern - appmesh-ecs

### DIFF
--- a/appmesh-ecs/README.md
+++ b/appmesh-ecs/README.md
@@ -1,0 +1,158 @@
+# AWS App Mesh with ECS Utilizing Two Services
+
+This pattern will setup an ECS Cluster with two services and then stand up App Mesh so that one can achieve a circuit
+breaker pattern and retry policy with only infrastructure.
+
+To demonstrate how to implement App Mesh, a sample application will be utilized that was built from the ground up. This application consists of two ECS services: Service B and Service C. B, once executed, will then call C. A two word sentence will then be constructed. In short, this is a more complex version of Hello, World.
+
+The technology stack that will drive our application is a Fargate ECS Cluster with two task definitions. Further, a new VPC with two public subnets and two private subnets will be created. This solution is rounded out with a bastion host in one of the private subnets that utilizes Systems Manager (SSM) in order to communicate with the endpoints.
+
+An App Mesh is then created along with a virtual gateway, virtual services, virtual routes, and virtual nodes. In the backend, AWS Cloud Map and Route53 is utilized in order to provide service discovery.
+
+Finally, a self-signed certificate will be generated so that SSL termination can be demonstrated with this solution. While the AWS CLI is necessary to generate the certificate, one can utilize either the CloudFormation service or SAM (Serverless Application Model) in order to execute the CF template located below.
+
+
+Learn more about this pattern at Serverless Land Patterns: [https://serverlessland.com/patterns](https://serverlessland.com/patterns)
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+2. Change directory to the pattern directory:
+    ```
+    cd _patterns-model
+    ```
+3. Setup the security certificate and export the ARN so that the CloudFormation template can utilize it.
+   1. First, create a root Certificate Authority (CA):
+   ```
+   export ROOT_CA_ARN=`aws acm-pca create-certificate-authority \
+    --certificate-authority-type ROOT \
+    --certificate-authority-configuration \
+    "KeyAlgorithm=RSA_2048,
+    SigningAlgorithm=SHA256WITHRSA,
+    Subject={
+        Country=US,
+        State=WA,
+        Locality=Seattle,
+        Organization=App Mesh Examples,
+        OrganizationalUnit=Ingress Example,
+        CommonName=${SERVICES_DOMAIN}}" \
+        --query CertificateAuthorityArn --output text`
+   ```
+   2. Next, we’ll need to self-sign this root CA. First fetch the CSR:
+   ```
+   ROOT_CA_CSR=`aws acm-pca get-certificate-authority-csr \
+    --certificate-authority-arn ${ROOT_CA_ARN} \
+    --query Csr --output text`
+   ```
+   3. Then sign the CSR as the issuer:
+   ```
+   AWS_CLI_VERSION=$(aws --version 2>&1 | cut -d/ -f2 | cut -d. -f1)
+   [[ ${AWS_CLI_VERSION} -gt 1 ]] && ROOT_CA_CSR="$(echo ${ROOT_CA_CSR} | base64)"
+
+   ROOT_CA_CERT_ARN=`aws acm-pca issue-certificate \
+   --certificate-authority-arn ${ROOT_CA_ARN} \
+   --template-arn arn:aws:acm-pca:::template/RootCACertificate/V1 \
+   --signing-algorithm SHA256WITHRSA \
+   --validity Value=10,Type=YEARS \
+   --csr "${ROOT_CA_CSR}" \
+   --query CertificateArn --output text`
+   ```
+   4. Import this signed certificate as the root CA:
+   ```
+   ROOT_CA_CERT=`aws acm-pca get-certificate \
+    --certificate-arn ${ROOT_CA_CERT_ARN} \
+    --certificate-authority-arn ${ROOT_CA_ARN} \
+    --query Certificate --output text`
+   [[ ${AWS_CLI_VERSION} -gt 1 ]] && ROOT_CA_CERT="$(echo ${ROOT_CA_CERT} | base64)"
+   ```
+   5. Then import the certificate:
+   ```
+   aws acm-pca import-certificate-authority-certificate \
+    --certificate-authority-arn $ROOT_CA_ARN \
+    --certificate "${ROOT_CA_CERT}"
+   ```
+   6. We also want permissions to allow the CA to renew the certificate:
+   ```
+   aws acm-pca create-permission \
+    --certificate-authority-arn $ROOT_CA_ARN \
+    --actions IssueCertificate GetCertificate ListPermissions \
+    --principal acm.amazonaws.com
+   ```
+   7. Finally, we can request a managed certificate using the CA:
+   ```
+   export CERTIFICATE_ARN=`aws acm request-certificate \
+    --domain-name "*.${SERVICES_DOMAIN}" \
+    --certificate-authority-arn ${ROOT_CA_ARN} \
+    --query CertificateArn --output text`
+   ```
+4. Build and Upload the Container Images to ECR
+   1. First, authenticate to ECR via the AWS CLI. Make sure to replace <ACCOUNT_ID> and <REGION> with the appropriate values.
+   ```
+   aws ecr get-login-password --region <REGION> \
+   | docker login --username AWS --password-stdin \
+   <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com
+   ```
+   2. Next, build the images with
+   ```
+   cd src/serviceB
+   docker build -t <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/serviceb .
+   ```
+   3. Then push it to ECR:
+   ```
+   docker push <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/serviceb:latest
+   ```
+   4. Repeat steps ii and iii for serviceC.
+5. Modify the parameters in the CloudFormation template. 
+   
+6. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
+    ```
+    sam deploy --guided
+    ```
+7. During the prompts:
+    * Enter a stack name
+    * Enter the desired AWS Region
+    * Allow SAM CLI to create IAM roles with the required permissions.
+
+    Once you have run `sam deploy --guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+
+8. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## How it works
+
+App Mesh is a service mesh that provides application-level networking and improves observability by providing consistent visibility and traffic controls.
+
+App Mesh utilizes [Envoy](https://www.envoyproxy.io (https://www.envoyproxy.io/)) as a proxy to monitor and control communications to a container as a sidecar. With this control plane, one can achieve both circuit breaker and retry patterns in addition to service discovery.
+
+
+## Testing
+
+From the SAM output, take the `oServiceAppEndpoint` URL and paste that into a browser. One should see the output from 
+the services that are being called through App Mesh.
+
+## Cleanup
+ 
+1. Delete the stack
+    ```bash
+    aws cloudformation delete-stack --stack-name STACK_NAME
+    ```
+2. Confirm the stack has been deleted
+    ```bash
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus"
+    ```
+3. Delete the security certificate through ACM.   
+----
+Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/appmesh-ecs/src/serviceB/Dockerfile
+++ b/appmesh-ecs/src/serviceB/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:12-alpine
+RUN mkdir -p /usr/src/serviceB
+WORKDIR /usr/src/serviceB
+COPY . .
+RUN npm install
+EXPOSE 3001
+CMD [ "node", "index.js" ]

--- a/appmesh-ecs/src/serviceB/index.js
+++ b/appmesh-ecs/src/serviceB/index.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const app = express();
+const xray = require('aws-xray-sdk');
+const axios = require('axios');
+const serviceC = 'http://servicec.services.local:3001';
+const util = require('util');
+const http = require('http');
+
+xray.captureHTTPsGlobal(require('http'));
+xray.capturePromise();
+
+app.use(xray.express.openSegment('serviceB'));
+
+app.get('/', async (req, res) => {
+    const barr = ['Hi', 'Hello', 'Konnichiwa', 'Ohaiyo'];
+    const bres = barr[Math.floor(Math.random() * barr.length)];
+    try {
+        const serviceCRes = await axios.get(serviceC);
+        if (typeof serviceCRes === 'object') {
+            console.log(`serviceC (obj): ${util.inspect(serviceCRes)}`);
+        } else {
+            console.log(`serviceC (str): ${serviceCRes}`);
+        }
+        res.send(`${bres} ${serviceCRes.data}`);
+    } catch (e) {
+        console.log(`Error getting serviceC: ${e}`);
+        res.send(e);
+    }
+});
+
+app.get('/health', async(req, res) => {
+    res.sendStatus(200);
+});
+
+app.use(xray.express.closeSegment());
+
+app.listen(3001, () => {
+    console.log(`ServiceB started`);
+})

--- a/appmesh-ecs/src/serviceB/package.json
+++ b/appmesh-ecs/src/serviceB/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "multiplesvc",
+  "version": "0.0.1",
+  "description": "SAM app for testing multiple services with circuit breaker",
+  "main": "src/serviceA/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "JJ Johnson <mthojoh@amazon.com>",
+  "license": "ISC",
+  "dependencies": {
+    "aws-xray-sdk": "^3.3.3",
+    "axios": "^0.21.1",
+    "express": "^4.17.1"
+  }
+}

--- a/appmesh-ecs/src/serviceC/Dockerfile
+++ b/appmesh-ecs/src/serviceC/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:12-alpine
+RUN mkdir -p /usr/src/serviceC
+WORKDIR /usr/src/serviceC
+COPY . .
+RUN npm install
+EXPOSE 3001
+CMD [ "node", "index.js" ]

--- a/appmesh-ecs/src/serviceC/index.js
+++ b/appmesh-ecs/src/serviceC/index.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const app = express();
+const axios = require('axios');
+const xray = require('aws-xray-sdk');
+
+app.use(xray.express.openSegment('serviceC'));
+
+app.get('/', async(req, res) => {
+    const carr = ['there', 'world', 'friend'];
+    const cres = carr[Math.floor(Math.random() * carr.length)];
+    res.send(cres);
+});
+
+app.get('/health', async(req, res) => {
+    res.sendStatus(200);
+});
+
+app.use(xray.express.closeSegment());
+
+app.listen(3001, () => {
+    console.log(`ServiceC started`);
+})

--- a/appmesh-ecs/src/serviceC/package.json
+++ b/appmesh-ecs/src/serviceC/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "multiplesvc",
+  "version": "0.0.1",
+  "description": "SAM app for testing multiple services with circuit breaker",
+  "main": "src/serviceA/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "JJ Johnson <mthojoh@amazon.com>",
+  "license": "ISC",
+  "dependencies": {
+    "aws-xray-sdk": "^3.3.3",
+    "axios": "^0.21.1",
+    "express": "^4.17.1"
+  }
+}

--- a/appmesh-ecs/template.yml
+++ b/appmesh-ecs/template.yml
@@ -1,0 +1,1336 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: SAM Template for creating an App Mesh
+
+###
+# Metadata
+###
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: KeyPairs for EC2
+        Parameters:
+          - pPrivateKeyName
+    ParameterLabels:
+      pPrivateKeyName:
+        default: Keypair name for Bastion
+      pStageName:
+        default: Stage name
+
+###
+# Globals
+###
+Globals:
+  Function:
+    Timeout: 30
+  Api:
+    BinaryMediaTypes:
+      - '*/*'
+
+###
+# Parameters
+###
+Parameters:
+  pEnvironmentName:
+    Type: String
+    Description: Environment name that joins all the stacks
+    AllowedPattern: ^[A-Za-z]*$
+    Default: Test
+  pInstanceType:
+    Description: Which instance type should we use to build the ECS cluster?
+    Type: String
+    Default: t3.medium
+  pECSServiceLogGroupRetentionInDays:
+    Type: String
+    AllowedPattern: ^[0-9]*$
+    Description: Number of days to keep logs
+    Default: 3
+  pAppMeshMeshName:
+    Type: String
+    Description: Name of mesh
+    AllowedPattern: ^[A-Za-z]*$
+    Default: TechMesh
+  pECSServicesDomain:
+    Type: String
+    Description: DNS namespace used by services e.g. default.svc.cluster.local
+    AllowedPattern: ^[A-Za-z\.]*$
+    Default: services.local
+  pEnvoyImage:
+    Type: String
+    Description: The image to use for the Envoy container
+    AllowedPattern: ^[A-Za-z0-9\-\.\/\:]*$
+    Default: 840364872350.dkr.ecr.us-east-1.amazonaws.com/aws-appmesh-envoy:v1.19.0.0-prod
+  pServiceBImage:
+    Type: String
+    Description: Docker Container for ServiceB
+    AllowedPattern: ^[A-Za-z]*$
+    Default: serviceb
+  pServiceBName:
+    Type: String
+    Description: Name for ServiceB
+    AllowedPattern: ^[A-Za-z]*$
+    Default: serviceB
+  pServiceBPort:
+    Type: String
+    Description: App port for ServiceB
+    AllowedPattern: ^[0-9]*$
+    Default: 3001
+  pServiceCImage:
+    Type: String
+    Description: Docker Container for ServiceC
+    AllowedPattern: ^[A-Za-z]*$
+    Default: servicec
+  pServiceCName:
+    Type: String
+    Description: Name for ServiceB
+    AllowedPattern: ^[A-Za-z]*$
+    Default: serviceC
+  pServiceCPort:
+    Type: String
+    Description: App port for ServiceC
+    AllowedPattern: ^[0-9]*$
+    Default: 3001
+  pPrivateKeyName:
+    Type: AWS::EC2::KeyPair::KeyName
+    Default: bastionkey
+    AllowedPattern: ^[A-Za-z0-9]*$
+    Description: Keypair name that already exists which will be used for the EC2 bastion instance
+  pLoadBalancerCertificateArn:
+    Type: String
+    Default: arn:aws:acm:us-east-2:954260157019:certificate/14a30f03-99a0-45f3-9b05-eb1b2216fb7d
+    AllowedPattern: ^[A-Za-z0-9\-\.\/\:]*$
+    Description: ARN for the Load Balancer Certificate
+
+###
+# Mappings
+###
+Mappings:
+  mSubnetConfig:
+    VPC:
+      CIDR: 10.0.0.0/16
+    PublicAZ1:
+      CIDR: 10.0.1.0/24
+    PublicAZ2:
+      CIDR: 10.0.2.0/24
+    PrivateECSAZ1:
+      CIDR: 10.0.3.0/24
+    PrivateDBAZ1:
+      CIDR: 10.0.4.0/24
+    PrivateECSAZ2:
+      CIDR: 10.0.5.0/24
+    PrivateDBAZ2:
+      CIDR: 10.0.6.0/24
+
+###
+# Resources
+###
+Resources:
+  rVPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      CidrBlock:
+        Fn::FindInMap:
+          - mSubnetConfig
+          - VPC
+          - CIDR
+      Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: VPC for ${AWS::StackName}
+  rInternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: Internet Gateway for ${AWS::StackName}
+  rGatewayToInternet:
+    Type: AWS::EC2::VPCGatewayAttachment
+    DependsOn:
+      - rInternetGateway
+      - rVPC
+    Properties:
+      VpcId:
+        Ref: rVPC
+      InternetGatewayId:
+        Ref: rInternetGateway
+  rPublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    DependsOn: rVPC
+    Properties:
+      VpcId:
+        Ref: rVPC
+      Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: ${AWS::StackName}-public
+  rPublicRoute:
+    Type: AWS::EC2::Route
+    DependsOn:
+      - rPublicRouteTable
+      - rInternetGateway
+    Properties:
+      RouteTableId:
+        Ref: rPublicRouteTable
+      DestinationCidrBlock: '0.0.0.0/0'
+      GatewayId:
+        Ref: rInternetGateway
+  rPublicSubnetAZ1Association:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    DependsOn:
+      - rPublicSubnetAZ1
+      - rPublicRouteTable
+    Properties:
+      SubnetId:
+        Ref: rPublicSubnetAZ1
+      RouteTableId:
+        Ref: rPublicRouteTable
+  rPublicSubnetAZ2Association:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    DependsOn:
+      - rPublicSubnetAZ2
+      - rPublicRouteTable
+    Properties:
+      SubnetId:
+        Ref: rPublicSubnetAZ2
+      RouteTableId:
+        Ref: rPublicRouteTable
+  rPublicSubnetAZ1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone:
+        Fn::Select:
+          - 0
+          - Fn::GetAZs:
+              Ref: AWS::Region
+      VpcId:
+        Ref: rVPC
+      CidrBlock:
+        Fn::FindInMap:
+          - mSubnetConfig
+          - PublicAZ1
+          - CIDR
+      Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: Public Subnet AZ1 for ${AWS::StackName}
+  rPublicSubnetAZ2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone:
+        Fn::Select:
+          - 1
+          - Fn::GetAZs:
+              Ref: AWS::Region
+      VpcId:
+        Ref: rVPC
+      CidrBlock:
+        Fn::FindInMap:
+          - mSubnetConfig
+          - PublicAZ2
+          - CIDR
+      Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: Public Subnet AZ2 for ${AWS::StackName}
+  rNatGatewayAZ1Attachment:
+    Type: AWS::EC2::EIP
+    DependsOn: rGatewayToInternet
+    Properties:
+      Domain: rVPC
+      Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: Nat Gateway attachment for AZ1 for ${AWS::StackName}
+  rNatGatewayAZ2Attachment:
+    Type: AWS::EC2::EIP
+    DependsOn: rGatewayToInternet
+    Properties:
+      Domain: rVPC
+      Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: Nat Gateway attachment for AZ2 for ${AWS::StackName}
+  rNatGatewayAZ1:
+    Type: AWS::EC2::NatGateway
+    DependsOn: rNatGatewayAZ1Attachment
+    Properties:
+      AllocationId:
+        Fn::GetAtt:
+          - rNatGatewayAZ1Attachment
+          - AllocationId
+      SubnetId:
+        Ref: rPublicSubnetAZ1
+      Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: Nat Gateway to AZ1 for ${AWS::StackName}
+  rNatGatewayAZ2:
+    Type: AWS::EC2::NatGateway
+    DependsOn: rNatGatewayAZ2Attachment
+    Properties:
+      AllocationId:
+        Fn::GetAtt:
+          - rNatGatewayAZ2Attachment
+          - AllocationId
+      SubnetId:
+        Ref: rPublicSubnetAZ2
+      Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: Nat Gateway to AZ2 for ${AWS::StackName}
+  rPrivateRouteTable:
+    Type: AWS::EC2::RouteTable
+    DependsOn: rVPC
+    Properties:
+      VpcId:
+        Ref: rVPC
+      Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: Private Route Table for ${AWS::StackName}
+  rPrivateRoute:
+    Type: AWS::EC2::Route
+    DependsOn:
+      - rPrivateRouteTable
+      - rNatGatewayAZ1
+    Properties:
+      RouteTableId:
+        Ref: rPrivateRouteTable
+      DestinationCidrBlock: '0.0.0.0/0'
+      NatGatewayId:
+        Ref: rNatGatewayAZ1
+  rPrivateECSAZ1RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    DependsOn:
+      - rPrivateSubnetECSAZ1
+      - rPrivateRouteTable
+    Properties:
+      SubnetId:
+        Ref: rPrivateSubnetECSAZ1
+      RouteTableId:
+        Ref: rPrivateRouteTable
+  rPrivateECSAZ2RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    DependsOn:
+      - rPrivateSubnetECSAZ2
+      - rPrivateRouteTable
+    Properties:
+      SubnetId:
+        Ref: rPrivateSubnetECSAZ2
+      RouteTableId:
+        Ref: rPrivateRouteTable
+  rPrivateSubnetECSAZ1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone:
+        Fn::Select:
+          - 0
+          - Fn::GetAZs:
+              Ref: AWS::Region
+      VpcId:
+        Ref: rVPC
+      CidrBlock:
+        Fn::FindInMap:
+          - mSubnetConfig
+          - PrivateECSAZ1
+          - CIDR
+      Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: Private Subnet for ECS AZ1 for ${AWS::StackName}
+  rPrivateSubnetECSAZ2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone:
+        Fn::Select:
+          - 1
+          - Fn::GetAZs:
+              Ref: AWS::Region
+      VpcId:
+        Ref: rVPC
+      CidrBlock:
+        Fn::FindInMap:
+          - mSubnetConfig
+          - PrivateECSAZ2
+          - CIDR
+      Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: Private Subnet ECS AZ2 for ${AWS::StackName}
+  rInternalAccessSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    DependsOn: rVPC
+    Properties:
+      GroupDescription: Instance to instance access in VPC
+      VpcId:
+        Ref: rVPC
+      Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: Security Group to control instance access for ${AWS::StackName}
+  rInternalAccessSecurityGroupIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn: rInternalAccessSecurityGroup
+    Properties:
+      GroupId:
+        Ref: rInternalAccessSecurityGroup
+      IpProtocol: '-1'
+      SourceSecurityGroupId:
+        Ref: rInternalAccessSecurityGroup
+  rEC2SecGroup:
+    Type: AWS::EC2::SecurityGroup
+    DependsOn:
+      - rVPC
+      - rPublicSubnetAZ1
+      - rPublicSubnetAZ2
+    Properties:
+      GroupDescription: SG for EC2
+      VpcId:
+        Ref: rVPC
+      Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: EC2 SG for ${AWS::StackName}
+  rECSSecGroup:
+    Type: AWS::EC2::SecurityGroup
+    DependsOn:
+      - rVPC
+      - rPrivateSubnetECSAZ1
+      - rPrivateSubnetECSAZ2
+    Properties:
+      GroupDescription: SG for ECS
+      VpcId:
+        Ref: rVPC
+      Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: ECS SG for ${AWS::StackName}
+  rSSHSecGroup:
+    Type: AWS::EC2::SecurityGroup
+    DependsOn:
+      - rVPC
+      - rPrivateSubnetECSAZ1
+      - rPrivateSubnetECSAZ2
+    Properties:
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          SourceSecurityGroupId:
+            Ref: rEC2SecGroup
+      GroupDescription: Allow SSH
+      VpcId:
+        Ref: rVPC
+      Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: SSH SG for ${AWS::StackName}
+
+  rECSCluster:
+    Type: AWS::ECS::Cluster
+    DependsOn:
+      - rVPC
+      - rPrivateSubnetECSAZ1
+      - rPrivateSubnetECSAZ2
+    Properties:
+      ClusterName: !Ref pEnvironmentName
+      Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: ECS Cluster for ${AWS::StackName}
+  rECSInstancesSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: "Security group for the instances"
+      VpcId:
+        !Ref rVPC
+      SecurityGroupIngress:
+        - CidrIp:
+            Fn::FindInMap:
+              - mSubnetConfig
+              - VPC
+              - CIDR
+          IpProtocol: -1
+      Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: ECS Instances SG for ${AWS::StackName}
+
+  rECSServiceDiscoveryNamespace:
+    Type: AWS::ServiceDiscovery::PrivateDnsNamespace
+    Properties:
+      Vpc: !Ref rVPC
+      Name: !Sub "${pECSServicesDomain}"
+      Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: DNS Based VPC Private Namespace for ${AWS::StackName}
+  rECSServiceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: "Security group for the service"
+      VpcId:
+        !Ref rVPC
+      SecurityGroupIngress:
+        - CidrIp:
+            Fn::FindInMap:
+              - mSubnetConfig
+              - VPC
+              - CIDR
+          IpProtocol: -1
+      Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: ECS Instances Service SG for ${AWS::StackName}
+  rTaskIamRoleECS:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: /
+      AssumeRolePolicyDocument: |
+        {
+            "Statement": [{
+                "Effect": "Allow",
+                "Principal": { "Service": [ "ecs-tasks.amazonaws.com" ]},
+                "Action": [ "sts:AssumeRole" ]
+            }]
+        }
+      Policies:
+        - PolicyName: ACMExportCertificateAccess
+          PolicyDocument: |
+            {
+              "Statement": [{
+                "Effect": "Allow",
+                "Action": ["acm:ExportCertificate"],
+                "Resource": ["*"]
+              }]
+            }
+        - PolicyName: ACMCertificateAuthorityAccess
+          PolicyDocument: |
+            {
+              "Statement": [{
+                "Effect": "Allow",
+                "Action": ["acm-pca:GetCertificateAuthorityCertificate"],
+                "Resource": ["*"]
+              }]
+            }
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/CloudWatchFullAccess
+        - arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess
+        - arn:aws:iam::aws:policy/AWSAppMeshPreviewEnvoyAccess
+        - arn:aws:iam::aws:policy/AWSAppMeshEnvoyAccess
+      Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: ECS Task IAM Role for ${AWS::StackName}
+
+  rTaskExecutionIamRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: /
+      AssumeRolePolicyDocument: |
+        {
+            "Statement": [{
+                "Effect": "Allow",
+                "Principal": { "Service": [ "ecs-tasks.amazonaws.com" ]},
+                "Action": [ "sts:AssumeRole" ]
+            }]
+        }
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+        - arn:aws:iam::aws:policy/CloudWatchLogsFullAccess
+    Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: Task Execution IAM Role for ${AWS::StackName}
+
+  rECSServiceLogGroup:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      RetentionInDays:
+        Ref: pECSServiceLogGroupRetentionInDays
+  rECSServiceDiscoveryNamespace:
+    Type: AWS::ServiceDiscovery::PrivateDnsNamespace
+    Properties:
+      Vpc:
+        !Ref rVPC
+      Name: !Sub "${pECSServicesDomain}"
+    Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: DNS Based VPC Private Namespace for ${AWS::StackName}
+  rECSTaskIamRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: /
+      AssumeRolePolicyDocument: |
+        {
+            "Statement": [{
+                "Effect": "Allow",
+                "Principal": { "Service": [ "ecs-tasks.amazonaws.com" ]},
+                "Action": [ "sts:AssumeRole" ]
+            }]
+        }
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/CloudWatchFullAccess
+        - arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess
+        - arn:aws:iam::aws:policy/AWSAppMeshEnvoyAccess
+    Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: ECS Task IAM Role for ${AWS::StackName}
+  rServiceBTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      RequiresCompatibilities:
+        - 'FARGATE'
+      Family: !Sub '${pEnvironmentName}-serviceB'
+      NetworkMode: 'awsvpc'
+      Cpu: 256
+      Memory: 512
+      TaskRoleArn: !GetAtt rTaskIamRoleECS.Arn
+      ExecutionRoleArn: !GetAtt rTaskExecutionIamRole.Arn
+      ProxyConfiguration:
+        Type: 'APPMESH'
+        ContainerName: 'envoy'
+        ProxyConfigurationProperties:
+          - Name: 'IgnoredUID'
+            Value: '1337'
+          - Name: 'ProxyIngressPort'
+            Value: '15000'
+          - Name: 'ProxyEgressPort'
+            Value: '15001'
+          - Name: 'AppPorts'
+            Value: !Sub "${pServiceBPort}"
+          - Name: 'EgressIgnoredIPs'
+            Value: '169.254.170.2,169.254.169.254'
+      ContainerDefinitions:
+        - Name: 'app'
+          Image: !Sub '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${pServiceBImage}'
+          Essential: true
+          DependsOn:
+            - ContainerName: 'envoy'
+              Condition: 'HEALTHY'
+          LogConfiguration:
+            LogDriver: 'awslogs'
+            Options:
+              awslogs-group: !Ref rECSServiceLogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: 'envoy'
+          PortMappings:
+            - ContainerPort: !Sub "${pServiceBPort}"
+              Protocol: 'http'
+          Environment:
+            - Name: 'SERVER_PORT'
+              Value: !Sub "${pServiceBPort}"
+        - Name: envoy
+          Image: !Ref pEnvoyImage
+          Essential: true
+          User: '1337'
+          Ulimits:
+            - Name: "nofile"
+              HardLimit: 15000
+              SoftLimit: 15000
+          PortMappings:
+            - ContainerPort: 9901
+              Protocol: 'tcp'
+            - ContainerPort: 15000
+              Protocol: 'tcp'
+            - ContainerPort: 15001
+              Protocol: 'tcp'
+          HealthCheck:
+            Command:
+              - 'CMD-SHELL'
+              - 'echo hello'
+            Interval: 5
+            Timeout: 2
+            Retries: 3
+          LogConfiguration:
+            LogDriver: 'awslogs'
+            Options:
+              awslogs-group: !Ref rECSServiceLogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: !Sub '${pServiceBName}-envoy'
+          Environment:
+            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+              Value: !Sub 'mesh/${pAppMeshMeshName}/virtualNode/servicebnode'
+            - Name: 'ENABLE_ENVOY_XRAY_TRACING'
+              Value: '1'
+        - Name: 'xray-daemon'
+          Image: 'public.ecr.aws/xray/aws-xray-daemon:latest'
+          Essential: true
+          LogConfiguration:
+            LogDriver: 'awslogs'
+            Options:
+              awslogs-group:
+                !Ref rECSServiceLogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: 'serviceb'
+    Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: ECS Service B Task Definition for ${AWS::StackName}
+  rServiceBServiceDiscoveryRecord:
+    Type: AWS::ServiceDiscovery::Service
+    Properties:
+      Name: "serviceb"
+      DnsConfig:
+        NamespaceId:
+          !Ref rECSServiceDiscoveryNamespace
+        DnsRecords:
+          - Type: A
+            TTL: 300
+      HealthCheckCustomConfig:
+        FailureThreshold: 1
+    Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: Service B Discovery for ${AWS::StackName}
+  rServiceBService:
+    Type: AWS::ECS::Service
+    Properties:
+      Cluster: !Ref rECSCluster
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 100
+      DesiredCount: 1
+      LaunchType: FARGATE
+      ServiceRegistries:
+        - RegistryArn: !GetAtt rServiceBServiceDiscoveryRecord.Arn
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED
+          SecurityGroups:
+            - !Ref rECSServiceSecurityGroup
+          Subnets:
+            - !Ref rPrivateSubnetECSAZ1
+            - !Ref rPrivateSubnetECSAZ2
+      TaskDefinition: !Ref rServiceBTaskDefinition
+    Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: ECS Service B for ${AWS::StackName}
+  rServiceCTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      RequiresCompatibilities:
+        - 'FARGATE'
+      Family: !Sub '${pEnvironmentName}-serviceC'
+      NetworkMode: 'awsvpc'
+      Cpu: 256
+      Memory: 512
+      TaskRoleArn: !GetAtt rTaskIamRoleECS.Arn
+      ExecutionRoleArn: !GetAtt rTaskExecutionIamRole.Arn
+      ProxyConfiguration:
+        Type: 'APPMESH'
+        ContainerName: 'envoy'
+        ProxyConfigurationProperties:
+          - Name: 'IgnoredUID'
+            Value: '1337'
+          - Name: 'ProxyIngressPort'
+            Value: '15000'
+          - Name: 'ProxyEgressPort'
+            Value: '15001'
+          - Name: 'AppPorts'
+            Value: !Sub "${pServiceCPort}"
+          - Name: 'EgressIgnoredIPs'
+            Value: '169.254.170.2,169.254.169.254'
+      ContainerDefinitions:
+        - Name: 'app'
+          Image: !Sub '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${pServiceCImage}'
+          Essential: true
+          DependsOn:
+            - ContainerName: 'envoy'
+              Condition: 'HEALTHY'
+          LogConfiguration:
+            LogDriver: 'awslogs'
+            Options:
+              awslogs-group: !Ref rECSServiceLogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: 'servicec'
+          PortMappings:
+            - ContainerPort: !Sub "${pServiceCPort}"
+              Protocol: 'http'
+          Environment:
+            - Name: 'SERVER_PORT'
+              Value: !Sub "${pServiceCPort}"
+        - Name: envoy
+          Image: !Ref pEnvoyImage
+          Essential: true
+          User: '1337'
+          Ulimits:
+            - Name: "nofile"
+              HardLimit: 15000
+              SoftLimit: 15000
+          PortMappings:
+            - ContainerPort: 9901
+              Protocol: 'tcp'
+            - ContainerPort: 15000
+              Protocol: 'tcp'
+            - ContainerPort: 15001
+              Protocol: 'tcp'
+          HealthCheck:
+            Command:
+              - 'CMD-SHELL'
+              - 'echo hello'
+            Interval: 5
+            Timeout: 2
+            Retries: 3
+          LogConfiguration:
+            LogDriver: 'awslogs'
+            Options:
+              awslogs-group: !Ref rECSServiceLogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: !Sub '${pServiceCName}-envoy'
+          Environment:
+            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+              Value: !Sub 'mesh/${pAppMeshMeshName}/virtualNode/servicecnode'
+            - Name: 'ENABLE_ENVOY_XRAY_TRACING'
+              Value: '1'
+        - Name: 'xray-daemon'
+          Image: 'public.ecr.aws/xray/aws-xray-daemon:latest'
+          Essential: true
+          User: '1337'
+          LogConfiguration:
+            LogDriver: 'awslogs'
+            Options:
+              awslogs-group:
+                !Ref rECSServiceLogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: 'servicec'
+    Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: ECS service C Task Definition for ${AWS::StackName}
+  rServiceCServiceDiscoveryRecord:
+    Type: AWS::ServiceDiscovery::Service
+    Properties:
+      Name: "servicec"
+      DnsConfig:
+        NamespaceId: !Ref rECSServiceDiscoveryNamespace
+        DnsRecords:
+          - Type: A
+            TTL: 300
+      HealthCheckCustomConfig:
+        FailureThreshold: 1
+    Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: ECS Service C Discovery for ${AWS::StackName}
+  rServiceCService:
+    Type: AWS::ECS::Service
+    Properties:
+      Cluster: !Ref rECSCluster
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 100
+      DesiredCount: 1
+      LaunchType: FARGATE
+      ServiceRegistries:
+        - RegistryArn: !GetAtt rServiceCServiceDiscoveryRecord.Arn
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED
+          SecurityGroups:
+            - !Ref rECSServiceSecurityGroup
+          Subnets:
+            - !Ref rPrivateSubnetECSAZ1
+            - !Ref rPrivateSubnetECSAZ2
+      TaskDefinition: !Ref rServiceCTaskDefinition
+    Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: ECS Service C for ${AWS::StackName}
+  rMainGatewayTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      RequiresCompatibilities:
+        - 'FARGATE'
+      Family: !Sub '${pEnvironmentName}-cmaingateway'
+      NetworkMode: 'awsvpc'
+      Cpu: 256
+      Memory: 512
+      TaskRoleArn: !GetAtt rTaskIamRoleECS.Arn
+      ExecutionRoleArn: !GetAtt rTaskExecutionIamRole.Arn
+      ContainerDefinitions:
+        - Name: 'app'
+          Image: !Ref pEnvoyImage
+          Essential: true
+          Ulimits:
+            - Name: "nofile"
+              HardLimit: 15000
+              SoftLimit: 15000
+          PortMappings:
+            - ContainerPort: 9901
+              Protocol: 'tcp'
+            - ContainerPort: !Sub "${pServiceBPort}"
+              Protocol: 'tcp'
+          HealthCheck:
+            Command:
+              - 'CMD-SHELL'
+              - 'echo hello'
+            Interval: 5
+            Timeout: 2
+            Retries: 3
+            StartPeriod: 60
+          LogConfiguration:
+            LogDriver: 'awslogs'
+            Options:
+              awslogs-group:
+                !Ref rECSServiceLogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: 'gateway-envoy'
+          Environment:
+            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+              Value: !Sub 'mesh/${pAppMeshMeshName}/virtualGateway/maingateway-vg'
+            - Name: 'ENABLE_ENVOY_STATS_TAGS'
+              Value: '1'
+            - Name: 'ENABLE_ENVOY_DOG_STATSD'
+              Value: '1'
+            - Name: 'STATSD_PORT'
+              Value: '8125'
+            - Name: 'ENABLE_ENVOY_XRAY_TRACING'
+              Value: '1'
+        - Name: 'xray-daemon'
+          Image: 'public.ecr.aws/xray/aws-xray-daemon:latest'
+          Essential: true
+          LogConfiguration:
+            LogDriver: 'awslogs'
+            Options:
+              awslogs-group:
+                !Ref rECSServiceLogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: 'gateway-agent'
+        - Name: 'cw-agent'
+          Image: 'public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest'
+          Essential: true
+          PortMappings:
+            - ContainerPort: 8125
+              Protocol: 'udp'
+          Environment:
+            - Name: CW_CONFIG_CONTENT
+              Value:
+                Fn::Sub:
+                  - "{ \"metrics\": { \"namespace\":\"${MetricNamespace}\", \"metrics_collected\": { \"statsd\": { \"metrics_aggregation_interval\": 0}}}}"
+                  - MetricNamespace:
+                      Fn::Join:
+                        - '/'
+                        - - !Ref pEnvironmentName
+                          - gateway-envoy
+                          - StatsD
+          LogConfiguration:
+            LogDriver: 'awslogs'
+            Options:
+              awslogs-group:
+                !Ref rECSServiceLogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: 'gateway-agent'
+    Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: Main Gateway Task Definition for ${AWS::StackName}
+  rMainGatewayServiceDiscoveryRecord:
+    Type: AWS::ServiceDiscovery::Service
+    DependsOn:
+      - rMainGatewayTaskDefinition
+    Properties:
+      Name: "gateway"
+      DnsConfig:
+        NamespaceId: !Ref rECSServiceDiscoveryNamespace
+        DnsRecords:
+          - Type: A
+            TTL: 300
+      HealthCheckCustomConfig:
+        FailureThreshold: 1
+    Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: Main Gateway Service Discovery Record for ${AWS::StackName}
+  rMainGatewayService:
+    Type: AWS::ECS::Service
+    DependsOn:
+      - rPublicLoadBalancerListener
+    Properties:
+      Cluster: !Ref rECSCluster
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 100
+      DesiredCount: 1
+      LaunchType: FARGATE
+      ServiceRegistries:
+        - RegistryArn: !GetAtt rMainGatewayServiceDiscoveryRecord.Arn
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED
+          SecurityGroups:
+            - !Ref rECSServiceSecurityGroup
+          Subnets:
+            - !Ref rPrivateSubnetECSAZ1
+            - !Ref rPrivateSubnetECSAZ2
+      TaskDefinition: !Ref rMainGatewayTaskDefinition
+      LoadBalancers:
+        - ContainerName: app
+          ContainerPort: 3001
+          TargetGroupArn: !Ref rWebTargetGroup
+    Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: Main Gateway Service for ${AWS::StackName}
+
+  rPublicLoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    DependsOn: rECSCluster
+    Properties:
+      Scheme: internet-facing
+      Subnets:
+        - !Ref rPublicSubnetAZ1
+        - !Ref rPublicSubnetAZ2
+      Type: network
+    Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: Public Elastic Load Balancer for ${AWS::StackName}
+
+  rWebTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    DependsOn: rPublicLoadBalancer
+    Properties:
+      HealthCheckIntervalSeconds: 30
+      HealthCheckPort: 3001
+      HealthCheckProtocol: TCP
+      HealthCheckTimeoutSeconds: 10
+      HealthyThresholdCount: 3
+      TargetType: ip
+      Name: !Sub "${pEnvironmentName}-web"
+      Port: 443
+      Protocol: TLS
+      UnhealthyThresholdCount: 3
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: 120
+      VpcId:
+        !Ref rVPC
+    Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: Public Load Balancer Target Group for ${AWS::StackName}
+
+  rPublicLoadBalancerListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    DependsOn:
+      - rPublicLoadBalancer
+    Properties:
+      DefaultActions:
+        - TargetGroupArn: !Ref rWebTargetGroup
+          Type: 'forward'
+      LoadBalancerArn: !Ref rPublicLoadBalancer
+      Port: 443
+      Protocol: TLS
+      Certificates:
+        - CertificateArn: !Sub '${pLoadBalancerCertificateArn}'
+  rAppMesh:
+    Type: AWS::AppMesh::Mesh
+    Properties:
+      MeshName: !Sub "${pAppMeshMeshName}"
+      Spec:
+        EgressFilter:
+          Type: 'ALLOW_ALL'
+    Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: AppMesh for ${AWS::StackName}
+  rVirtualGateway:
+    Type: AWS::AppMesh::VirtualGateway
+    DependsOn:
+      - rAppMesh
+    Properties:
+      MeshName: !Sub "${pAppMeshMeshName}"
+      Spec:
+        Listeners:
+          - PortMapping:
+              Port: 3001
+              Protocol: 'http'
+            TLS:
+              Certificate:
+                ACM:
+                  CertificateArn: !Ref pLoadBalancerCertificateArn
+              Mode: 'PERMISSIVE'
+      VirtualGatewayName: 'maingateway-vg'
+    Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: AppMesh Virtual Gateway for ${AWS::StackName}
+  rVirtualRouterServiceB:
+    Type: AWS::AppMesh::VirtualRouter
+    DependsOn:
+      - rAppMesh
+    Properties:
+      MeshName: !Sub "${pAppMeshMeshName}"
+      VirtualRouterName: 'serviceb'
+      Spec:
+        Listeners:
+          - PortMapping:
+              Port: 3001
+              Protocol: 'http'
+    Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: AppMesh Virtual Router B for ${AWS::StackName}
+  rVirtualRouterServiceC:
+    Type: AWS::AppMesh::VirtualRouter
+    DependsOn:
+      - rAppMesh
+    Properties:
+      MeshName: !Sub "${pAppMeshMeshName}"
+      VirtualRouterName: 'servicec'
+      Spec:
+        Listeners:
+          - PortMapping:
+              Port: 3001
+              Protocol: 'http'
+    Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: AppMesh Virtual Router C for ${AWS::StackName}
+  rVirtualNodeServiceB:
+    Type: AWS::AppMesh::VirtualNode
+    DependsOn:
+      - rAppMesh
+    Properties:
+      MeshName: !Sub "${pAppMeshMeshName}"
+      VirtualNodeName: 'servicebnode'
+      Spec:
+        Listeners:
+          - PortMapping:
+              Port: 3001
+              Protocol: 'http'
+            HealthCheck:
+              HealthyThreshold: 2
+              IntervalMillis: 5000
+              Path: '/health'
+              Protocol: 'http'
+              TimeoutMillis: 2000
+              UnhealthyThreshold: 2
+        ServiceDiscovery:
+          DNS:
+            Hostname: 'serviceb.services.local'
+    Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: AppMesh Virtual Node B for ${AWS::StackName}
+  rVirtualNodeServiceC:
+    Type: AWS::AppMesh::VirtualNode
+    DependsOn:
+      - rAppMesh
+    Properties:
+      MeshName: !Sub "${pAppMeshMeshName}"
+      VirtualNodeName: 'servicecnode'
+      Spec:
+        Listeners:
+          - PortMapping:
+              Port: 3001
+              Protocol: 'http'
+            HealthCheck:
+              HealthyThreshold: 2
+              IntervalMillis: 5000
+              Path: '/health'
+              Protocol: 'http'
+              TimeoutMillis: 2000
+              UnhealthyThreshold: 2
+        ServiceDiscovery:
+          DNS:
+            Hostname: 'servicec.services.local'
+    Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: AppMesh Virtual Node C for ${AWS::StackName}
+  rVirtualServiceB:
+    Type: AWS::AppMesh::VirtualService
+    DependsOn:
+      - rAppMesh
+      - rVirtualRouterServiceB
+    Properties:
+      MeshName: !Sub "${pAppMeshMeshName}"
+      VirtualServiceName: 'servicebservice'
+      Spec:
+        Provider:
+          VirtualRouter:
+            VirtualRouterName: 'serviceb'
+    Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: AppMesh Virtual Service B for ${AWS::StackName}
+  rVirtualServiceC:
+    Type: AWS::AppMesh::VirtualService
+    DependsOn:
+      - rAppMesh
+      - rVirtualRouterServiceC
+    Properties:
+      MeshName: !Sub "${pAppMeshMeshName}"
+      VirtualServiceName: 'servicecservice'
+      Spec:
+        Provider:
+          VirtualRouter:
+            VirtualRouterName: 'servicec'
+     Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: AppMesh Virtual Service C for ${AWS::StackName}
+  rVirtualRouteB:
+    Type: AWS::AppMesh::Route
+    DependsOn:
+      - rAppMesh
+      - rVirtualNodeServiceB
+    Properties:
+      MeshName: !Sub "${pAppMeshMeshName}"
+      RouteName: 'service-b-route'
+      VirtualRouterName: 'serviceb'
+      Spec:
+        HttpRoute:
+          Action:
+            WeightedTargets:
+              - VirtualNode: 'servicebnode'
+                Weight: 1
+          Match:
+            Path:
+              Exact: '/'
+          RetryPolicy:
+            HttpRetryEvents:
+              - 'server-error'
+              - 'gateway-error'
+            MaxRetries: 2
+            PerRetryTimeout:
+              Unit: 'ms'
+              Value: 2000
+     Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: AppMesh Route B for ${AWS::StackName}
+  rVirtualRouteC:
+    Type: AWS::AppMesh::Route
+    DependsOn:
+      - rAppMesh
+      - rVirtualNodeServiceC
+    Properties:
+      MeshName: !Sub "${pAppMeshMeshName}"
+      RouteName: 'service-b-route'
+      VirtualRouterName: 'servicec'
+      Spec:
+        HttpRoute:
+          Action:
+            WeightedTargets:
+              - VirtualNode: 'servicecnode'
+                Weight: 1
+          Match:
+            Path:
+              Exact: '/'
+          RetryPolicy:
+            HttpRetryEvents:
+              - 'server-error'
+              - 'gateway-error'
+            MaxRetries: 2
+            PerRetryTimeout:
+              Unit: 'ms'
+              Value: 2000
+    Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: AppMesh Route C for ${AWS::StackName}
+  rGatewayRouterB:
+    Type: AWS::AppMesh::GatewayRoute
+    DependsOn:
+      - rVirtualGateway
+      - rVirtualServiceB
+    Properties:
+      GatewayRouteName: 'broute'
+      MeshName: !Sub "${pAppMeshMeshName}"
+      VirtualGatewayName: 'maingateway-vg'
+      Spec:
+        HttpRoute:
+          Action:
+            Target:
+              VirtualService:
+                VirtualServiceName: 'servicebservice'
+          Match:
+            Method: 'GET'
+    Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: GatewayRouter B for ${AWS::StackName}
+  rGatewayRouterC:
+    Type: AWS::AppMesh::GatewayRoute
+    DependsOn:
+      - rVirtualGateway
+      - rVirtualServiceB
+    Properties:
+      GatewayRouteName: 'croute'
+      MeshName: !Sub "${pAppMeshMeshName}"
+      VirtualGatewayName: 'maingateway-vg'
+      Spec:
+        HttpRoute:
+          Action:
+            Target:
+              VirtualService:
+                VirtualServiceName: 'servicecservice'
+          Match:
+            Method: 'GET'
+    Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: GatewayRouter C for ${AWS::StackName}
+
+###
+# Outputs
+###
+Outputs:
+  oServiceAppEndpoint:
+    Description: Public endpoint for App service
+    Value: !Join [ '', [ 'https://', !GetAtt 'rPublicLoadBalancer.DNSName' ] ]
+  oECSCluster:
+    Description: A reference to the ECS cluster
+    Value: !Ref rECSCluster
+    Export:
+      Name: !Sub "${pEnvironmentName}:rECSCluster"
+  oECSServiceDiscoveryNamespace:
+    Description: A SDS namespace that will be used by all services in this cluster
+    Value: !Ref rECSServiceDiscoveryNamespace
+    Export:
+      Name: !Sub "${pEnvironmentName}:rECSServiceDiscoveryNamespace"
+  oVPCId:
+    Description: The ID of the VPC
+    Value:
+      Ref: rVPC
+    Export:
+      Name:
+        Fn::Sub: ${AWS::StackName}:VPCId
+  oPublicSubnetAZ1:
+    Description: Public subnet
+    Value:
+      Ref: rPublicSubnetAZ1
+    Export:
+      Name:
+        Fn::Sub: ${AWS::StackName}:PublicSubnetAZ1
+  oPublicSubnetAZ2:
+    Description: Public subnet
+    Value:
+      Ref: rPublicSubnetAZ2
+    Export:
+      Name:
+        Fn::Sub: ${AWS::StackName}:PublicSubnetAZ2
+  oPrivateSubnetECSAZ1:
+    Description: Private subnet one
+    Value:
+      Ref: rPrivateSubnetECSAZ1
+    Export:
+      Name:
+        Fn::Sub: ${AWS::StackName}:PrivateSubnetECSAZ1
+  oPrivateSubnetECSAZ2:
+    Description: Private subnet one
+    Value:
+      Ref: rPrivateSubnetECSAZ2
+    Export:
+      Name:
+        Fn::Sub: ${AWS::StackName}:PrivateSubnetECSAZ2


### PR DESCRIPTION
Description of changes: Added a new serverless pattern which covers how to setup App Mesh with two sample ECS services backed by Fargate. Pattern creates a new VPC with two public subnets and two private subnets, an ECS cluster, two services, and then an App Mesh implementation with a virtual gateway, virtual services, and virtual routers. All of this is provisioned through SAM. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
