### PR TITLE
New serverless pattern - datadog-event-bridge-api-destination

### DIFF
--- a/eventbridge-api-destinations/7-datadog/DataDogApiDestination.yml
+++ b/eventbridge-api-destinations/7-datadog/DataDogApiDestination.yml
@@ -1,0 +1,102 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Create an API destination in EventBridge for DataDog Put Logs API
+
+Parameters:
+  MyDataDogAPIKey:
+    NoEcho: true
+    Type: String
+    Default: '' 
+
+Resources:
+  MyDataDogEventBus:
+    Type: AWS::Events::EventBus
+    Properties:
+      Name: "MyDataDogEventBus"
+
+  MyDataDogConnection:
+    Type: AWS::Events::Connection
+    Properties:
+      AuthorizationType: API_KEY
+      Description: 'My connection with an API key'
+      AuthParameters:
+        ApiKeyAuthParameters:
+          ApiKeyName: "DD-API-KEY"
+          ApiKeyValue: !Ref MyDataDogAPIKey
+
+  SendLogAPIDestination:
+    Type: AWS::Events::ApiDestination
+    Properties:
+      Name: 'SendLogAPIDestination'
+      ConnectionArn: !GetAtt MyDataDogConnection.Arn
+      InvocationEndpoint: "https://http-intake.logs.datadoghq.com/api/v2/logs"
+      HttpMethod: POST
+      InvocationRateLimitPerSecond: 10
+
+  EventBridgeTargetRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - events.amazonaws.com
+            Action:
+              - sts:AssumeRole      
+      Policies:
+        - PolicyName: AllowAPIdestinationAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: 'events:InvokeApiDestination'
+                Resource: !GetAtt SendLogAPIDestination.Arn
+
+
+  MyDLQueue: 
+    Type: AWS::SQS::Queue
+
+  EventRuleSendLog: 
+    Type: AWS::Events::Rule
+    Properties: 
+      Description: "EventRule"
+      State: "ENABLED"
+      EventBusName: !Ref MyDataDogEventBus
+      EventPattern: 
+        source:
+          - "MyDataDogApp"       
+      Targets: 
+        - Arn: !GetAtt SendLogAPIDestination.Arn
+          RoleArn: !GetAtt EventBridgeTargetRole.Arn
+          Id: "SendLogs"
+          InputTransformer:
+            InputPathsMap:
+              "detail" : "$.detail"
+            InputTemplate:
+              '{"message" : <detail>}'
+          DeadLetterConfig:
+            Arn:  !GetAtt MyDLQueue.Arn
+
+Outputs:
+  MyDataDogEventBusName:
+    Description: Application EventBus Name
+    Value: !Ref MyDataDogEventBus
+
+  MyDataDogEventBusArn:
+    Description: Application EventBus ARN
+    Value: !GetAtt MyDataDogEventBus.Arn
+
+  MyDataDogConnectionName:
+    Value: !Ref MyDataDogConnection
+  MyDataDogConnectionArn:
+    Value: !GetAtt MyDataDogConnection.Arn        
+
+  SendLogAPIDestinationName:
+    Value: !Ref SendLogAPIDestination
+  SendLogAPIDestinationArn:
+    Value: !GetAtt SendLogAPIDestination.Arn
+
+  EventBridgeTargetRoleArn:
+    Value: !GetAtt EventBridgeTargetRole.Arn

--- a/eventbridge-api-destinations/7-datadog/testEvent.json
+++ b/eventbridge-api-destinations/7-datadog/testEvent.json
@@ -1,0 +1,5 @@
+{
+    "EventBusName": "MyDataDogEventBus",
+    "Source": "MyDataDogApp",
+    "Detail": "{\"ddsource\": \"nginx\",\"ddtags\": \"env:staging,version:5.1\",\"hostname\": \"i-012345678\",\"message\": \"2019-11-19T14:37:58,995 INFO [process.name][20081] Hi from Eventbridge \",\"service\": \"payment\"}"
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added Datadog API Destination pattern. To run, just enable API Key authentication on Datadog and run the Cloudformation template and test event.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
