### PR TITLE
migrated to AWS CDK v2 (typescript)

### DIFF
--- a/cdk-codecommit-codepipeline-sfn-athena-glue/app.ts
+++ b/cdk-codecommit-codepipeline-sfn-athena-glue/app.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
-import { App, Stack } from '@aws-cdk/core';
-import { StepFunctionInvokeAction } from '@aws-cdk/aws-codepipeline-actions';
-import { PolicyStatement, Effect } from '@aws-cdk/aws-iam';
+
+import { App, Stack } from 'aws-cdk-lib';
+import { StepFunctionInvokeAction } from 'aws-cdk-lib/aws-codepipeline-actions';
+import { PolicyStatement, Effect } from 'aws-cdk-lib/aws-iam';
 
 import { DemoPipeline } from './src/stacks/stack_pipeline';
 import { S3GlueStack } from './src/stacks/stack_s3buckets';

--- a/cdk-codecommit-codepipeline-sfn-athena-glue/cdk.json
+++ b/cdk-codecommit-codepipeline-sfn-athena-glue/cdk.json
@@ -1,19 +1,32 @@
 {
   "app": "npx ts-node --prefer-ts-exts app.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": true,
-    "aws-cdk:enableDiffNoFail": true,
     "@aws-cdk/core:stackRelativeExports": true,
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
     "@aws-cdk/aws-lambda:recognizeVersionProps": true,
     "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
-    "@aws-cdk/core:newStyleStackSynthesis": true
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
   }
 }

--- a/cdk-codecommit-codepipeline-sfn-athena-glue/package.json
+++ b/cdk-codecommit-codepipeline-sfn-athena-glue/package.json
@@ -7,27 +7,17 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/assertions": "^1.132.0",
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
-    "aws-cdk": "^1.132.0",
+    "aws-cdk": "^2.13.0",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-athena": "^1.132.0",
-    "@aws-cdk/aws-codecommit": "^1.132.0",
-    "@aws-cdk/aws-codepipeline": "^1.132.0",
-    "@aws-cdk/aws-codepipeline-actions": "^1.132.0",
-    "@aws-cdk/aws-glue": "^1.132.0",
-    "@aws-cdk/aws-iam": "^1.132.0",
-    "@aws-cdk/aws-logs": "^1.132.0",
-    "@aws-cdk/aws-s3": "^1.132.0",
-    "@aws-cdk/aws-stepfunctions": "^1.132.0",
-    "@aws-cdk/aws-stepfunctions-tasks": "^1.132.0",
-    "@aws-cdk/core": "^1.132.0",
-    "@aws-cdk/pipelines": "^1.132.0",
+    "@aws-cdk/aws-glue-alpha": "^2.15.0-alpha.0",
+    "aws-cdk-lib": "^2.13.0",
+    "constructs": "^10.0.0",
     "source-map-support": "^0.5.16"
   }
 }

--- a/cdk-codecommit-codepipeline-sfn-athena-glue/src/helpers/interfaces.ts
+++ b/cdk-codecommit-codepipeline-sfn-athena-glue/src/helpers/interfaces.ts
@@ -1,7 +1,7 @@
-import { StackProps  } from '@aws-cdk/core';
-import { IBucket  } from '@aws-cdk/aws-s3';
-import { IDatabase } from '@aws-cdk/aws-glue';
-import { CfnNamedQuery } from '@aws-cdk/aws-athena';
+import { StackProps  } from 'aws-cdk-lib';
+import { IBucket  } from 'aws-cdk-lib/aws-s3';
+import { IDatabase } from '@aws-cdk/aws-glue-alpha';
+import { CfnNamedQuery } from 'aws-cdk-lib/aws-athena';
 
 export interface s3BucketProps extends StackProps {
     s3EmpMaster: IBucket,

--- a/cdk-codecommit-codepipeline-sfn-athena-glue/src/stacks/stack_athena.ts
+++ b/cdk-codecommit-codepipeline-sfn-athena-glue/src/stacks/stack_athena.ts
@@ -1,7 +1,8 @@
-import { Stack, Construct, RemovalPolicy, Duration} from '@aws-cdk/core';
-import { CfnWorkGroup, CfnNamedQuery } from '@aws-cdk/aws-athena';
-import { AthenaStartQueryExecution, EncryptionOption } from '@aws-cdk/aws-stepfunctions-tasks';
-import { IntegrationPattern, StateMachine, IStateMachine, LogLevel} from '@aws-cdk/aws-stepfunctions';
+import { Stack, RemovalPolicy, Duration} from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { CfnWorkGroup, CfnNamedQuery } from 'aws-cdk-lib/aws-athena';
+import { AthenaStartQueryExecution, EncryptionOption } from 'aws-cdk-lib/aws-stepfunctions-tasks';
+import { IntegrationPattern, StateMachine, IStateMachine, LogLevel} from 'aws-cdk-lib/aws-stepfunctions';
 
 import * as fs from 'fs';
 import * as path from 'path';

--- a/cdk-codecommit-codepipeline-sfn-athena-glue/src/stacks/stack_glue.ts
+++ b/cdk-codecommit-codepipeline-sfn-athena-glue/src/stacks/stack_glue.ts
@@ -1,5 +1,6 @@
-import { Stack, Construct, StackProps } from '@aws-cdk/core';
-import { Schema, Database, Table, IDatabase, ITable, CfnTable, DataFormat } from '@aws-cdk/aws-glue';
+import { Stack, StackProps } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Schema, Database, Table, IDatabase, ITable, DataFormat } from '@aws-cdk/aws-glue-alpha';
 
 import { config } from '../config';
 import { s3BucketProps } from '../helpers/interfaces';

--- a/cdk-codecommit-codepipeline-sfn-athena-glue/src/stacks/stack_pipeline.ts
+++ b/cdk-codecommit-codepipeline-sfn-athena-glue/src/stacks/stack_pipeline.ts
@@ -1,6 +1,7 @@
-import { Construct, Stack, StackProps } from '@aws-cdk/core';
-import { Repository } from '@aws-cdk/aws-codecommit';
-import { CodePipeline, ShellStep, CodePipelineSource } from "@aws-cdk/pipelines";
+import { Stack, StackProps } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Repository } from 'aws-cdk-lib/aws-codecommit';
+import { CodePipeline, ShellStep, CodePipelineSource } from "aws-cdk-lib/pipelines";
 
 import { config } from '../config';
 

--- a/cdk-codecommit-codepipeline-sfn-athena-glue/src/stacks/stack_s3buckets.ts
+++ b/cdk-codecommit-codepipeline-sfn-athena-glue/src/stacks/stack_s3buckets.ts
@@ -1,5 +1,6 @@
-import { Construct, RemovalPolicy, Stack, StackProps } from '@aws-cdk/core';
-import { BlockPublicAccess, Bucket, IBucket } from '@aws-cdk/aws-s3';
+import { RemovalPolicy, Stack, StackProps } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { BlockPublicAccess, Bucket, IBucket } from 'aws-cdk-lib/aws-s3';
 import { config } from '../config';
 
 


### PR DESCRIPTION
*Issue #, if available:* closes #487

*Description of changes:*
Migrated pattern from CDK v1 to CDK v2.

Changes include:

* updating feature flags in cdk.json
* dependency updates in package.json
* updating imports to use the new constructs and consolidated aws-cdk-lib libraries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
