### PR TITLE
Rust: align all rust examples to use zigbuild for cross compilation

### DIFF
--- a/apigw-http-api-lambda-rust/Makefile
+++ b/apigw-http-api-lambda-rust/Makefile
@@ -1,8 +1,16 @@
 FUNCTIONS := handler
 ARCH := aarch64-unknown-linux-gnu
+ARCH_SPLIT = $(subst -, ,$(ARCH))
 
 build:
-	cross build --release --target $(ARCH)
+ifeq ("$(shell zig targets | jq -r .native.cpu.arch)-$(shell zig targets | jq -r .native.os)-$(shell zig targets | jq -r .native.abi)", "$(word 1,$(ARCH_SPLIT))-$(word 3,$(ARCH_SPLIT))-$(word 4,$(ARCH_SPLIT))")
+	@echo "Same host and target. Using native build"
+	cargo build --release --target $(ARCH)
+else
+	@echo "Different host and target. Using zigbuild"
+	cargo zigbuild --release --target $(ARCH)
+endif
+
 	rm -rf ./build
 	mkdir -p ./build
 	${MAKE} ${MAKEOPTS} $(foreach function,${FUNCTIONS}, build-${function})

--- a/apigw-http-api-lambda-rust/README.md
+++ b/apigw-http-api-lambda-rust/README.md
@@ -12,6 +12,8 @@ Important: this application uses various AWS services and there are costs associ
 * [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
 * [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 * [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+* [Rust](https://www.rust-lang.org/) 1.56.0 or higher
+* [cargo-zigbuild](https://github.com/messense/cargo-zigbuild) and [Zig](https://ziglang.org/) for cross-compilation
 
 ## Deployment Instructions
 
@@ -23,7 +25,7 @@ Important: this application uses various AWS services and there are costs associ
     ```
     cd apigw-http-api-lambda-rust
     ```
-3. Install dependencies and build (docker and cross build are required):
+3. Install dependencies and build:
     ```
     make build
     ```

--- a/lambda-s3-rust/Makefile
+++ b/lambda-s3-rust/Makefile
@@ -1,8 +1,16 @@
 FUNCTIONS := handler
 ARCH := aarch64-unknown-linux-gnu
+ARCH_SPLIT = $(subst -, ,$(ARCH))
 
 build:
-	cross build --release --target $(ARCH)
+ifeq ("$(shell zig targets | jq -r .native.cpu.arch)-$(shell zig targets | jq -r .native.os)-$(shell zig targets | jq -r .native.abi)", "$(word 1,$(ARCH_SPLIT))-$(word 3,$(ARCH_SPLIT))-$(word 4,$(ARCH_SPLIT))")
+	@echo "Same host and target. Using native build"
+	cargo build --release --target $(ARCH)
+else
+	@echo "Different host and target. Using zigbuild"
+	cargo zigbuild --release --target $(ARCH)
+endif
+
 	rm -rf ./build
 	mkdir -p ./build
 	${MAKE} ${MAKEOPTS} $(foreach function,${FUNCTIONS}, build-${function})

--- a/lambda-s3-rust/README.md
+++ b/lambda-s3-rust/README.md
@@ -12,6 +12,8 @@ Important: this application uses various AWS services and there are costs associ
 * [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
 * [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 * [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+* [Rust](https://www.rust-lang.org/) 1.56.0 or higher
+* [cargo-zigbuild](https://github.com/messense/cargo-zigbuild) and [Zig](https://ziglang.org/) for cross-compilation
 
 ## Deployment Instructions
 
@@ -23,7 +25,7 @@ Important: this application uses various AWS services and there are costs associ
     ```
     cd lambda-s3-rust
     ```
-3. Install dependencies and build (docker and cross build are required):
+3. Install dependencies and build:
     ```
     make build
     ```

--- a/lambda-sfn-rust/Makefile
+++ b/lambda-sfn-rust/Makefile
@@ -1,8 +1,16 @@
 FUNCTIONS := handler
 ARCH := aarch64-unknown-linux-gnu
+ARCH_SPLIT = $(subst -, ,$(ARCH))
 
 build:
-	cross build --release --target $(ARCH)
+ifeq ("$(shell zig targets | jq -r .native.cpu.arch)-$(shell zig targets | jq -r .native.os)-$(shell zig targets | jq -r .native.abi)", "$(word 1,$(ARCH_SPLIT))-$(word 3,$(ARCH_SPLIT))-$(word 4,$(ARCH_SPLIT))")
+	@echo "Same host and target. Using native build"
+	cargo build --release --target $(ARCH)
+else
+	@echo "Different host and target. Using zigbuild"
+	cargo zigbuild --release --target $(ARCH)
+endif
+
 	rm -rf ./build
 	mkdir -p ./build
 	${MAKE} ${MAKEOPTS} $(foreach function,${FUNCTIONS}, build-${function})

--- a/lambda-sfn-rust/README.md
+++ b/lambda-sfn-rust/README.md
@@ -12,6 +12,8 @@ Important: this application uses various AWS services and there are costs associ
 * [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
 * [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 * [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+* [Rust](https://www.rust-lang.org/) 1.56.0 or higher
+* [cargo-zigbuild](https://github.com/messense/cargo-zigbuild) and [Zig](https://ziglang.org/) for cross-compilation
 
 ## Deployment Instructions
 
@@ -23,7 +25,7 @@ Important: this application uses various AWS services and there are costs associ
     ```
     cd lambda-sfn-rust
     ```
-3. Install dependencies and build (docker and cross build are required):
+3. Install dependencies and build:
     ```
     make build
     ```

--- a/lambda-sqs-rust/Makefile
+++ b/lambda-sqs-rust/Makefile
@@ -1,8 +1,16 @@
 FUNCTIONS := handler
 ARCH := aarch64-unknown-linux-gnu
+ARCH_SPLIT = $(subst -, ,$(ARCH))
 
 build:
-	cross build --release --target $(ARCH)
+ifeq ("$(shell zig targets | jq -r .native.cpu.arch)-$(shell zig targets | jq -r .native.os)-$(shell zig targets | jq -r .native.abi)", "$(word 1,$(ARCH_SPLIT))-$(word 3,$(ARCH_SPLIT))-$(word 4,$(ARCH_SPLIT))")
+	@echo "Same host and target. Using native build"
+	cargo build --release --target $(ARCH)
+else
+	@echo "Different host and target. Using zigbuild"
+	cargo zigbuild --release --target $(ARCH)
+endif
+
 	rm -rf ./build
 	mkdir -p ./build
 	${MAKE} ${MAKEOPTS} $(foreach function,${FUNCTIONS}, build-${function})

--- a/lambda-sqs-rust/README.md
+++ b/lambda-sqs-rust/README.md
@@ -12,6 +12,8 @@ Important: this application uses various AWS services and there are costs associ
 * [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
 * [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 * [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+* [Rust](https://www.rust-lang.org/) 1.56.0 or higher
+* [cargo-zigbuild](https://github.com/messense/cargo-zigbuild) and [Zig](https://ziglang.org/) for cross-compilation
 
 ## Deployment Instructions
 
@@ -23,7 +25,7 @@ Important: this application uses various AWS services and there are costs associ
     ```
     cd lambda-sqs-rust
     ```
-3. Install dependencies and build (docker and cross build are required):
+3. Install dependencies and build:
     ```
     make build
     ```

--- a/s3-eventbridge-direct-rust/Cargo.toml
+++ b/s3-eventbridge-direct-rust/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sqs-lambda-rust"
+name = "s3-eventbridge-direct-rust"
 version = "0.1.0"
 edition = "2021"
 

--- a/s3-eventbridge-direct-rust/Makefile
+++ b/s3-eventbridge-direct-rust/Makefile
@@ -1,8 +1,16 @@
 FUNCTIONS := handler
 ARCH := aarch64-unknown-linux-gnu
+ARCH_SPLIT = $(subst -, ,$(ARCH))
 
 build:
-	cross build --release --target $(ARCH)
+ifeq ("$(shell zig targets | jq -r .native.cpu.arch)-$(shell zig targets | jq -r .native.os)-$(shell zig targets | jq -r .native.abi)", "$(word 1,$(ARCH_SPLIT))-$(word 3,$(ARCH_SPLIT))-$(word 4,$(ARCH_SPLIT))")
+	@echo "Same host and target. Using native build"
+	cargo build --release --target $(ARCH)
+else
+	@echo "Different host and target. Using zigbuild"
+	cargo zigbuild --release --target $(ARCH)
+endif
+
 	rm -rf ./build
 	mkdir -p ./build
 	${MAKE} ${MAKEOPTS} $(foreach function,${FUNCTIONS}, build-${function})

--- a/s3-eventbridge-direct-rust/README.md
+++ b/s3-eventbridge-direct-rust/README.md
@@ -14,6 +14,8 @@ Important: this application uses various AWS services and there are costs associ
 * [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
 * [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 * [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+* [Rust](https://www.rust-lang.org/) 1.56.0 or higher
+* [cargo-zigbuild](https://github.com/messense/cargo-zigbuild) and [Zig](https://ziglang.org/) for cross-compilation
 
 ## Deployment Instructions
 
@@ -25,7 +27,7 @@ Important: this application uses various AWS services and there are costs associ
     ```
     cd s3-eventbridge-direct-rust
     ```
-3. Install dependencies and build (docker and cross build are required):
+3. Install dependencies and build:
     ```
     make build
     ```

--- a/sqs-lambda-rust/Makefile
+++ b/sqs-lambda-rust/Makefile
@@ -1,8 +1,16 @@
 FUNCTIONS := handler
 ARCH := aarch64-unknown-linux-gnu
+ARCH_SPLIT = $(subst -, ,$(ARCH))
 
 build:
-	cross build --release --target $(ARCH)
+ifeq ("$(shell zig targets | jq -r .native.cpu.arch)-$(shell zig targets | jq -r .native.os)-$(shell zig targets | jq -r .native.abi)", "$(word 1,$(ARCH_SPLIT))-$(word 3,$(ARCH_SPLIT))-$(word 4,$(ARCH_SPLIT))")
+	@echo "Same host and target. Using native build"
+	cargo build --release --target $(ARCH)
+else
+	@echo "Different host and target. Using zigbuild"
+	cargo zigbuild --release --target $(ARCH)
+endif
+
 	rm -rf ./build
 	mkdir -p ./build
 	${MAKE} ${MAKEOPTS} $(foreach function,${FUNCTIONS}, build-${function})

--- a/sqs-lambda-rust/README.md
+++ b/sqs-lambda-rust/README.md
@@ -12,6 +12,8 @@ Important: this application uses various AWS services and there are costs associ
 * [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
 * [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 * [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+* [Rust](https://www.rust-lang.org/) 1.56.0 or higher
+* [cargo-zigbuild](https://github.com/messense/cargo-zigbuild) and [Zig](https://ziglang.org/) for cross-compilation
 
 ## Deployment Instructions
 
@@ -23,7 +25,7 @@ Important: this application uses various AWS services and there are costs associ
     ```
     cd sqs-lambda-rust
     ```
-3. Install dependencies and build (docker and cross build are required):
+3. Install dependencies and build:
     ```
     make build
     ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I have aligned with one MR all the rust examples already approved instead of doing one fix for each (I hope you do not mind).
I have updated:
- readme instruction (requirements section)
- MakeFile to use zigbuild for cross compilation

I have followed the AWS SA Nicolas Moutschen from a twitter discussion [here](https://twitter.com/NMoutschen/status/1494595443300483072?s=20&t=J2iJiOWY0mW7mjcSIH7lFw)

And you can see the official [recomendation](https://github.com/aws-samples/serverless-rust-demo/pull/41) 

 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
