### PR TITLE
migrated to AWS CDK v2 (python)

### DIFF
--- a/eventbridge-lambda-cdk/cdk/app.py
+++ b/eventbridge-lambda-cdk/cdk/app.py
@@ -1,14 +1,18 @@
 from aws_cdk import (
+    App,
+    Stack,
+    RemovalPolicy,
+    Duration,
     aws_events as events,
     aws_lambda as lambda_,
     aws_events_targets as targets,
-    aws_logs as logs,
-    core as cdk,
+    aws_logs as logs
 )
+from constructs import Construct
 
 
-class EventBridgeLambdaStack(cdk.Stack):
-    def __init__(self, app: cdk.App, id: str) -> None:
+class EventBridgeLambdaStack(Stack):
+    def __init__(self, app: App, id: str) -> None:
         super().__init__(app, id)
 
         # Lambda Function
@@ -19,7 +23,7 @@ class EventBridgeLambdaStack(cdk.Stack):
             self, "Singleton",
             code=lambda_.InlineCode(handler_code),
             handler="index.main",
-            timeout=cdk.Duration.seconds(10),
+            timeout=Duration.seconds(10),
             runtime=lambda_.Runtime.PYTHON_3_9,
         )
 
@@ -28,7 +32,7 @@ class EventBridgeLambdaStack(cdk.Stack):
             self,
             'logs',
             log_group_name = f"/aws/lambda/{lambdaFn.function_name}",
-            removal_policy = cdk.RemovalPolicy.DESTROY,
+            removal_policy = RemovalPolicy.DESTROY,
             retention = logs.RetentionDays.ONE_DAY
         )
 
@@ -43,6 +47,6 @@ class EventBridgeLambdaStack(cdk.Stack):
         rule.add_target(targets.LambdaFunction(lambdaFn))
 
 
-app = cdk.App()
+app = App()
 EventBridgeLambdaStack(app, "EventBridgeLambdaExample")
 app.synth()

--- a/eventbridge-lambda-cdk/cdk/cdk.json
+++ b/eventbridge-lambda-cdk/cdk/cdk.json
@@ -1,18 +1,30 @@
 {
   "app": "python3 app.py",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "requirements*.txt",
+      "source.bat",
+      "**/__init__.py",
+      "python/__pycache__",
+      "tests"
+    ]
+  },
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
+    "@aws-cdk/core:stackRelativeExports": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
     "@aws-cdk/aws-lambda:recognizeVersionProps": true,
-    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
   }
 }

--- a/eventbridge-lambda-cdk/cdk/requirements.txt
+++ b/eventbridge-lambda-cdk/cdk/requirements.txt
@@ -1,5 +1,2 @@
-aws-cdk.aws-events
-aws-cdk.aws-events-targets
-aws-cdk.aws-lambda
-aws-cdk.aws-logs
-aws-cdk.core
+aws-cdk-lib==2.13.0
+constructs>=10.0.0,<11.0.0


### PR DESCRIPTION
*Issue #, if available:*
#414 

*Description of changes:*
Migrated pattern from CDK v1 to CDK v2.

Changes include:
-  updating feature flags in ```cdk.json```
- dependency updates in ```requirements.txt```
- updating imports to use the new ```constructs``` module and consolidated ```aws-cdk-lib``` package

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
