### PR TITLE
migrated to AWS CDK v2 (typescript)

### DIFF
--- a/dynamodb-lambda-cdk/src/bin/dynamo-to-lambda-cdk.ts
+++ b/dynamodb-lambda-cdk/src/bin/dynamo-to-lambda-cdk.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
 import { DynamoToLambdaCdkStack } from '../lib/dynamo-to-lambda-cdk-stack';
 
 const app = new cdk.App();

--- a/dynamodb-lambda-cdk/src/cdk.json
+++ b/dynamodb-lambda-cdk/src/cdk.json
@@ -1,17 +1,32 @@
 {
   "app": "npx ts-node --prefer-ts-exts bin/dynamo-to-lambda-cdk.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
+    "@aws-cdk/core:stackRelativeExports": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
-    "@aws-cdk/aws-lambda:recognizeVersionProps": true
+    "@aws-cdk/aws-lambda:recognizeVersionProps": true,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
   }
 }

--- a/dynamodb-lambda-cdk/src/lib/dynamo-to-lambda-cdk-stack.ts
+++ b/dynamodb-lambda-cdk/src/lib/dynamo-to-lambda-cdk-stack.ts
@@ -1,12 +1,13 @@
-import * as cdk from '@aws-cdk/core';
-import { Table, BillingMode, AttributeType, StreamViewType } from '@aws-cdk/aws-dynamodb';
-import { NodejsFunction } from '@aws-cdk/aws-lambda-nodejs';
-import * as lambda from '@aws-cdk/aws-lambda';
+import { Stack, StackProps, CfnOutput } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Table, BillingMode, AttributeType, StreamViewType } from 'aws-cdk-lib/aws-dynamodb';
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { aws_lambda as lambda }from 'aws-cdk-lib';
 import * as path from 'path';
-import { DynamoEventSource } from '@aws-cdk/aws-lambda-event-sources';
+import { DynamoEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
 
-export class DynamoToLambdaCdkStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+export class DynamoToLambdaCdkStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
     // DynamoDB table
     const dynamoTable = new Table(this, 'DynamoTable', {
@@ -31,7 +32,7 @@ export class DynamoToLambdaCdkStack extends cdk.Stack {
     }))
 
     // Outputs
-    new cdk.CfnOutput(this, 'DynamoDbTableName', { value: dynamoTable.tableName });
-    new cdk.CfnOutput(this, 'LambdaFunctionArn', { value: lambdaReadStream.functionArn });
+    new CfnOutput(this, 'DynamoDbTableName', { value: dynamoTable.tableName });
+    new CfnOutput(this, 'LambdaFunctionArn', { value: lambdaReadStream.functionArn });
   }
 }

--- a/dynamodb-lambda-cdk/src/package.json
+++ b/dynamodb-lambda-cdk/src/package.json
@@ -11,20 +11,16 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.116.0",
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
-    "aws-cdk": "^1.127.0",
+    "aws-cdk": "^2.13.0",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-dynamodb": "^1.127.0",
-    "@aws-cdk/aws-lambda": "^1.127.0",
-    "@aws-cdk/aws-lambda-event-sources": "^1.127.0",
-    "@aws-cdk/aws-lambda-nodejs": "^1.127.0",
-    "@aws-cdk/core": "^1.127.0"
+    "aws-cdk-lib": "^2.13.0",
+    "constructs": "^10.0.0"
   }
 }


### PR DESCRIPTION
*Issue #, if available:* closes #494

*Description of changes:*
Migrated pattern from CDK v1 to CDK v2.

Changes include:

* updating feature flags in cdk.json
* dependency updates in package.json
* updating imports to use the new constructs and consolidated aws-cdk-lib libraries


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
