### PR TITLE
migrated to AWS CDK v2 (typescript)

### DIFF
--- a/cdk-appsync-sqs/cdk/bin/cdk-appsync-sqs.ts
+++ b/cdk-appsync-sqs/cdk/bin/cdk-appsync-sqs.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import * as cdk from '@aws-cdk/core'
+import * as cdk from 'aws-cdk-lib';
 import { CdkAppSyncSqSStack } from '../lib/main'
 
 const app = new cdk.App()

--- a/cdk-appsync-sqs/cdk/cdk.json
+++ b/cdk-appsync-sqs/cdk/cdk.json
@@ -1,17 +1,32 @@
 {
   "app": "npx ts-node --prefer-ts-exts bin/cdk-appsync-sqs.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
+    "@aws-cdk/core:stackRelativeExports": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
-    "@aws-cdk/aws-lambda:recognizeVersionProps": true
+    "@aws-cdk/aws-lambda:recognizeVersionProps": true,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
   }
 }

--- a/cdk-appsync-sqs/cdk/lib/main.ts
+++ b/cdk-appsync-sqs/cdk/lib/main.ts
@@ -1,7 +1,9 @@
-import * as sqs from '@aws-cdk/aws-sqs'
-import * as cdk from '@aws-cdk/core'
-import * as appsync from '@aws-cdk/aws-appsync'
-import { join } from 'path'
+
+import { Stack, StackProps, CfnOutput } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import {aws_sqs as sqs } from 'aws-cdk-lib';
+import * as appsync from '@aws-cdk/aws-appsync-alpha';
+import { join } from 'path';
 
 const REQUEST_TEMPLATE = (accountId: String, queue: sqs.Queue) => {
   return `
@@ -37,12 +39,12 @@ const RESPONSE_TEMPLATE = `
 #end
 `
 
-export class CdkAppSyncSqSStack extends cdk.Stack {
-  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+export class CdkAppSyncSqSStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props)
 
-    const region = cdk.Stack.of(this).region
-    const account = cdk.Stack.of(this).account
+    const region = Stack.of(this).region
+    const account = Stack.of(this).account
 
     const api = new appsync.GraphqlApi(this, 'Api', {
       name: 'ToSqSApi',
@@ -63,9 +65,9 @@ export class CdkAppSyncSqSStack extends cdk.Stack {
       responseMappingTemplate: appsync.MappingTemplate.fromString(RESPONSE_TEMPLATE),
     })
 
-    new cdk.CfnOutput(this, 'graphqlUrl', { value: api.graphqlUrl })
-    new cdk.CfnOutput(this, 'apiKey', { value: api.apiKey! })
-    new cdk.CfnOutput(this, 'apiId', { value: api.apiId })
-    new cdk.CfnOutput(this, 'queueUrl', { value: queue.queueUrl })
+    new CfnOutput(this, 'graphqlUrl', { value: api.graphqlUrl })
+    new CfnOutput(this, 'apiKey', { value: api.apiKey! })
+    new CfnOutput(this, 'apiId', { value: api.apiId })
+    new CfnOutput(this, 'queueUrl', { value: queue.queueUrl })
   }
 }

--- a/cdk-appsync-sqs/cdk/package.json
+++ b/cdk-appsync-sqs/cdk/package.json
@@ -11,18 +11,17 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.110.0",
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
-    "aws-cdk": "1.110.0",
+    "aws-cdk": "^2.13.0",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-appsync": "1.110.0",
-    "@aws-cdk/aws-sqs": "1.110.0",
-    "@aws-cdk/core": "1.110.0"
+    "@aws-cdk/aws-appsync-alpha": "^2.15.0-alpha.0",
+    "aws-cdk-lib": "^2.13.0",
+    "constructs": "^10.0.0"
   }
 }


### PR DESCRIPTION
*Issue #, if available:* closes #484

*Description of changes:*
Migrated pattern from CDK v1 to CDK v2.

Changes include:

* updating feature flags in cdk.json
* dependency updates in package.json
* updating imports to use the new constructs and consolidated aws-cdk-lib libraries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
