### PR TITLE
migrated to AWS CDK v2 (python)

### DIFF
--- a/eventbridge-sns-cdk/app.py
+++ b/eventbridge-sns-cdk/app.py
@@ -1,23 +1,18 @@
 #!/usr/bin/env python3
-import os
 
-from aws_cdk import core as cdk
 from aws_cdk import (
+    App,
+    Stack,
+    CfnOutput,
     aws_sns as sns,
-    aws_sns_subscriptions as subs,
     aws_events as events,
-    aws_events_targets as targets,
-    core
+    aws_events_targets as targets
 )
-# For consistency with TypeScript code, `cdk` is the preferred import name for
-# the CDK's core module.  The following line also imports it as `core` for use
-# with examples from the CDK Developer's Guide, which are in the process of
-# being updated to use `cdk`.  You may delete this import if you don't need it.
-from aws_cdk import core
+from constructs import Construct
 
-class EventbridgeSnsCdkStack(cdk.Stack):
+class EventbridgeSnsCdkStack(Stack):
 
-    def __init__(self, scope: cdk.Construct, construct_id: str, **kwargs) -> None:
+    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
         #SNS Topic
@@ -47,10 +42,10 @@ class EventbridgeSnsCdkStack(cdk.Stack):
         rule.add_target(targets.SnsTopic(MySnsTopic))
 
         # CDK Outputs
-        cdk.CfnOutput(self, "SNS topic name", description="SNS topic name", value=MySnsTopic.topic_name)
-        cdk.CfnOutput(self, "SNS topic ARN", description="SNS topic ARN", value=MySnsTopic.topic_arn)
+        CfnOutput(self, "SNS topic name", description="SNS topic name", value=MySnsTopic.topic_name)
+        CfnOutput(self, "SNS topic ARN", description="SNS topic ARN", value=MySnsTopic.topic_arn)
 
 
-app = core.App()
+app = App()
 EventbridgeSnsCdkStack(app,"EventbridgeSnsCdkExample")
 app.synth()

--- a/eventbridge-sns-cdk/cdk.json
+++ b/eventbridge-sns-cdk/cdk.json
@@ -1,18 +1,30 @@
 {
   "app": "python3 app.py",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "requirements*.txt",
+      "source.bat",
+      "**/__init__.py",
+      "python/__pycache__",
+      "tests"
+    ]
+  },
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": true,
-    "aws-cdk:enableDiffNoFail": true,
     "@aws-cdk/core:stackRelativeExports": true,
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
     "@aws-cdk/aws-lambda:recognizeVersionProps": true,
-    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
   }
 }

--- a/eventbridge-sns-cdk/requirements.txt
+++ b/eventbridge-sns-cdk/requirements.txt
@@ -1,5 +1,2 @@
-aws_cdk.aws_sns
-aws_cdk.aws_sns_subscriptions
-aws_cdk.aws_events
-aws_cdk.aws_events_targets
-aws-cdk.core
+aws-cdk-lib==2.13.0
+constructs>=10.0.0,<11.0.0


### PR DESCRIPTION
*Issue #, if available:*
#415 
*Description of changes:*
Migrated pattern from CDK v1 to CDK v2.

Changes include:
-  updating feature flags in ```cdk.json```
- dependency updates in ```requirements.txt```
- updating imports to use the new ```constructs``` module and consolidated ```aws-cdk-lib``` package

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
