### PR TITLE
migrated to AWS CDK v2 (typescript)

### DIFF
--- a/appsync-direct-lambda-resolver/cdk/.gitignore
+++ b/appsync-direct-lambda-resolver/cdk/.gitignore
@@ -1,0 +1,8 @@
+*.js
+!jest.config.js
+*.d.ts
+node_modules
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/appsync-direct-lambda-resolver/cdk/bin/appsync-with-direct-lambda-resolver.ts
+++ b/appsync-direct-lambda-resolver/cdk/bin/appsync-with-direct-lambda-resolver.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import 'source-map-support/register'
-import * as cdk from '@aws-cdk/core'
+import * as cdk from 'aws-cdk-lib';
 import { MainStack } from '../lib/main'
 
 const app = new cdk.App()

--- a/appsync-direct-lambda-resolver/cdk/cdk.json
+++ b/appsync-direct-lambda-resolver/cdk/cdk.json
@@ -1,17 +1,32 @@
 {
   "app": "npx ts-node --prefer-ts-exts bin/appsync-with-direct-lambda-resolver.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
+    "@aws-cdk/core:stackRelativeExports": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
-    "@aws-cdk/aws-lambda:recognizeVersionProps": true
+    "@aws-cdk/aws-lambda:recognizeVersionProps": true,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
   }
 }

--- a/appsync-direct-lambda-resolver/cdk/lib/main.ts
+++ b/appsync-direct-lambda-resolver/cdk/lib/main.ts
@@ -1,10 +1,11 @@
-import * as cdk from '@aws-cdk/core'
-import { GraphqlApi, Schema, FieldLogLevel, AuthorizationType } from '@aws-cdk/aws-appsync'
-import { NodejsFunction } from '@aws-cdk/aws-lambda-nodejs'
-import { join } from 'path'
+import { Stack, StackProps, CfnOutput } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { GraphqlApi, Schema, FieldLogLevel, AuthorizationType } from '@aws-cdk/aws-appsync-alpha';
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { join } from 'path';
 
-export class MainStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+export class MainStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props)
 
     const api = new GraphqlApi(this, 'Api', {
@@ -29,9 +30,9 @@ export class MainStack extends cdk.Stack {
     ]
     fields.forEach(({ typeName, fieldName }) => datasource.createResolver({ typeName, fieldName }))
 
-    new cdk.CfnOutput(this, 'graphqlUrl', { value: api.graphqlUrl })
-    new cdk.CfnOutput(this, 'apiKey', { value: api.apiKey! })
-    new cdk.CfnOutput(this, 'apiId', { value: api.apiId })
-    new cdk.CfnOutput(this, 'lambda', { value: directLambda.functionArn })
+    new CfnOutput(this, 'graphqlUrl', { value: api.graphqlUrl })
+    new CfnOutput(this, 'apiKey', { value: api.apiKey! })
+    new CfnOutput(this, 'apiId', { value: api.apiId })
+    new CfnOutput(this, 'lambda', { value: directLambda.functionArn })
   }
 }

--- a/appsync-direct-lambda-resolver/cdk/package.json
+++ b/appsync-direct-lambda-resolver/cdk/package.json
@@ -10,11 +10,10 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.107.0",
     "@types/aws-lambda": "^8.10.77",
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
-    "aws-cdk": "1.107.0",
+    "aws-cdk": "^2.13.0",
     "esbuild": "^0.12.8",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
@@ -22,9 +21,9 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-appsync": "1.107.0",
-    "@aws-cdk/aws-lambda-nodejs": "1.107.0",
-    "@aws-cdk/core": "1.107.0",
+    "@aws-cdk/aws-appsync-alpha": "^2.15.0-alpha.0",
+    "aws-cdk-lib": "^2.13.0",
+    "constructs": "^10.0.0",
     "source-map-support": "^0.5.16"
   }
 }


### PR DESCRIPTION
*Issue #, if available:* closes #478

*Description of changes:*
Migrated pattern from CDK v1 to CDK v2.

Changes include:

* updating feature flags in cdk.json
* dependency updates in package.json
* updating imports to use the new constructs and consolidated aws-cdk-lib libraries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
