### PR TITLE
migrated to AWS CDK v2 (typescript)

### DIFF
--- a/cdk-cloudfront-to-s3-and-lambda/api/package.json
+++ b/cdk-cloudfront-to-s3-and-lambda/api/package.json
@@ -12,6 +12,10 @@
     "cool-ascii-faces": "^1.3.4"
   },
   "devDependencies": {
-    "typescript": "^4.2.3"
+    "@types/aws-lambda": "^8.10.93",
+    "@types/node": "10.17.27",
+    "esbuild": "^0.14.20",
+    "ts-node": "^9.0.0",
+    "typescript": "~3.9.7"
   }
 }

--- a/cdk-cloudfront-to-s3-and-lambda/cdk/bin/static-site.ts
+++ b/cdk-cloudfront-to-s3-and-lambda/cdk/bin/static-site.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
 import { StaticSiteStack } from '../lib/static-site-stack';
 
 const app = new cdk.App();

--- a/cdk-cloudfront-to-s3-and-lambda/cdk/cdk.json
+++ b/cdk-cloudfront-to-s3-and-lambda/cdk/cdk.json
@@ -1,13 +1,32 @@
 {
   "app": "npx ts-node --prefer-ts-exts bin/static-site.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
   "context": {
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true
+    "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
+    "@aws-cdk/core:stackRelativeExports": true,
+    "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
+    "@aws-cdk/aws-lambda:recognizeVersionProps": true,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
   }
 }

--- a/cdk-cloudfront-to-s3-and-lambda/cdk/lib/static-site-stack.ts
+++ b/cdk-cloudfront-to-s3-and-lambda/cdk/lib/static-site-stack.ts
@@ -1,16 +1,16 @@
-import * as cdk from "@aws-cdk/core";
-import * as lambda from "@aws-cdk/aws-lambda";
-import * as lambdaNode from "@aws-cdk/aws-lambda-nodejs";
+import { Stack, StackProps, Duration, CfnOutput } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { aws_lambda as  lambda } from 'aws-cdk-lib';
+import { aws_lambda_nodejs as lambdaNode } from 'aws-cdk-lib';
+import { aws_iam as iam } from 'aws-cdk-lib';
+import { aws_cloudfront as cloudfront } from 'aws-cdk-lib';
+import { aws_s3 as s3 } from 'aws-cdk-lib';
+import { aws_s3_deployment as s3Deployment } from 'aws-cdk-lib';
+import { aws_apigateway as apigw } from 'aws-cdk-lib';
 import * as path from "path";
-import * as apigw from "@aws-cdk/aws-apigateway";
-import * as s3 from "@aws-cdk/aws-s3";
-import * as s3Deployment from "@aws-cdk/aws-s3-deployment";
-import * as cloudfront from "@aws-cdk/aws-cloudfront";
-import * as iam from "@aws-cdk/aws-iam";
-import {Duration} from "@aws-cdk/core";
 
-export class StaticSiteStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+export class StaticSiteStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
     const apiDefaultHandler = new lambdaNode.NodejsFunction(
@@ -71,8 +71,8 @@ export class StaticSiteStack extends cdk.Stack {
     const staticBucket = new s3.Bucket(this, "staticBucket", {
       encryption: s3.BucketEncryption.S3_MANAGED,
       lifecycleRules: [
-        { abortIncompleteMultipartUploadAfter: cdk.Duration.days(7) },
-        { noncurrentVersionExpiration: cdk.Duration.days(7) },
+        { abortIncompleteMultipartUploadAfter: Duration.days(7) },
+        { noncurrentVersionExpiration: Duration.days(7) },
       ],
       blockPublicAccess: {
         blockPublicAcls: true,
@@ -137,8 +137,8 @@ export class StaticSiteStack extends cdk.Stack {
         {
           customOriginSource: {
             domainName: `${apiGateway.restApiId}.execute-api.${this.region}.${this.urlSuffix}`,
+            originPath: `/${apiGateway.deploymentStage.stageName}`
           },
-          originPath: `/${apiGateway.deploymentStage.stageName}`,
           behaviors: [
             {
               lambdaFunctionAssociations: [
@@ -172,6 +172,6 @@ export class StaticSiteStack extends cdk.Stack {
         },
       ],
     });
-    new cdk.CfnOutput(this, "distributionDomainName", { value: distribution.distributionDomainName });
+    new CfnOutput(this, "distributionDomainName", { value: distribution.distributionDomainName });
   }
 }

--- a/cdk-cloudfront-to-s3-and-lambda/cdk/package.json
+++ b/cdk-cloudfront-to-s3-and-lambda/cdk/package.json
@@ -11,24 +11,18 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.95.1",
-    "@aws-cdk/aws-apigateway": "1.95.1",
-    "@aws-cdk/aws-cloudfront": "1.95.1",
-    "@aws-cdk/aws-iam": "1.95.1",
-    "@aws-cdk/aws-lambda-nodejs": "1.95.1",
-    "@aws-cdk/aws-s3": "1.95.1",
-    "@aws-cdk/aws-s3-deployment": "1.95.1",
+    "@types/aws-lambda": "^8.10.93",
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
-    "aws-cdk": "1.95.1",
-    "esbuild": "^0.10.0",
+    "esbuild": "^0.14.20",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",
-    "@aws-cdk/core": "1.95.1",
-    "@types/aws-lambda": "^8.10.73",
-    "aws-lambda": "^1.0.6",
-    "source-map-support": "^0.5.16",
     "typescript": "~3.9.7"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.13.0",
+    "constructs": "^10.0.0",
+    "source-map-support": "^0.5.16"
   }
 }

--- a/cdk-cloudfront-to-s3-and-lambda/cdk/test/static-site.test.ts
+++ b/cdk-cloudfront-to-s3-and-lambda/cdk/test/static-site.test.ts
@@ -1,5 +1,5 @@
-import { expect as expectCDK, matchTemplate, MatchStyle } from '@aws-cdk/assert';
-import * as cdk from '@aws-cdk/core';
+import { Template } from 'aws-cdk-lib/assertions';
+import * as cdk from 'aws-cdk-lib';
 import * as StaticSite from '../lib/static-site-stack';
 
 test('Empty Stack', () => {
@@ -7,7 +7,5 @@ test('Empty Stack', () => {
     // WHEN
     const stack = new StaticSite.StaticSiteStack(app, 'MyTestStack');
     // THEN
-    expectCDK(stack).to(matchTemplate({
-      "Resources": {}
-    }, MatchStyle.EXACT))
+    Template.fromStack(stack).hasResource("AWS::Lambda::Function", {});
 });


### PR DESCRIPTION
*Issue #, if available:* closes #485

*Description of changes:*
Migrated pattern from CDK v1 to CDK v2.

Changes include:

* updating feature flags in cdk.json
* dependency updates in package.json
* updating imports to use the new constructs and consolidated aws-cdk-lib libraries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
