### PR TITLE
migrated to AWS CDK v2 (typescript)

### DIFF
--- a/cdk-eventbridge-stepfunction/bin/cdk-eventbridge-stepfunction.ts
+++ b/cdk-eventbridge-stepfunction/bin/cdk-eventbridge-stepfunction.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
 import { CdkEventbridgeStepfunctionStack } from '../lib/cdk-eventbridge-stepfunction-stack';
 
 const app = new cdk.App();

--- a/cdk-eventbridge-stepfunction/cdk.json
+++ b/cdk-eventbridge-stepfunction/cdk.json
@@ -1,16 +1,32 @@
 {
   "app": "npx ts-node --prefer-ts-exts bin/cdk-eventbridge-stepfunction.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
+    "@aws-cdk/core:stackRelativeExports": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true
+    "@aws-cdk/aws-lambda:recognizeVersionProps": true,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
   }
 }

--- a/cdk-eventbridge-stepfunction/lib/cdk-eventbridge-stepfunction-stack.ts
+++ b/cdk-eventbridge-stepfunction/lib/cdk-eventbridge-stepfunction-stack.ts
@@ -1,22 +1,23 @@
-import * as cdk from "@aws-cdk/core";
+import { Stack, StackProps, CfnOutput, Duration } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 import * as path from "path";
-import * as lambda from "@aws-cdk/aws-lambda";
-import * as lambdaNode from "@aws-cdk/aws-lambda-nodejs";
-import * as sfn from "@aws-cdk/aws-stepfunctions";
-import * as tasks from "@aws-cdk/aws-stepfunctions-tasks";
-import * as events from "@aws-cdk/aws-events";
-import { EventBus } from "@aws-cdk/aws-events";
-import * as eventsTarget from "@aws-cdk/aws-events-targets";
+import { aws_lambda as lambda } from "aws-cdk-lib";
+import { aws_lambda_nodejs as lambdaNode } from "aws-cdk-lib";
+import { aws_stepfunctions as sfn } from "aws-cdk-lib";
+import { aws_stepfunctions_tasks as tasks } from "aws-cdk-lib";
+import { aws_events as events } from "aws-cdk-lib";
+import { aws_events_targets as eventsTarget } from "aws-cdk-lib";
+
 import {EventBridgeTypes} from "../handlers/stepfunctions/waitUntil/sendReminder";
 
-export class CdkEventbridgeStepfunctionStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+export class CdkEventbridgeStepfunctionStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
     // Create an EventBus to receive and send events.
-    const bus = new EventBus(this, "reminderEventBus");
+    const bus = new events.EventBus(this, "reminderEventBus");
     // Output the name of the new bus.
-    new cdk.CfnOutput(this, "reminderBus", { value: bus.eventBusName });
+    new CfnOutput(this, "reminderBus", { value: bus.eventBusName });
 
     // Define the wait task.
     // Because we're subscribing to an EventBridge event, the "at" field
@@ -62,7 +63,7 @@ export class CdkEventbridgeStepfunctionStack extends cdk.Stack {
     // Construct the state machine.
     const reminderMachine = new sfn.StateMachine(this, "reminder", {
       definition: reminderMachineDefinition,
-      timeout: cdk.Duration.days(90),
+      timeout: Duration.days(90),
     });
 
     // Configure EventBridge to start the reminder machine when a remind event is received.

--- a/cdk-eventbridge-stepfunction/package.json
+++ b/cdk-eventbridge-stepfunction/package.json
@@ -11,17 +11,10 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.100.0",
-    "@aws-cdk/aws-events": "^1.100.0",
-    "@aws-cdk/aws-events-targets": "^1.100.0",
-    "@aws-cdk/aws-lambda": "^1.100.0",
-    "@aws-cdk/aws-lambda-nodejs": "^1.100.0",
-    "@aws-cdk/aws-stepfunctions": "^1.100.0",
-    "@aws-cdk/aws-stepfunctions-tasks": "^1.100.0",
+    "aws-cdk": "^2.13.0",
     "@types/aws-lambda": "^8.10.75",
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
-    "aws-cdk": "1.100.0",
     "esbuild": "^0.11.13",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
@@ -29,7 +22,8 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/core": "1.100.0",
+    "aws-cdk-lib": "^2.13.0",
+    "constructs": "^10.0.0",
     "aws-lambda": "^1.0.6",
     "source-map-support": "^0.5.16"
   }

--- a/cdk-eventbridge-stepfunction/test/cdk-eventbridge-stepfunction.test.ts
+++ b/cdk-eventbridge-stepfunction/test/cdk-eventbridge-stepfunction.test.ts
@@ -1,5 +1,5 @@
-import { expect as expectCDK, matchTemplate, MatchStyle } from '@aws-cdk/assert';
-import * as cdk from '@aws-cdk/core';
+import { Template } from 'aws-cdk-lib/assertions';
+import * as cdk from 'aws-cdk-lib';
 import * as CdkEventbridgeStepfunction from '../lib/cdk-eventbridge-stepfunction-stack';
 
 test('Empty Stack', () => {
@@ -7,7 +7,6 @@ test('Empty Stack', () => {
     // WHEN
     const stack = new CdkEventbridgeStepfunction.CdkEventbridgeStepfunctionStack(app, 'MyTestStack');
     // THEN
-    expectCDK(stack).to(matchTemplate({
-      "Resources": {}
-    }, MatchStyle.EXACT))
+    Template.fromStack(stack).hasResource("AWS::Lambda::Function", {})
+
 });


### PR DESCRIPTION
*Issue #, if available:* closes #490

*Description of changes:*
Migrated pattern from CDK v1 to CDK v2.

Changes include:

* updating feature flags in cdk.json
* dependency updates in package.json
* updating imports to use the new constructs and consolidated aws-cdk-lib libraries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
