### PR TITLE
migrated to AWS CDK v2 (typescript)

### DIFF
--- a/apigw-s3-cdk/cdk/bin/apigw-s3-cdk.ts
+++ b/apigw-s3-cdk/cdk/bin/apigw-s3-cdk.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
 import { ApigwS3CdkStack } from '../lib/apigw-s3-cdk-stack';
 
 const app = new cdk.App();

--- a/apigw-s3-cdk/cdk/cdk.json
+++ b/apigw-s3-cdk/cdk/cdk.json
@@ -1,17 +1,32 @@
 {
   "app": "npx ts-node --prefer-ts-exts bin/apigw-s3-cdk.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
+    "@aws-cdk/core:stackRelativeExports": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
-    "@aws-cdk/aws-lambda:recognizeVersionProps": true
+    "@aws-cdk/aws-lambda:recognizeVersionProps": true,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
   }
 }

--- a/apigw-s3-cdk/cdk/lib/apigw-s3-cdk-stack.ts
+++ b/apigw-s3-cdk/cdk/lib/apigw-s3-cdk-stack.ts
@@ -1,12 +1,13 @@
-import * as cdk from '@aws-cdk/core';
+import { Stack, StackProps } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 //import * as s3 from "@aws-cdk/aws-s3";
-import * as apigw from "@aws-cdk/aws-apigateway";
-import * as iam from "@aws-cdk/aws-iam";
+import { aws_apigateway as apigw } from "aws-cdk-lib";
+import { aws_iam as iam } from "aws-cdk-lib";
 
-export class ApigwS3CdkStack extends cdk.Stack {
+export class ApigwS3CdkStack extends Stack {
   public readonly apiGatewayRole: iam.Role;
 
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
     
     //Create REST API

--- a/apigw-s3-cdk/cdk/package.json
+++ b/apigw-s3-cdk/cdk/package.json
@@ -11,19 +11,17 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.114.0",
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
-    "aws-cdk": "1.114.0",
+    "aws-cdk": "^2.13.0",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-apigateway": "^1.135.0",
-    "@aws-cdk/aws-s3": "^1.135.0",
-    "@aws-cdk/core": "1.114.0",
+    "aws-cdk-lib": "^2.13.0",
+    "constructs": "^10.0.0",
     "source-map-support": "^0.5.16"
   }
 }


### PR DESCRIPTION
*Issue #, if available:* closes #476

*Description of changes:*
Migrated pattern from CDK v1 to CDK v2.

Changes include:

* updating feature flags in cdk.json
* dependency updates in package.json
* updating imports to use the new constructs and consolidated aws-cdk-lib libraries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
