### PR TITLE
New API Destination pattern - eventbridge-api-destination-MongoDB

### DIFF
--- a/eventbridge-api-destinations/4-mongodb/mongoDB.yaml
+++ b/eventbridge-api-destinations/4-mongodb/mongoDB.yaml
@@ -1,0 +1,119 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Create an API destination in EventBridge - open API using MongoDB.com
+
+Parameters:
+  MyMongoDBURL:
+    Type: String
+    Default: '<<ENTER YOUR UNIQUE URL HERE>>'
+  MyAPIKeyName:
+    Type: String
+    Default: '<<Enter your APIKeyName>>'
+  MyAPIKeyValue:
+    Type: String
+    Default: '<<Enter your APIKeyValue>>' 
+
+Resources:
+  MyEventBus:
+    Type: AWS::Events::EventBus
+    Properties:
+      Name: "MyMongoDBEventBus"
+
+  MyConnection:
+    Type: AWS::Events::Connection
+    Properties:
+      AuthorizationType: API_KEY
+      Description: 'My connection with an API key'
+      AuthParameters:
+        ApiKeyAuthParameters:
+          ApiKeyName: !Ref MyAPIKeyName
+          ApiKeyValue: !Ref MyAPIKeyValue
+        InvocationHttpParameters:
+          BodyParameters:
+            - Key: 'api-key'
+              Value: !Ref MyAPIKeyValue
+              IsValueSecret: false
+
+  MyApiDestination:
+    Type: AWS::Events::ApiDestination
+    Properties:
+      Name: 'MyMongoDBTest'
+      ConnectionArn: !GetAtt MyConnection.Arn
+      InvocationEndpoint: !Ref MyMongoDBURL
+      HttpMethod: POST
+      InvocationRateLimitPerSecond: 10
+
+  EventBridgeTargetRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - events.amazonaws.com
+            Action:
+              - sts:AssumeRole      
+      Policies:
+        - PolicyName: AllowAPIdestinationAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: 'events:InvokeApiDestination'
+                Resource: !GetAtt MyApiDestination.Arn
+  MyDLQueue: 
+    Type: AWS::SQS::Queue
+
+  EventRule: 
+    Type: AWS::Events::Rule
+    Properties: 
+      Description: "EventRule"
+      State: "ENABLED"
+      EventBusName: !Ref MyEventBus
+      EventPattern: 
+        source:
+          - "MyTestApp"
+        detail-type:
+          - "MyTestMessage"       
+      Targets: 
+        - Arn: !GetAtt MyApiDestination.Arn
+          RoleArn: !GetAtt EventBridgeTargetRole.Arn
+          Id: "MyAPIdestination"
+          InputTransformer:
+            InputPathsMap:
+              "api" : "$.detail.api-key"
+              "body" : "$.detail.message"
+            InputTemplate: |
+              {
+                "body" : <body>,
+                "api-key" : <api>
+              }
+          DeadLetterConfig:
+            Arn: !GetAtt MyDLQueue.Arn
+
+Outputs:
+  MyEventBusName:
+    Description: Application EventBus Name
+    Value: !Ref MyEventBus
+
+  MyEventBusArn:
+    Description: Application EventBus ARN
+    Value: !GetAtt MyEventBus.Arn
+
+  MyConnectionName:
+    Value: !Ref MyConnection
+  MyConnectionArn:
+    Value: !GetAtt MyConnection.Arn        
+
+  MyApiDestinationName:
+    Value: !Ref MyApiDestination
+  MyApiDestinationArn:
+    Value: !GetAtt MyApiDestination.Arn
+
+  EventBridgeTargetRoleArn:
+    Value: !GetAtt EventBridgeTargetRole.Arn
+
+  MyDLQueue:
+    Value: !GetAtt MyDLQueue.Arn

--- a/eventbridge-api-destinations/4-mongodb/testEvent.json
+++ b/eventbridge-api-destinations/4-mongodb/testEvent.json
@@ -1,0 +1,8 @@
+[
+    {
+        "DetailType": "MyTestMessage",
+        "EventBusName": "MyMongoDBEventBus",
+        "Source": "MyTestApp",
+        "Detail": "{\"message\":\"<message>\"}"
+    }
+  ]

--- a/eventbridge-api-destinations/README.md
+++ b/eventbridge-api-destinations/README.md
@@ -17,6 +17,7 @@ Important: this application uses various AWS services and there are costs associ
 * To run example #1, an account with [Webhook.site](https://webhook.site/)
 * To run example #2, an account with [Slack](http://slack.com). Follow the instructions at [Create a bot for your workspace](https://slack.com/help/articles/115005265703-Create-a-bot-for-your-workspace) and note the bot's token (this code begins with xoxb) and the channel ID. You need both of these values to deploy the solution.
 * To run example #3, an account with [sumologic](https://sumologic.com). Follow the instructions at [Create an HTTP Source ](https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/HTTP-Source) and note the unique URL for your HTTP Source you need this value to deploy the solution.
+* To run example #4, an account with [mongodb](https://www.mongodb.com/). Follow the instructions at [Create an HTTPS Endpoint](https://docs.mongodb.com/realm/endpoints/) and note the unique URL for your API destination endpoint to deploy the solution.
 
 ## Deployment Instructions
 
@@ -32,6 +33,7 @@ Important: this application uses various AWS services and there are costs associ
 - To run the Webhook.test open API example, cd to `1-webhook-site`.
 - To run the Slack authenticated API example, cd to `2-slack`.
 - To run the sumologic HTTP Source collector example, cd to `3-sumologic`.
+- To run the mongoDB API destination example, cd to `4-mongodb`.
 1. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
     ```
     sam deploy --guided
@@ -54,6 +56,7 @@ aws events put-events --entries file://testEvent.json
 2. In the Webhook.site example, the API call appears in the dashboard.
 3. In the Slack example, a message appears in the specified Slack channel ("Payment failed").
 4. For the sumo logic example use the testEvent.json within the 3-sumologic directory
+5. For the mongoDB example use the testEvent.json within the 4-mongodb directory
 ```
 aws events put-events --entries file://3-sumologic/testEvent.json
 ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added MongoDB API Destination pattern. To run, just enable API Key authentication on MongoDB and run the Cloudformation template and test event 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
