### PR TITLE
Bug: Updated the command while doing the change path

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -52,7 +52,7 @@ Create a new local branch for each serverless pattern or modification being made
 
 Now is the time to create your new serverless pattern or modify existing code.
 
-1. If you are creating a new serverless pattern, copy the folder named "_pattern-model" to start with a template: `cp _pattern-model {new-folder-name}`
+1. If you are creating a new serverless pattern, copy the folder named "_pattern-model" to start with a template: `cp -r _pattern-model {new-folder-name}`
 1. If you are modifying existing code, make your code changes now.
 1. When your code is complete, stage the changes to your local branch: `git add .`
 1. Commit the changes to your local branch: `git commit -m 'Comment here'`


### PR DESCRIPTION
Existing command doesn't work and gives error of `cp: _pattern-model is a directory (not copied).`. To remove this error correct command is added by using recursive copy.

*Issue #, if available:*

*Description of changes:*
- Updated command to modify the command used to copy folder `_pattern-model`.
- Existing command gives below error: 

```javascript
     cp: _pattern-model is a directory (not copied).
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
