### PR TITLE
migrated to AWS CDK v2 (python)

### DIFF
--- a/sfn-comprehend-sdk/app.py
+++ b/sfn-comprehend-sdk/app.py
@@ -1,18 +1,12 @@
 #!/usr/bin/env python3
-import os
 
-from aws_cdk import core as cdk
 
-# For consistency with TypeScript code, `cdk` is the preferred import name for
-# the CDK's core module.  The following line also imports it as `core` for use
-# with examples from the CDK Developer's Guide, which are in the process of
-# being updated to use `cdk`.  You may delete this import if you don't need it.
-from aws_cdk import core
+from aws_cdk import App
 
 from sfn_comprehend_sdk.sfn_comprehend_sdk_stack import SfnComprehendSdkStack
 
 
-app = core.App()
+app = App()
 SfnComprehendSdkStack(app, "SfnComprehendSdkStack",
     # If you don't specify 'env', this stack will be environment-agnostic.
     # Account/Region-dependent features and context lookups will not work,

--- a/sfn-comprehend-sdk/cdk.json
+++ b/sfn-comprehend-sdk/cdk.json
@@ -1,18 +1,30 @@
 {
   "app": "python3 app.py",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "requirements*.txt",
+      "source.bat",
+      "**/__init__.py",
+      "python/__pycache__",
+      "tests"
+    ]
+  },
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": true,
-    "aws-cdk:enableDiffNoFail": true,
     "@aws-cdk/core:stackRelativeExports": true,
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
     "@aws-cdk/aws-lambda:recognizeVersionProps": true,
-    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
   }
 }

--- a/sfn-comprehend-sdk/requirements.txt
+++ b/sfn-comprehend-sdk/requirements.txt
@@ -1,4 +1,2 @@
-aws-cdk.core>=1.132.0
-aws-cdk.aws-stepfunctions>=1.132.0
-aws-cdk.aws-stepfunctions-tasks>=1.132.0
-aws-cdk.assertions>=1.132.0
+aws-cdk-lib==2.13.0
+constructs>=10.0.0,<11.0.0

--- a/sfn-comprehend-sdk/sfn_comprehend_sdk/sfn_comprehend_sdk_stack.py
+++ b/sfn-comprehend-sdk/sfn_comprehend_sdk/sfn_comprehend_sdk_stack.py
@@ -1,14 +1,16 @@
 from aws_cdk import (
-    core as cdk,
+    Stack,
+    CfnOutput,
+    Duration,
     aws_stepfunctions as sfn,
     aws_stepfunctions_tasks as sfn_tasks,
     aws_iam as iam
 )
+from constructs import Construct
 
+class SfnComprehendSdkStack(Stack):
 
-class SfnComprehendSdkStack(cdk.Stack):
-
-    def __init__(self, scope: cdk.Construct, construct_id: str, **kwargs) -> None:
+    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
         detect_sentiment_task = sfn_tasks.CallAwsService(self, "DetectSentiment", service="comprehend",
@@ -19,8 +21,8 @@ class SfnComprehendSdkStack(cdk.Stack):
         state_machine = sfn.StateMachine(
             self, "DetectSentimentStateMachine",
             definition=definition,
-            timeout=cdk.Duration.minutes(5)
+            timeout=Duration.minutes(5)
         )
 
-        cdk.CfnOutput(scope=self, id='StateMachineArn',
+        CfnOutput(scope=self, id='StateMachineArn',
                       value=state_machine.state_machine_arn)

--- a/sfn-comprehend-sdk/tests/unit/test_sfn_comprehend_sdk_stack.py
+++ b/sfn-comprehend-sdk/tests/unit/test_sfn_comprehend_sdk_stack.py
@@ -1,5 +1,5 @@
 from aws_cdk import (
-        core,
+        App,
         assertions
     )
 
@@ -9,7 +9,7 @@ from sfn_comprehend_sdk.sfn_comprehend_sdk_stack import SfnComprehendSdkStack
 # example tests. To run these tests, uncomment this file along with the example
 # resource in sfn_comprehend_sdk/sfn_comprehend_sdk_stack.py
 def test_sfn_queue_created():
-    app = core.App()
+    app = App()
     stack = SfnComprehendSdkStack(app, "sfn-comprehend-sdk")
     template = assertions.Template.from_stack(stack)
     template.has_resource_properties("AWS::StepFunctions::StateMachine", {})


### PR DESCRIPTION
*Issue #, if available:*
#421 
*Description of changes:*
Migrated pattern from CDK v1 to CDK v2.

Changes include:
-  updating feature flags in ```cdk.json```
- dependency updates in ```requirements.txt```
- updating imports to use the new ```constructs``` module and consolidated ```aws-cdk-lib``` package

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
