### PR TITLE
migrated to AWS CDK v2 (typescript)

### DIFF
--- a/auroraserverless-secretsmanager/CDK/bin/cdk.ts
+++ b/auroraserverless-secretsmanager/CDK/bin/cdk.ts
@@ -1,5 +1,5 @@
 import 'source-map-support/register';
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
 import { CdkStack } from '../lib/cdk-stack';
 
 const app = new cdk.App();

--- a/auroraserverless-secretsmanager/CDK/cdk.json
+++ b/auroraserverless-secretsmanager/CDK/cdk.json
@@ -21,6 +21,12 @@
     "@aws-cdk/core:stackRelativeExports": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
     "@aws-cdk/aws-lambda:recognizeVersionProps": true,
-    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
   }
 }

--- a/auroraserverless-secretsmanager/CDK/lib/cdk-stack.ts
+++ b/auroraserverless-secretsmanager/CDK/lib/cdk-stack.ts
@@ -1,7 +1,9 @@
-import { CfnOutput, Construct, Stack, StackProps} from '@aws-cdk/core';
-import * as sm from "@aws-cdk/aws-secretsmanager";
-import { CfnDBCluster, CfnDBSubnetGroup } from '@aws-cdk/aws-rds';
-import { SubnetType, Vpc } from '@aws-cdk/aws-ec2';
+
+import { Stack, StackProps, CfnOutput  } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { aws_secretsmanager as sm } from "aws-cdk-lib";
+import { CfnDBCluster, CfnDBSubnetGroup } from 'aws-cdk-lib/aws-rds';
+import { SubnetType, Vpc } from 'aws-cdk-lib/aws-ec2';
 
 export class CdkStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {

--- a/auroraserverless-secretsmanager/CDK/package.json
+++ b/auroraserverless-secretsmanager/CDK/package.json
@@ -15,17 +15,12 @@
     "@types/node": "16.11.11",
     "jest": "^27.4.3",
     "ts-jest": "^27.1.0",
-    "aws-cdk": "2.0.0",
+    "aws-cdk": "^2.13.0",
     "ts-node": "^10.4.0",
     "typescript": "~4.5.2"
   },
   "dependencies": {
-    "@aws-cdk/assert": "^2.0.0",
-    "@aws-cdk/assertions": "^1.134.0",
-    "@aws-cdk/aws-rds": "^1.134.0",
-    "@aws-cdk/aws-s3": "^1.134.0",
-    "@aws-cdk/core": "^1.134.0",
-    "aws-cdk-lib": "2.0.0",
+    "aws-cdk-lib": "^2.13.0",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.21"
   }

--- a/auroraserverless-secretsmanager/CDK/test/cdk.test.ts
+++ b/auroraserverless-secretsmanager/CDK/test/cdk.test.ts
@@ -1,6 +1,6 @@
 import { CdkStack } from '../lib/cdk-stack';
-import * as cdk from '@aws-cdk/core';
-import { Template } from "@aws-cdk/assertions";
+import * as cdk from 'aws-cdk-lib';
+import { Template } from "aws-cdk-lib/assertions";
 
 
 test('Validate stack resources', () => {


### PR DESCRIPTION
*Issue #, if available:* closes #482

*Description of changes:*
Migrated pattern from CDK v1 to CDK v2.

Changes include:

* updating feature flags in cdk.json
* dependency updates in package.json
* updating imports to use the new constructs and consolidated aws-cdk-lib libraries


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
