### PR TITLE
sqs-lambda-rust: change to arm64 architecture

### DIFF
--- a/sqs-lambda-rust/Makefile
+++ b/sqs-lambda-rust/Makefile
@@ -1,21 +1,21 @@
 FUNCTIONS := handler
-ARCH := x86_64-unknown-linux-musl
+ARCH := aarch64-unknown-linux-gnu
 
 build:
-	rm -rf ./build
 	cross build --release --target $(ARCH)
+	rm -rf ./build
 	mkdir -p ./build
 	${MAKE} ${MAKEOPTS} $(foreach function,${FUNCTIONS}, build-${function})
 
 build-%:
 	mkdir -p ./build/$*
 	cp -v ./target/$(ARCH)/release/$* ./build/$*/bootstrap
-build-%:
-	mkdir -p ./build/$*
-	cp -v ./target/$(ARCH)/release/$* ./build/$*/bootstrap
 
 deploy:
-	sam deploy --guided
+	if [ -f samconfig.toml ]; \
+		then sam deploy; \
+		else sam deploy -g; \
+	fi
 
 delete:
 	sam delete

--- a/sqs-lambda-rust/README.md
+++ b/sqs-lambda-rust/README.md
@@ -23,7 +23,7 @@ Important: this application uses various AWS services and there are costs associ
     ```
     cd sqs-lambda-rust
     ```
-3. Install dependencies and build
+3. Install dependencies and build (docker and cross build are required):
     ```
     make build
     ```
@@ -38,7 +38,7 @@ Important: this application uses various AWS services and there are costs associ
 
     Once you have run `sam deploy -guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
 
-1. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+6. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
    
 ## Example event payload from SQS to Lambda
 

--- a/sqs-lambda-rust/template.yaml
+++ b/sqs-lambda-rust/template.yaml
@@ -5,8 +5,9 @@ Description: Serverless patterns - SQS to Lambda
 Globals:
   Function:
     MemorySize: 128
-    Handler: bootstrap.is.real.handler
-    Runtime: provided
+    Architectures: ["arm64"]
+    Handler: bootstrap
+    Runtime: provided.al2
     Timeout: 30
     Environment:
       Variables:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Because the Makefile was already using the cross build I think is best to use arm64 architecture as default.
To be able to use arm64 architecture, we must install [CROSS](https://github.com/rust-embedded/cross)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
