### PR TITLE
migrated to AWS CDK v2 (typescript)

### DIFF
--- a/appsync-express-workflow/cdk/.gitignore
+++ b/appsync-express-workflow/cdk/.gitignore
@@ -1,0 +1,8 @@
+*.js
+!jest.config.js
+*.d.ts
+node_modules
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/appsync-express-workflow/cdk/.npmignore
+++ b/appsync-express-workflow/cdk/.npmignore
@@ -1,0 +1,6 @@
+*.ts
+!*.d.ts
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/appsync-express-workflow/cdk/bin/appsync-express-workflow.ts
+++ b/appsync-express-workflow/cdk/bin/appsync-express-workflow.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
 import { AppsyncExpressWorkflowStack } from '../lib/appsync-express-workflow-stack';
 
 const app = new cdk.App();

--- a/appsync-express-workflow/cdk/cdk.json
+++ b/appsync-express-workflow/cdk/cdk.json
@@ -1,17 +1,32 @@
 {
   "app": "npx ts-node --prefer-ts-exts bin/appsync-express-workflow.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
+    "@aws-cdk/core:stackRelativeExports": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
-    "@aws-cdk/aws-lambda:recognizeVersionProps": true
+    "@aws-cdk/aws-lambda:recognizeVersionProps": true,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
   }
 }

--- a/appsync-express-workflow/cdk/lib/appsync-express-workflow-stack.ts
+++ b/appsync-express-workflow/cdk/lib/appsync-express-workflow-stack.ts
@@ -1,7 +1,8 @@
-import * as cdk from '@aws-cdk/core';
-import {Pass, StateMachine, StateMachineType} from '@aws-cdk/aws-stepfunctions';
-import { GraphqlApi, Schema, FieldLogLevel, AuthorizationType, MappingTemplate } from '@aws-cdk/aws-appsync';
-import { Role, ServicePrincipal, PolicyStatement } from "@aws-cdk/aws-iam";
+import { Stack, StackProps, CfnOutput } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import {Pass, StateMachine, StateMachineType} from 'aws-cdk-lib/aws-stepfunctions';
+import { GraphqlApi, Schema, FieldLogLevel, AuthorizationType, MappingTemplate } from '@aws-cdk/aws-appsync-alpha';
+import { Role, ServicePrincipal, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { join } from 'path';
 
 const START_EXECUTION_REQUEST_TEMPLATE = (stateMachineArn: String) => {
@@ -41,8 +42,8 @@ const RESPONSE_TEMPLATE = `
 #end
 `
 
-export class AppsyncExpressWorkflowStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+export class AppsyncExpressWorkflowStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
     // The code that defines your stack goes here
@@ -90,9 +91,9 @@ export class AppsyncExpressWorkflowStack extends cdk.Stack {
     })
 
 
-    new cdk.CfnOutput(this, 'graphqlUrl', { value: api.graphqlUrl })
-    new cdk.CfnOutput(this, 'apiKey', { value: api.apiKey! })
-    new cdk.CfnOutput(this, 'apiId', { value: api.apiId })
-    new cdk.CfnOutput(this, 'stateMachine', {value: stateMachine.stateMachineArn})
+    new CfnOutput(this, 'graphqlUrl', { value: api.graphqlUrl })
+    new CfnOutput(this, 'apiKey', { value: api.apiKey! })
+    new CfnOutput(this, 'apiId', { value: api.apiId })
+    new CfnOutput(this, 'stateMachine', {value: stateMachine.stateMachineArn})
   }
 }

--- a/appsync-express-workflow/cdk/package.json
+++ b/appsync-express-workflow/cdk/package.json
@@ -11,20 +11,18 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.113.0",
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
+    "aws-cdk": "^2.13.0",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
-    "aws-cdk": "1.113.0",
     "ts-node": "^9.0.0",
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/core": "1.113.0",
-    "@aws-cdk/aws-stepfunctions": "1.113.0",
-    "@aws-cdk/aws-appsync": "1.113.0",
-    "@aws-cdk/aws-iam": "1.113.0",
+    "@aws-cdk/aws-appsync-alpha": "^2.15.0-alpha.0",
+    "aws-cdk-lib": "^2.13.0",
+    "constructs": "^10.0.0",
     "source-map-support": "^0.5.16"
   }
 }


### PR DESCRIPTION
*Issue #, if available:* closes #481

*Description of changes:*
Migrated pattern from CDK v1 to CDK v2.

Changes include:

* updating feature flags in cdk.json
* dependency updates in package.json
* updating imports to use the new constructs and consolidated aws-cdk-lib libraries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
