### PR TITLE
migrated to AWS CDK v2 (python)

### DIFF
--- a/apigw-canary-deployment-cdk/cdk.json
+++ b/apigw-canary-deployment-cdk/cdk.json
@@ -1,18 +1,3 @@
 {
-  "app": "python3 app.py",
-  "context": {
-    "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
-    "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
-    "@aws-cdk/aws-lambda:recognizeVersionProps": true,
-    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true
-  }
+  "app": "python3 app.py"
 }

--- a/apigw-canary-deployment-cdk/requirements.txt
+++ b/apigw-canary-deployment-cdk/requirements.txt
@@ -1,3 +1,5 @@
+aws-cdk-lib
+constructs
 aws-cdk.aws-apigateway
 aws-cdk.aws-lambda
 aws-cdk.aws-iam


### PR DESCRIPTION
#411 
*Description of changes:*
Migrated pattern from CDK v1 to CDK v2.

Changes include:
-  updating feature flags in ```cdk.json```
- dependency updates in ```requirements.txt```
- updating imports to use the new ```constructs``` module and consolidated ```aws-cdk-lib``` package

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
