### PR TITLE
New serverless pattern - codecommit-s3

### DIFF
--- a/codecommit-s3/README.md
+++ b/codecommit-s3/README.md
@@ -1,0 +1,64 @@
+# AWS CodeCommit to S3
+
+This pattern implements the solution outlined on the ["Automate event-driven backups from CodeCommit to Amazon S3 using CodeBuild and CloudWatch Events" Presciptive Guidance](https://docs.aws.amazon.com/prescriptive-guidance/latest/patterns/automate-event-driven-backups-from-codecommit-to-amazon-s3-using-codebuild-and-cloudwatch-events.html#automate-event-driven-backups-from-codecommit-to-amazon-s3-using-codebuild-and-cloudwatch-events-tools). 
+
+Learn more about this pattern at Serverless Land Patterns: https://serverlessland.com/patterns/codecomit-s3.
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ```
+    cd codecommit-s3
+    ```
+1. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
+    ```
+    sam deploy --guided  --capabilities CAPABILITY_NAMED_IAM
+    ```
+1. During the prompts:
+    * Enter a stack name
+    * Enter the desired AWS Region
+    * Allow SAM CLI to create IAM roles with the required permissions.
+
+    Once you have run `sam deploy --guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+
+1. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## How it works
+
+When the content of a CodeCommit repository is modified (for example, by a git push command), it notifies EventBridge of the repository change. EventBridge then invokes AWS CodeBuild with the CodeCommit repository information. CodeBuild clones the entire CodeCommit repository, packages it into a .zip file and uploads the it to an S3 bucket.
+During deployment, the pattern uses a Lambda function and a CloudFormation Custom Resource to create the CodeBuild's buildspec.yml template.
+
+## Testing
+
+1. Create or use a pre-existing CodeCommit repository
+1. Update the repository content
+1. Verify that the zip file is created on the backup bucket, under the folder `repositories`
+
+
+## Cleanup
+ 
+1. Delete the stack
+    ```bash
+    aws cloudformation delete-stack --stack-name STACK_NAME
+    ```
+1. Confirm the stack has been deleted
+    ```bash
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus"
+    ```
+----
+Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/codecommit-s3/template.yaml
+++ b/codecommit-s3/template.yaml
@@ -1,0 +1,207 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: Serverless patterns - Backup CodeCommit to S3 using EventBridge and CodeBuild
+
+Resources:
+
+  # Bucket that will store the CodeCommit backups
+  CodeCommitBackupBucket:
+    Type: 'AWS::S3::Bucket'
+    Description: Bucket to store CodeCommit code
+    Properties:
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerEnforced
+
+  # Role with permisions for the CodeBuild project
+  CodeBuildRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+            - Effect: Allow
+              Principal:
+                  Service:
+                    - codebuild.amazonaws.com
+              Action:
+                - sts:AssumeRole
+      Description: !Sub "IAM Role for ${AWS::StackName}"
+      Path: '/'
+      Policies:
+        - PolicyName: root
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                  - codecommit:GitPull
+                  - s3:Get*
+                  - s3:List*
+                  - s3:PutObject
+                Effect: Allow
+                Resource: '*'
+
+  # Project that clones the CodeCommit repository, compress the files in a .zip and uploads to S3              
+  CodeBuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Description: CodeBuild project to sync CodeCommit repositories to S3 on backup account
+      ServiceRole: !GetAtt CodeBuildRole.Arn
+      Artifacts:
+        Type: NO_ARTIFACTS
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/standard:4.0
+        EnvironmentVariables:
+          - Name: BUCKET
+            Value: !Ref CodeCommitBackupBucket
+            Type: PLAINTEXT
+          - Name: ACCOUNT
+            Value: !Sub ${AWS::AccountId}
+            Type: PLAINTEXT
+      Source:
+        Location: !Join
+          - ''
+          - - !Ref CodeCommitBackupBucket
+            - '/codebuild-source/'
+        Type: S3
+      TimeoutInMinutes: 10
+
+  # Lambda function to create the buildspec.yml in the CodeCommitBackupBucket 
+  CreateBuildspec:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: python3.9
+      # Python inline code to create a buildspec.yml file in the backup bucket to run CodeBuild
+      InlineCode: |
+        import boto3
+        import os
+        import cfnresponse
+
+        def handler(event, context):
+            filename = "buildspec.yml"
+            # buildspec.yml code inside the string
+            string = """
+        version: 0.2
+        phases:
+          install:
+            commands:
+              - pip install git-remote-codecommit
+          build:
+            commands:
+              - git clone -b $REFERENCE_NAME codecommit::$REPO_REGION://$REPOSITORY_NAME
+              - dt=$(date '+%d-%m-%Y-%H:%M:%S');
+              - echo "$dt" 
+              - zip -r $dt-$REPOSITORY_NAME-backup.zip $REPOSITORY_NAME
+              - timestamp=$(date +"%Y-%m-%d_%H-%M-%S")
+              - aws s3 cp $dt-$REPOSITORY_NAME-backup.zip s3://$BUCKET/repositories/"""
+
+            encoded_string = string.encode("utf-8")
+            bucket_name = os.environ['bucket']
+            s3_path = "codebuild-source/" + filename
+            s3 = boto3.resource("s3")
+            responseData = {}
+            try:
+                print("Creating buildspec file")
+                s3.Bucket(bucket_name).put_object(Key=s3_path, Body=encoded_string)
+                print("File created")
+                responseData['Data'] = "File created"
+                cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)
+            except Exception as e:
+                print("There was an error creating the file")
+                log_exception()
+                responseData['Data'] = e
+                cfnresponse.send(event, context, cfnresponse.FAILED, responseData)
+            return
+      Environment:
+        Variables:
+          bucket: !Ref CodeCommitBackupBucket
+      Policies:
+        - AWSLambdaExecute
+        - Version: '2012-10-17' 
+          Statement:
+            - Effect: Allow
+              Action:
+                - s3:PutObject
+              Resource: !Join                                                                                       
+                - ''
+                - - 'arn:aws:s3:::'
+                  - !Ref CodeCommitBackupBucket
+                  - '/*'
+
+  # Custom resource to trigger the Lambda function at deployment time
+  TriggerBuildspecCreation:
+    Type: AWS::CloudFormation::CustomResource
+    DependsOn: CreateBuildspec
+    Version: "1.0"
+    Properties:
+      ServiceToken: !GetAtt CreateBuildspec.Arn
+
+  # Role for the event 
+  EventRole:
+    Description: IAM role to allow Amazon CloudWatch Events to trigger AWS CodeBuild build
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action: sts:AssumeRole
+          Effect: Allow
+          Principal:
+            Service:
+            - events.amazonaws.com
+          Sid: 1
+      Policies:
+      - PolicyDocument:
+          Statement:
+          - Action:
+            - codebuild:StartBuild
+            Effect: Allow
+            Resource: !GetAtt 'CodeBuildProject.Arn'
+        PolicyName: !Join
+          - '-'
+          - - !Ref 'AWS::StackName'
+            - CloudWatchEventPolicy
+      RoleName: !Join
+        - '-'
+        - - !Ref 'AWS::StackName'
+          - CloudWatchEventRule
+    Type: AWS::IAM::Role
+
+  # Event that triggers the CodeBuild when the content of a CodeCommit repository is modified 
+  EventRule:
+    Type: "AWS::Events::Rule"
+    Properties:
+      Description: "EventRule"
+      EventPattern:
+        source:
+        - aws.codecommit
+        detail-type:
+        - CodeCommit Repository State Change
+        detail:
+          event:
+          - referenceCreated
+          - referenceUpdated
+      State: "ENABLED"
+      Targets:
+        - Arn: !GetAtt 'CodeBuildProject.Arn'
+          Id: CodeCommit2S3
+          RoleArn: !GetAtt 'EventRole.Arn'
+          InputTransformer:
+            InputPathsMap: 
+              "referenceType": "$.detail.referenceType"
+              "region": "$.region"
+              "repositoryName": "$.detail.repositoryName"
+              "account": "$.account"
+              "referenceName": "$.detail.referenceName"
+            InputTemplate: |
+              {"environmentVariablesOverride": [{"name": "REFERENCE_NAME","value": <referenceName>},{"name": "REFERENCE_TYPE","value": <referenceType>},{"name": "REPOSITORY_NAME","value": <repositoryName>},{"name": "REPO_REGION","value": <region>},{"name": "ACCOUNT_ID","value": <account>}]}
+
+Outputs:
+  CodeCommitBackupBucket:
+    Description: "Bucket to store the CodeCommit backup files"
+    Value:
+      Ref: CodeCommitBackupBucket              


### PR DESCRIPTION
*Description of changes:*
Adds a new serverless pattern to backup CodeCommit repositories to S3 buckets, using Lambda, EventBridge, and CodeBuild.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
