### PR TITLE
migrated to AWS CDK v2 (typescript)

### DIFF
--- a/apigw-fargate-cdk/cdk/bin/cdk.ts
+++ b/apigw-fargate-cdk/cdk/bin/cdk.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
-import * as cdk from '@aws-cdk/core';
+import { App } from 'aws-cdk-lib';   
 import { CdkStack } from '../lib/cdk-stack';
 
-const app = new cdk.App();
+const app = new App();
 new CdkStack(app, 'CdkStack', {
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,

--- a/apigw-fargate-cdk/cdk/cdk.json
+++ b/apigw-fargate-cdk/cdk/cdk.json
@@ -1,18 +1,32 @@
 {
   "app": "npx ts-node --prefer-ts-exts bin/cdk.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
+    "@aws-cdk/core:stackRelativeExports": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
     "@aws-cdk/aws-lambda:recognizeVersionProps": true,
-    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
   }
 }

--- a/apigw-fargate-cdk/cdk/lib/cdk-stack.ts
+++ b/apigw-fargate-cdk/cdk/lib/cdk-stack.ts
@@ -1,8 +1,10 @@
-import { CfnOutput, CfnResource, Construct, Stack, StackProps } from '@aws-cdk/core';
-import { Vpc } from '@aws-cdk/aws-ec2';
-import { Cluster, ContainerImage } from '@aws-cdk/aws-ecs';
-import { ApplicationLoadBalancedFargateService } from '@aws-cdk/aws-ecs-patterns';
-import { CfnIntegration, CfnRoute, HttpApi } from '@aws-cdk/aws-apigatewayv2';
+import { CfnOutput, CfnResource, Stack, StackProps } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import { Cluster, ContainerImage } from 'aws-cdk-lib/aws-ecs';
+import { ApplicationLoadBalancedFargateService } from 'aws-cdk-lib/aws-ecs-patterns';
+import { CfnIntegration, CfnRoute } from 'aws-cdk-lib/aws-apigatewayv2';
+import { HttpApi } from '@aws-cdk/aws-apigatewayv2-alpha';
 import path = require('path');
 
 export class CdkStack extends Stack {

--- a/apigw-fargate-cdk/cdk/package.json
+++ b/apigw-fargate-cdk/cdk/package.json
@@ -11,21 +11,18 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.130.0",
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
+    "aws-cdk": "^2.13.0",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
-    "aws-cdk": "1.130.0",
     "ts-node": "^9.0.0",
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-apigatewayv2": "^1.130.0",
-    "@aws-cdk/aws-ec2": "^1.130.0",
-    "@aws-cdk/aws-ecs": "^1.130.0",
-    "@aws-cdk/aws-ecs-patterns": "^1.130.0",
-    "@aws-cdk/core": "1.130.0",
+    "@aws-cdk/aws-apigatewayv2-alpha": "^2.14.0-alpha.0",
+    "aws-cdk-lib": "^2.13.0",
+    "constructs": "^10.0.0",
     "source-map-support": "^0.5.16"
   }
 }

--- a/apigw-fargate-cdk/cdk/test/cdk.test.ts
+++ b/apigw-fargate-cdk/cdk/test/cdk.test.ts
@@ -1,17 +1,19 @@
-import { expect as expectCDK, haveResource } from '@aws-cdk/assert';
-import * as cdk from '@aws-cdk/core';
+//import { expect as expectCDK, haveResource } from '@aws-cdk/assert';
+import { Capture, Match, Template } from "aws-cdk-lib/assertions";
+
+import * as cdk from "aws-cdk-lib";
 import { CdkStack } from '../lib/cdk-stack';
 
 test('Validate stack resources', () => {
   const app = new cdk.App();
   const stack = new CdkStack(app, 'MyTestStack');
 
-  expectCDK(stack).to(haveResource('AWS::ECS::Cluster'));
-  expectCDK(stack).to(haveResource('AWS::ECS::Service'));
-  expectCDK(stack).to(haveResource('AWS::ECS::TaskDefinition'));
-  expectCDK(stack).to(haveResource('AWS::ElasticLoadBalancingV2::LoadBalancer'));
-  expectCDK(stack).to(haveResource('AWS::ApiGatewayV2::Api'));
-  expectCDK(stack).to(haveResource('AWS::ApiGatewayV2::Integration'));
-  expectCDK(stack).to(haveResource('AWS::ApiGatewayV2::Route'));
-  expectCDK(stack).to(haveResource('AWS::ApiGatewayV2::VpcLink'));
+  Template.fromStack(stack).hasResource('AWS::ECS::Cluster', {});
+  Template.fromStack(stack).hasResource('AWS::ECS::Service', {});
+  Template.fromStack(stack).hasResource('AWS::ECS::TaskDefinition', {});
+  Template.fromStack(stack).hasResource('AWS::ElasticLoadBalancingV2::LoadBalancer', {});
+  Template.fromStack(stack).hasResource('AWS::ApiGatewayV2::Api', {});
+  Template.fromStack(stack).hasResource('AWS::ApiGatewayV2::Integration', {});
+  Template.fromStack(stack).hasResource('AWS::ApiGatewayV2::Route', {});
+  Template.fromStack(stack).hasResource('AWS::ApiGatewayV2::VpcLink', {});
 });


### PR DESCRIPTION
*Issue #, if available:* closes #471

*Description of changes:*
Migrated pattern from CDK v1 to CDK v2.

Changes include:

* updating feature flags in cdk.json
* dependency updates in package.json
* updating imports to use the new constructs and consolidated aws-cdk-lib libraries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
