### PR TITLE
migrated to AWS CDK v2 (typescript)

### DIFF
--- a/cdk-vpc-lambda-sfn/app.ts
+++ b/cdk-vpc-lambda-sfn/app.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
-import { App } from '@aws-cdk/core';
+import { App } from 'aws-cdk-lib';
 
 import { vpcStack } from './src/stacks/vpc_stack';
 import { lambdaStack } from './src/stacks/lambda_stack';

--- a/cdk-vpc-lambda-sfn/cdk.json
+++ b/cdk-vpc-lambda-sfn/cdk.json
@@ -1,19 +1,32 @@
 {
   "app": "npx ts-node --prefer-ts-exts app.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": true,
-    "aws-cdk:enableDiffNoFail": true,
     "@aws-cdk/core:stackRelativeExports": true,
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
     "@aws-cdk/aws-lambda:recognizeVersionProps": true,
     "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
-    "@aws-cdk/core:newStyleStackSynthesis": true
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
   }
 }

--- a/cdk-vpc-lambda-sfn/package.json
+++ b/cdk-vpc-lambda-sfn/package.json
@@ -11,22 +11,16 @@
     "lambda": "cd ./src/lambda_code && npm i"
   },
   "devDependencies": {
-    "@aws-cdk/assertions": "^1.138.0",
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
-    "aws-cdk": "1.138.0",
+    "aws-cdk": "^2.13.0",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-ec2": "^1.138.0",
-    "@aws-cdk/aws-iam": "^1.138.0",
-    "@aws-cdk/aws-lambda": "^1.138.0",
-    "@aws-cdk/aws-logs": "^1.138.0",
-    "@aws-cdk/aws-stepfunctions": "^1.138.0",
-    "@aws-cdk/aws-stepfunctions-tasks": "^1.138.0",
-    "@aws-cdk/core": "^1.138.0",
+    "aws-cdk-lib": "^2.13.0",
+    "constructs": "^10.0.0",
     "source-map-support": "^0.5.16"
   }
 }

--- a/cdk-vpc-lambda-sfn/src/stacks/lambda_stack.ts
+++ b/cdk-vpc-lambda-sfn/src/stacks/lambda_stack.ts
@@ -1,7 +1,8 @@
-import { Function, IFunction, Code, Architecture, Runtime } from '@aws-cdk/aws-lambda';
-import { Policy, Effect, PolicyStatement } from '@aws-cdk/aws-iam';
-import { RetentionDays } from '@aws-cdk/aws-logs';
-import { Stack, StackProps, Construct } from '@aws-cdk/core';
+import { Function, IFunction, Code, Architecture, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { Policy, Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { Stack, StackProps } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 
 import * as path from 'path';
 import { vpcProps, vpcStack } from './vpc_stack';

--- a/cdk-vpc-lambda-sfn/src/stacks/sfn_stack.ts
+++ b/cdk-vpc-lambda-sfn/src/stacks/sfn_stack.ts
@@ -1,8 +1,9 @@
-import { Stack, Construct, RemovalPolicy } from '@aws-cdk/core';
-import { LambdaInvoke } from '@aws-cdk/aws-stepfunctions-tasks';
-import { StateMachine, LogLevel, IStateMachine } from '@aws-cdk/aws-stepfunctions';
-import { LogGroup } from '@aws-cdk/aws-logs';
-import { RetentionDays } from '@aws-cdk/aws-logs';
+import { Stack, RemovalPolicy } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { LambdaInvoke } from 'aws-cdk-lib/aws-stepfunctions-tasks';
+import { StateMachine, LogLevel, IStateMachine } from 'aws-cdk-lib/aws-stepfunctions';
+import { LogGroup } from 'aws-cdk-lib/aws-logs';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 
 import { lambdaProps } from './lambda_stack';
 

--- a/cdk-vpc-lambda-sfn/src/stacks/vpc_stack.ts
+++ b/cdk-vpc-lambda-sfn/src/stacks/vpc_stack.ts
@@ -1,8 +1,9 @@
-import { Stack, StackProps, Aspects, Tag, Construct } from '@aws-cdk/core';
+import { Stack, StackProps, Aspects, Tag } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 import {
     InterfaceVpcEndpointAwsService,
     ISecurityGroup, ISubnet, SecurityGroup, SubnetType, Vpc, Peer, Port, IVpc
-} from '@aws-cdk/aws-ec2';
+} from 'aws-cdk-lib/aws-ec2';
 
 
 export class vpcStack extends Stack {


### PR DESCRIPTION
*Issue #, if available:* closes #492

*Description of changes:*
Migrated pattern from CDK v1 to CDK v2.

Changes include:

* updating feature flags in cdk.json
* dependency updates in package.json
* updating imports to use the new constructs and consolidated aws-cdk-lib libraries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
