### PR TITLE
feature: add dynamodb streams to lambda function pattern via terraform

### DIFF
--- a/dynamodb-streams-lambda-terraform/README.md
+++ b/dynamodb-streams-lambda-terraform/README.md
@@ -1,0 +1,68 @@
+# Amazon Dynamodb Streams to AWS Lambda
+
+The Terraform template deploys a Lambda function, a DynamoDB table, and the minimum IAM resources required to run the application.
+
+When items are written or updated in the DynamoDB table, the changes are sent to a stream. This pattern configures a Lambda function to poll this stream. The function is invoked with a payload containing the contents of the table item that changed.
+
+Learn more about this pattern at Serverless Land Patterns: https://serverlessland.com/patterns/dynamodb-lambda.
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ```
+    cd dynamodb-streams-lambda-terraform
+    ```
+1. From the command line, initialize terraform to  to downloads and installs the providers defined in the configuration:
+    ```
+    terraform init
+    ```
+1. From the command line, apply the configuration in the main.tf file:
+    ```
+    terraform apply
+    ```
+1. During the prompts:
+    * Enter yes
+1. Note the outputs from the deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## How it works
+
+When items are written or updated in a DynamoDB table, the changes are sent to a stream. This pattern configures a Lambda function to poll this stream. The function is invoked with a payload containing the contents of the table item that changed.
+
+## Testing
+
+After deployment, add an item to the DynamoDB table. Go to the CloudWatch Logs for the deployed Lambda function. You will see the event is logged out containing the item data.
+
+## Cleanup
+ 
+1. Change directory to the pattern directory:
+    ```
+    cd dynamodb-streams-lambda-terraform
+    ```
+1. Delete all created resources
+    ```bash
+    terraform apply -destroy
+    ```
+1. During the prompts:
+    * Enter yes
+1. Confirm all created resources has been deleted
+    ```bash
+    terraform show
+    ```
+    ```
+----
+Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/dynamodb-streams-lambda-terraform/main.tf
+++ b/dynamodb-streams-lambda-terraform/main.tf
@@ -1,0 +1,129 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.27"
+    }
+  }
+
+  required_version = ">= 0.14.9"
+}
+
+provider "aws" {
+  profile = "default"
+  region  = "us-east-1"
+}
+
+resource "aws_dynamodb_table" "dynamodb_table_users" {
+  name             = "UsersIds"
+  billing_mode     = "PROVISIONED"
+  read_capacity    = 5
+  write_capacity   = 5
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+  hash_key         = "UserId"
+
+  attribute {
+    name = "UserId"
+    type = "S"
+  }
+
+  tags = {
+    Name        = "dynamodb-test-table"
+    Environment = "dev"
+  }
+}
+
+resource "aws_lambda_function" "lambda_dynamodb_stream_handler" {
+  function_name    = "process-usersids-records"
+  filename         = data.archive_file.lambda_zip_file.output_path
+  source_code_hash = data.archive_file.lambda_zip_file.output_base64sha256
+  handler          = "index.handler"
+  role             = aws_iam_role.iam_for_lambda.arn
+  runtime          = "nodejs14.x"
+}
+
+data "archive_file" "lambda_zip_file" {
+  type        = "zip"
+  source_file = "${path.module}/src/index.js"
+  output_path = "${path.module}/lambda.zip"
+}
+
+resource "aws_lambda_event_source_mapping" "lambda_dynamodb" {
+  event_source_arn  = aws_dynamodb_table.dynamodb_table_users.stream_arn
+  function_name     = aws_lambda_function.lambda_dynamodb_stream_handler.arn
+  starting_position = "LATEST"
+}
+
+resource "aws_iam_role" "iam_for_lambda" {
+  name = "iam_for_lambda"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "dynamodb_lambda_policy" {
+  name   = "lambda-dynamodb-policy"
+  role   = aws_iam_role.iam_for_lambda.id
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+        "Sid": "AllowLambdaFunctionToCreateLogs",
+        "Action": [ 
+            "logs:*" 
+        ],
+        "Effect": "Allow",
+        "Resource": [ 
+            "arn:aws:logs:*:*:*" 
+        ]
+    },
+    {
+        "Sid": "AllowLambdaFunctionInvocation",
+        "Effect": "Allow",
+        "Action": [
+            "lambda:InvokeFunction"
+        ],
+        "Resource": [
+            "${aws_dynamodb_table.dynamodb_table_users.arn}/stream/*"
+        ]
+    },
+    {
+        "Sid": "APIAccessForDynamoDBStreams",
+        "Effect": "Allow",
+        "Action": [
+            "dynamodb:GetRecords",
+            "dynamodb:GetShardIterator",
+            "dynamodb:DescribeStream",
+            "dynamodb:ListStreams"
+        ],
+        "Resource": "${aws_dynamodb_table.dynamodb_table_users.arn}/stream/*"
+    }
+  ]
+}
+EOF
+}
+
+output "dynamodb_usersIds_arn" {
+  value = aws_dynamodb_table.dynamodb_table_users.arn
+    description = "The ARN of the DynamoDB Users Ids table"
+}
+
+output "lambda_processing_arn" {
+  value = aws_lambda_function.lambda_dynamodb_stream_handler.arn
+    description = "The ARN of the Lambda function processing the DynamoDB stream"
+}

--- a/dynamodb-streams-lambda-terraform/src/app.js
+++ b/dynamodb-streams-lambda-terraform/src/app.js
@@ -1,0 +1,10 @@
+/*! Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: MIT-0
+ */
+
+'use strict'
+
+exports.handler = async (event) => {
+  // Lambda handler code
+  console.log(JSON.stringify(event, 0, null))
+}


### PR DESCRIPTION
Deploy DynamoDB table with stream enabled, Lambda function that process the stream records, via Terraform


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
