### PR TITLE
migrated to AWS CDK v2 (typescript)

### DIFF
--- a/apigw-http-api-eventbridge-cdk/cdk/bin/api-eventbridge.ts
+++ b/apigw-http-api-eventbridge-cdk/cdk/bin/api-eventbridge.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
-import * as cdk from '@aws-cdk/core';
+import { App } from 'aws-cdk-lib';
 import { ApiEventbridgeStack } from '../lib/api-eventbridge-stack';
 
-const app = new cdk.App();
+const app = new App();
 new ApiEventbridgeStack(app, 'ApiEventbridgeStack', {
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,

--- a/apigw-http-api-eventbridge-cdk/cdk/cdk.json
+++ b/apigw-http-api-eventbridge-cdk/cdk/cdk.json
@@ -1,17 +1,32 @@
 {
   "app": "npx ts-node --prefer-ts-exts bin/api-eventbridge.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
+    "@aws-cdk/core:stackRelativeExports": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
-    "@aws-cdk/aws-lambda:recognizeVersionProps": true
+    "@aws-cdk/aws-lambda:recognizeVersionProps": true,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
   }
 }

--- a/apigw-http-api-eventbridge-cdk/cdk/lib/api-eventbridge-stack.ts
+++ b/apigw-http-api-eventbridge-cdk/cdk/lib/api-eventbridge-stack.ts
@@ -1,13 +1,15 @@
-import * as cdk from '@aws-cdk/core';
-import { EventBus, Rule } from '@aws-cdk/aws-events';
-import { CfnIntegration, CfnRoute, HttpApi } from '@aws-cdk/aws-apigatewayv2';
-import { Effect, PolicyStatement, Role, ServicePrincipal } from '@aws-cdk/aws-iam';
-import { LogGroup } from '@aws-cdk/aws-logs';
-import { CloudWatchLogGroup } from '@aws-cdk/aws-events-targets';
+import { Stack, StackProps, CfnOutput } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { EventBus, Rule } from 'aws-cdk-lib/aws-events';
+import { CfnIntegration, CfnRoute } from 'aws-cdk-lib/aws-apigatewayv2';
+import { HttpApi } from '@aws-cdk/aws-apigatewayv2-alpha';
+import { Effect, PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { LogGroup } from 'aws-cdk-lib/aws-logs';
+import { CloudWatchLogGroup } from 'aws-cdk-lib/aws-events-targets';
 
 
-export class ApiEventbridgeStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+export class ApiEventbridgeStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
     const eventBus = new EventBus(this, 'MyEventBus', {
@@ -72,7 +74,7 @@ export class ApiEventbridgeStack extends cdk.Stack {
     });
     
     
-    new cdk.CfnOutput(this, 'apiUrl', { value: httpApi.url!, description: "HTTP API endpoint URL" });
+    new CfnOutput(this, 'apiUrl', { value: httpApi.url!, description: "HTTP API endpoint URL" });
   }
 }
 

--- a/apigw-http-api-eventbridge-cdk/cdk/package.json
+++ b/apigw-http-api-eventbridge-cdk/cdk/package.json
@@ -11,17 +11,15 @@
   },
   "devDependencies": {
     "@types/node": "10.17.27",
-    "aws-cdk": "1.113.0",
+    "aws-cdk": "^2.13.0",
     "ts-node": "^9.0.0",
     "typescript": "~3.9.7"
   },
   "dependencies": {
     "@aws-cdk/aws-apigatewayv2": "1.113.0",
-    "@aws-cdk/aws-events": "1.113.0",
-    "@aws-cdk/aws-events-targets": "1.113.0",
-    "@aws-cdk/aws-iam": "1.113.0",
-    "@aws-cdk/aws-logs": "1.113.0",
-    "@aws-cdk/core": "1.113.0",
+    "@aws-cdk/aws-apigatewayv2-alpha": "^2.14.0-alpha.0",
+    "aws-cdk-lib": "^2.13.0",
+    "constructs": "^10.0.0",
     "source-map-support": "^0.5.16"
   }
 }


### PR DESCRIPTION
*Issue #, if available:* closes #473 

*Description of changes:*
Migrated pattern from CDK v1 to CDK v2.

Changes include:

* updating feature flags in cdk.json
* dependency updates in package.json
* updating imports to use the new constructs and consolidated aws-cdk-lib libraries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
