### PR TITLE
migrated to AWS CDK v2 (typescript)

### DIFF
--- a/appsync-dynamodb-singletable-cdk/cdk/bin/appsync-cdk.ts
+++ b/appsync-dynamodb-singletable-cdk/cdk/bin/appsync-cdk.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
 import { AppsyncCdkStack } from '../lib/appsync-cdk-stack';
 
 const app = new cdk.App();

--- a/appsync-dynamodb-singletable-cdk/cdk/cdk.json
+++ b/appsync-dynamodb-singletable-cdk/cdk/cdk.json
@@ -1,17 +1,32 @@
 {
   "app": "npx ts-node --prefer-ts-exts bin/appsync-cdk.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
+    "@aws-cdk/core:stackRelativeExports": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
-    "@aws-cdk/aws-lambda:recognizeVersionProps": true
+    "@aws-cdk/aws-lambda:recognizeVersionProps": true,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
   }
 }

--- a/appsync-dynamodb-singletable-cdk/cdk/lib/appsync-cdk-stack.ts
+++ b/appsync-dynamodb-singletable-cdk/cdk/lib/appsync-cdk-stack.ts
@@ -1,10 +1,13 @@
-import * as cdk from '@aws-cdk/core';
+import { Stack, StackProps } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Table, BillingMode, AttributeType } from 'aws-cdk-lib/aws-dynamodb';
+import { GraphqlApi, MappingTemplate, Schema } from '@aws-cdk/aws-appsync-alpha';
 import { join } from 'path';
-import { GraphqlApi, MappingTemplate, Schema } from '@aws-cdk/aws-appsync'
-import { Table, BillingMode, AttributeType } from '@aws-cdk/aws-dynamodb'
 
-export class AppsyncCdkStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+
+
+export class AppsyncCdkStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
     // DynamoDB Table

--- a/appsync-dynamodb-singletable-cdk/cdk/package.json
+++ b/appsync-dynamodb-singletable-cdk/cdk/package.json
@@ -11,19 +11,18 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.115.0",
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
-    "aws-cdk": "1.115.0",
+    "aws-cdk": "^2.13.0",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-appsync": "^1.115.0",
-    "@aws-cdk/aws-dynamodb": "^1.115.0",
-    "@aws-cdk/core": "1.115.0",
+    "@aws-cdk/aws-appsync-alpha": "^2.15.0-alpha.0",
+    "aws-cdk-lib": "^2.13.0",
+    "constructs": "^10.0.0",
     "source-map-support": "^0.5.16"
   }
 }

--- a/appsync-dynamodb-singletable-cdk/cdk/test/appsync-cdk.test.ts
+++ b/appsync-dynamodb-singletable-cdk/cdk/test/appsync-cdk.test.ts
@@ -1,13 +1,12 @@
-import { expect as expectCDK, matchTemplate, MatchStyle } from '@aws-cdk/assert';
-import * as cdk from '@aws-cdk/core';
+import { Template } from 'aws-cdk-lib/assertions';
+import * as cdk from 'aws-cdk-lib';
 import * as AppsyncCdk from '../lib/appsync-cdk-stack';
 
-test('Empty Stack', () => {
+test('Testing Stack', () => {
     const app = new cdk.App();
     // WHEN
     const stack = new AppsyncCdk.AppsyncCdkStack(app, 'MyTestStack');
     // THEN
-    expectCDK(stack).to(matchTemplate({
-      "Resources": {}
-    }, MatchStyle.EXACT))
+    Template.fromStack(stack).hasResource("AWS::DynamoDB::Table", {})
+
 });


### PR DESCRIPTION
*Issue #, if available:* closes #479

*Description of changes:*
Migrated pattern from CDK v1 to CDK v2.

Changes include:

* updating feature flags in cdk.json
* dependency updates in package.json
* updating imports to use the new constructs and consolidated aws-cdk-lib libraries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
