### PR TITLE
Changes for pattern REST-API gateway with mutual TLS using cdk python

### DIFF
--- a/apigw-mutualtls-lambda-cdk/.gitignore
+++ b/apigw-mutualtls-lambda-cdk/.gitignore
@@ -1,0 +1,10 @@
+*.swp
+package-lock.json
+__pycache__
+.pytest_cache
+.venv
+*.egg-info
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/apigw-mutualtls-lambda-cdk/README.md
+++ b/apigw-mutualtls-lambda-cdk/README.md
@@ -1,0 +1,72 @@
+# Amazon REST API Gateway with MutualTLS authentication
+
+This pattern creates an Amazon [API Gateway RESTful API](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-rest-api.html), an AWS [Lambda function](https://docs.aws.amazon.com/lambda/latest/dg/welcome.html), and API is authenticated by certificate based MutualTLS(https://docs.aws.amazon.com/apigateway/latest/developerguide/rest-api-mutual-tls.html) using the AWS Cloud Development Kit (AWS CDK) in Python.
+
+Learn more about this pattern at Serverless Land Patterns: [https://serverlessland.com/patterns/apigw-mutualtls-lambda-cdk](https://serverlessland.com/patterns/apigw-mutualtls-lambda-cdk).
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS CDK Toolkit](https://docs.aws.amazon.com/cdk/latest/guide/cli.html) installed and configured
+* [Python 3.9+](https://www.python.org/downloads/) installed
+* [Custom domain name certificate](https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains-prerequisites.html) before setting up a custom domain name for an API, you must have an SSL/TLS certificate ready in AWS Certificate Manager.
+* [Configure truststore](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-mutual-tls.html) Create a truststore of X.509 certificates that you trust to access your API and upload the truststore to an Amazon S3 bucket in a single file.
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ```
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+2. Change directory to the pattern directory:
+    ```
+    cd serverless-patterns/apigw-mutualtls-lambda-cdk
+    ```
+3. Create a virtual environment for Python
+    ```
+    python3 -m venv .venv
+    ```
+4. Activate the virtual environment
+    ```
+    source .venv/bin/activate
+    ```
+    For a Windows platform, activate the virtualenv like this:
+    ```
+    .venv\Scripts\activate.bat
+    ```
+5. Install the Python required dependencies:
+    ```
+    pip install -r requirements.txt
+    ```
+6. From the command line, use AWS CDK to deploy the AWS resources for the serverless application as specified in the app.py file. We need to pass the custom domain name, certificate arn, s3 bucket name, public hosted zone id and name as parameters:
+    ```
+    cdk deploy --parameters customdomainname={custom-domain-name} --parameters certificatearn={certificate-arn} --parameters truststorebucket={bucket-name} --parameters publiczoneid={public-zone-hosted-id} --parameters publiczonename={public-hosted-zone-name}
+    ```
+7. Note the outputs from the CDK deployment process, it contains the custom domain name hosted zone and alias.
+
+## How it works
+
+This pattern deploys an Amazon API Gateway REST API with a default route which is integrated with an AWS Lambda function written in Python. The REST API is authenticated by certificate based mutual TLS. The Lambda function returns a basic response to the caller.
+
+## Testing
+
+From the command line, run the following command to send an HTTP `GET` request to your custom domain name value. As a best practice the default endpoint for the REST API will be disabled when mutual TLS is enabled. Either use a curl or call the endpoint from Postman using your client side public and private keys.
+
+```
+curl --key my_client.key --cert my_client.pem https://{your-custom-domain-name}
+```
+
+## Cleanup
+
+1. Delete the MutualTLSAPIGatewayStack Deployment stack
+    ```
+    cdk destroy
+    ```
+----
+Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/apigw-mutualtls-lambda-cdk/app.py
+++ b/apigw-mutualtls-lambda-cdk/app.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+import os
+
+from aws_cdk import (
+    core as cdk,
+    aws_apigateway as apigateway,
+    aws_lambda as lambda_,
+    aws_s3 as s3,
+    aws_certificatemanager as acm,
+    aws_route53 as route53,
+    aws_route53_targets as targets,
+    aws_iam as iam
+)
+
+DIRNAME = os.path.dirname(__file__)
+
+class MutualTLSAPIGatewayStack(cdk.Stack):
+
+    def __init__(self, scope: cdk.Construct, construct_id: str, **kwargs) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        # Create a Lambda function
+        # Code in ./src directory
+        lambda_fn = lambda_.Function(
+            self, "MyFunction",
+            runtime=lambda_.Runtime.PYTHON_3_9,
+            handler="index.handler",
+            code=lambda_.Code.from_asset(os.path.join(DIRNAME, "src"))
+        )
+        #Input parameter for custom domain name created for API Gateway, ex: apis.example.com
+        custom_domain_name = cdk.CfnParameter(self, "customdomainname", type="String",
+        description="The custom domain name for AWS REST API Gateway")
+
+        #Input parameter for ACM certificate arn
+        certificate_arn = cdk.CfnParameter(self, "certificatearn", type="String",
+        description="The ACM certificate ARN for custom domain name")
+
+        #Input parameter for s3 bucket name that has truststore pem file
+        truststore_bucket = cdk.CfnParameter(self, "truststorebucket", type="String",
+        description="The S3 trustsore uri for custom domain name")
+
+        #Input parameter for public hosted zone id
+        public_zone_id = cdk.CfnParameter(self, "publiczoneid", type="String",
+        description="The public hosted zone id to create a record for custom domain name")
+
+        #Input parameter for public hosted zone id
+        public_zone_name = cdk.CfnParameter(self, "publiczonename", type="String",
+        description="The public hosted zone name to create a record for custom domain name")
+
+        # Create the Rest API
+        rest_api = apigateway.RestApi(
+            self, "TLSRestAPI",
+            endpoint_types=[apigateway.EndpointType.REGIONAL],
+            description="RestAPI Gateway to verify mutual TLS",
+            deploy=False,
+            retain_deployments=False,
+            disable_execute_api_endpoint=True
+        )
+
+        # Create the custom domain
+        api_domain = apigateway.DomainName(
+            self, "MyDomainName",
+            domain_name=custom_domain_name.value_as_string,
+            certificate=acm.Certificate.from_certificate_arn(self, "cert", certificate_arn.value_as_string),
+            mtls=apigateway.MTLSConfig(
+                bucket=s3.Bucket.from_bucket_name(self, "Bucket", truststore_bucket.value_as_string),
+                key="/truststore.pem"
+            ),
+            security_policy=apigateway.SecurityPolicy.TLS_1_2
+        )
+
+        # Create API deployment
+        deployment = apigateway.Deployment(
+            self, "Deployment",
+            api=rest_api,
+            retain_deployments=False
+        )
+
+        # Create prod Stage for deployment
+        stage = apigateway.Stage(
+            self, "prod",
+            deployment=deployment,
+        )
+
+        # Create API mapping to custom domain
+        base_path_mapping = apigateway.BasePathMapping(self, "MyBasePathMapping",
+            domain_name=api_domain,
+            rest_api=rest_api,
+            stage=stage
+        )
+
+        #Get public hosted zone object
+        public_zone = route53.HostedZone.from_hosted_zone_attributes(self, "publiczone", hosted_zone_id=public_zone_id.value_as_string,zone_name=public_zone_name.value_as_string)
+
+        #Create A record for custom domain name in public hosted zone
+        #Record name will be taken from custom domain name, ex: for apis.example.com, record name will be apis
+        record = route53.ARecord(self, 'MyAliasRecord',
+            zone=public_zone,
+            record_name=cdk.Fn.select(0,cdk.Fn.split('.',custom_domain_name.value_as_string)),
+            target=route53.RecordTarget.from_alias(targets.ApiGatewayDomain(api_domain))
+        )
+
+        rest_api.deployment_stage = stage
+
+        # Create URI for lambda function
+        stage_uri = f"arn:aws:apigateway:{cdk.Aws.REGION}:lambda:path/2015-03-31/functions/{lambda_fn.function_arn}/invocations"
+
+        # Create Lambda Integration
+        integration = apigateway.Integration(
+            type=apigateway.IntegrationType.AWS_PROXY,
+            integration_http_method="POST",
+            uri=stage_uri
+        )
+
+        # Create APIGW Method
+        method = rest_api.root.add_method("GET", integration)
+
+        # Add Lambda permissions
+        lambda_fn.add_permission(
+            "lambdaPermission",
+            action="lambda:InvokeFunction",
+            principal=iam.ServicePrincipal("apigateway.amazonaws.com"),
+            source_arn=method.method_arn.replace(
+                rest_api.deployment_stage.stage_name, "*"
+            )
+        )
+
+        # OUTPUTS
+        cdk.CfnOutput(self, "LambdaFunction", export_name="MyLambdaFunction", value=lambda_fn.function_arn)
+        cdk.CfnOutput(self, "ApigwId", export_name="MyAPIGWID", value=rest_api.rest_api_id)
+        cdk.CfnOutput(self, "CustomDomainName", export_name="MyCustomDomain", value=api_domain.domain_name)
+        cdk.CfnOutput(self, "CustomDomainHostedZone", export_name="MyCustomeZone", value=api_domain.domain_name_alias_hosted_zone_id)
+        cdk.CfnOutput(self, "CustomDomainAlias", export_name="MyCustomAlias", value=api_domain.domain_name_alias_domain_name)
+
+app = cdk.App()
+MutualTLSAPIGatewayStack(app, "MutualTLSAPIGatewayStack")
+app.synth()

--- a/apigw-mutualtls-lambda-cdk/cdk.json
+++ b/apigw-mutualtls-lambda-cdk/cdk.json
@@ -1,0 +1,30 @@
+{
+  "app": "python3 app.py",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "requirements*.txt",
+      "source.bat",
+      "**/__init__.py",
+      "python/__pycache__",
+      "tests"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
+    "@aws-cdk/core:stackRelativeExports": true,
+    "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
+    "@aws-cdk/aws-lambda:recognizeVersionProps": true,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
+  }
+}

--- a/apigw-mutualtls-lambda-cdk/requirements.txt
+++ b/apigw-mutualtls-lambda-cdk/requirements.txt
@@ -1,0 +1,6 @@
+aws-cdk.aws-apigateway
+aws-cdk.aws-lambda
+aws-cdk.aws-iam
+aws-cdk.aws-route53
+aws-cdk.aws-route53-targets
+aws-cdk.aws-s3

--- a/apigw-mutualtls-lambda-cdk/src/index.py
+++ b/apigw-mutualtls-lambda-cdk/src/index.py
@@ -1,0 +1,30 @@
+from http import HTTPStatus
+import json
+import os
+
+def handler(event, context):
+    try:
+        body={
+            "MutualTLS": "Success"
+        }
+
+        response = {
+            "isBase64Encoded": False,
+            "statusCode": HTTPStatus.OK.value,
+            "body": json.dumps(body, indent=2),
+            "headers": {
+                "content-type": "application/json",
+            },
+        }
+
+    except Exception as e:
+        response = {
+            "isBase64Encoded": False,
+            "statusCode": HTTPStatus.INTERNAL_SERVER_ERROR.value,
+            "body": f"Exception={e}",
+            "headers": {
+                "content-type": "text/plain",
+            },
+        }
+
+    return response


### PR DESCRIPTION
*Issue #, if available:*
New pattern - REST API Gateway-lambda-mutual TLS CDK
*Description of changes:*
This pattern deploys a public Amazon API Gateway REST API that is integrated with a AWS Lambda function written in Python and the API calls are authenticated using mutual TLS. CDK-Python framework used for this example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
