### PR TITLE
migrated to AWS CDK v2 (typescript)

### DIFF
--- a/apigw-sns-sqs-lambda-cdk/cdk/bin/cdk-apigw-sns-sqs-lambda.ts
+++ b/apigw-sns-sqs-lambda-cdk/cdk/bin/cdk-apigw-sns-sqs-lambda.ts
@@ -5,7 +5,7 @@
  */
 
 import 'source-map-support/register';
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
 import { CdkApigwSnsSqsLambdaStack } from '../lib/cdk-apigw-sns-sqs-lambda-stack';
 
 const app = new cdk.App();

--- a/apigw-sns-sqs-lambda-cdk/cdk/cdk.json
+++ b/apigw-sns-sqs-lambda-cdk/cdk/cdk.json
@@ -1,18 +1,32 @@
 {
   "app": "npx ts-node --prefer-ts-exts bin/cdk-apigw-sns-sqs-lambda.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
+    "@aws-cdk/core:stackRelativeExports": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
     "@aws-cdk/aws-lambda:recognizeVersionProps": true,
-    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
   }
 }

--- a/apigw-sns-sqs-lambda-cdk/cdk/lib/cdk-apigw-sns-sqs-lambda-stack.ts
+++ b/apigw-sns-sqs-lambda-cdk/cdk/lib/cdk-apigw-sns-sqs-lambda-stack.ts
@@ -2,18 +2,20 @@
   *  SPDX-License-Identifier: MIT-0
  */
 
-import * as cdk from '@aws-cdk/core';
-import * as iam from '@aws-cdk/aws-iam';
-import * as lambda from '@aws-cdk/aws-lambda';
-import { SqsEventSource } from '@aws-cdk/aws-lambda-event-sources';
-import * as sns from '@aws-cdk/aws-sns';
-import * as sqs from '@aws-cdk/aws-sqs';
-import * as subscriptions from '@aws-cdk/aws-sns-subscriptions';
-import * as apigateway from '@aws-cdk/aws-apigateway';
+import { Stack, StackProps, Aws } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { aws_iam as iam } from 'aws-cdk-lib';
+import { aws_lambda as lambda } from 'aws-cdk-lib';
+import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
+import { aws_sqs as sqs } from 'aws-cdk-lib';
+import { aws_sns as sns } from 'aws-cdk-lib';
+import { aws_sns_subscriptions as subscriptions } from 'aws-cdk-lib';
+import { aws_apigateway as apigateway } from 'aws-cdk-lib';
+
 import * as path from 'path';
 
-export class CdkApigwSnsSqsLambdaStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+export class CdkApigwSnsSqsLambdaStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
     const topic = new sns.Topic(this, 'topic')
@@ -53,7 +55,7 @@ export class CdkApigwSnsSqsLambdaStack extends cdk.Stack {
       new apigateway.AwsIntegration({
         service: 'sns',
         integrationHttpMethod: 'POST',
-        path: `${cdk.Aws.ACCOUNT_ID}/${topic.topicName}`,
+        path: `${Aws.ACCOUNT_ID}/${topic.topicName}`,
         options: {
           credentialsRole: gatewayExecutionRole, 
           passthroughBehavior: apigateway.PassthroughBehavior.NEVER,

--- a/apigw-sns-sqs-lambda-cdk/cdk/package.json
+++ b/apigw-sns-sqs-lambda-cdk/cdk/package.json
@@ -10,23 +10,16 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.118.0",
     "@types/aws-lambda": "^8.10.83",
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
-    "aws-cdk": "^1.126.0",
+    "aws-cdk": "^2.13.0",
     "ts-node": "^9.0.0",
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-apigateway": "^1.126.0",
-    "@aws-cdk/aws-iam": "^1.126.0",
-    "@aws-cdk/aws-lambda": "^1.126.0",
-    "@aws-cdk/aws-lambda-event-sources": "^1.126.0",
-    "@aws-cdk/aws-sns": "^1.126.0",
-    "@aws-cdk/aws-sns-subscriptions": "^1.126.0",
-    "@aws-cdk/aws-sqs": "^1.126.0",
-    "@aws-cdk/core": "1.118.0",
+    "aws-cdk-lib": "^2.13.0",
+    "constructs": "^10.0.0",
     "source-map-support": "^0.5.16"
   }
 }


### PR DESCRIPTION
*Issue #, if available:* closes #477

*Description of changes:*
Migrated pattern from CDK v1 to CDK v2.

Changes include:

* updating feature flags in cdk.json
* dependency updates in package.json
* updating imports to use the new constructs and consolidated aws-cdk-lib libraries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
