### PR TITLE
Avoid buffering image conversion with streams

### DIFF
--- a/s3-object-lambda/src/app.js
+++ b/s3-object-lambda/src/app.js
@@ -24,7 +24,7 @@ exports.handler = async (event) => {
   // Resize the image
   // Height is optional, will automatically maintain aspect ratio.
   // withMetadata retains the EXIF data which preserves the orientation of the image.
-  const resized = await sharp(data).resize({ width: 100, height: 100 }).withMetadata().toBuffer();
+  const resized = await sharp(data).resize({ width: 100, height: 100 }).withMetadata();
 
   // Send the resized image back to S3 Object Lambda.
   const params = {


### PR DESCRIPTION
*Issue #, if available:*

The illustrated solution buffers the thumbnail entirely in memory before starting to send data back to the user.

*Description of changes:*

The proposed change keeps sharp operating in streaming mode and since `writeGetObjectResponse` supports a readable stream in the `Body` property, this approach should start to stream bytes back to the user while the thumbnail is generated.
