### PR TITLE
migrated to AWS CDK v2 (typescript)

### DIFF
--- a/eventbridge-scheduled-lambda-cdk-typescript/bin/eventbridge-scheduled-lambda-cdk.ts
+++ b/eventbridge-scheduled-lambda-cdk-typescript/bin/eventbridge-scheduled-lambda-cdk.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
 import { EventbridgeScheduledLambdaCdkStack } from '../lib/eventbridge-scheduled-lambda-cdk-stack';
 
 const app = new cdk.App();

--- a/eventbridge-scheduled-lambda-cdk-typescript/cdk.json
+++ b/eventbridge-scheduled-lambda-cdk-typescript/cdk.json
@@ -1,18 +1,32 @@
 {
   "app": "npx ts-node --prefer-ts-exts bin/eventbridge-scheduled-lambda-cdk.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": true,
-    "aws-cdk:enableDiffNoFail": true,
     "@aws-cdk/core:stackRelativeExports": true,
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
     "@aws-cdk/aws-lambda:recognizeVersionProps": true,
-    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
   }
 }

--- a/eventbridge-scheduled-lambda-cdk-typescript/lib/eventbridge-scheduled-lambda-cdk-stack.ts
+++ b/eventbridge-scheduled-lambda-cdk-typescript/lib/eventbridge-scheduled-lambda-cdk-stack.ts
@@ -1,11 +1,12 @@
-import * as cdk from '@aws-cdk/core';
-import * as lambda from '@aws-cdk/aws-lambda';
-import { Rule, Schedule } from "@aws-cdk/aws-events";
-import {LambdaFunction} from "@aws-cdk/aws-events-targets";
+import { Stack, StackProps, Duration } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import {aws_lambda as lambda } from 'aws-cdk-lib';
+import { Rule, Schedule } from "aws-cdk-lib/aws-events";
+import {LambdaFunction} from "aws-cdk-lib/aws-events-targets";
 import * as path from 'path';
 
-export class EventbridgeScheduledLambdaCdkStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+export class EventbridgeScheduledLambdaCdkStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
     // get interval in minutes from context (cdk deploy --context interval_in_minutes=<value>)
@@ -26,7 +27,7 @@ export class EventbridgeScheduledLambdaCdkStack extends cdk.Stack {
     const myFunction = new lambda.Function(this, 'function-name', {
       runtime: lambda.Runtime.NODEJS_14_X,
       memorySize: 128,
-      timeout: cdk.Duration.seconds(30),
+      timeout: Duration.seconds(30),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '/../src')),
       // create environment variable with the interval assigned with --context

--- a/eventbridge-scheduled-lambda-cdk-typescript/package.json
+++ b/eventbridge-scheduled-lambda-cdk-typescript/package.json
@@ -11,20 +11,17 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.129.0",
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
-    "aws-cdk": "1.129.0",
+    "aws-cdk": "^2.13.0",
     "ts-node": "^9.0.0",
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-events": "^1.129.0",
-    "@aws-cdk/aws-events-targets": "^1.129.0",
-    "@aws-cdk/aws-lambda": "^1.129.0",
-    "@aws-cdk/core": "1.129.0",
+    "aws-cdk-lib": "^2.13.0",
+    "constructs": "^10.0.0",
     "source-map-support": "^0.5.16"
   }
 }

--- a/eventbridge-scheduled-lambda-cdk-typescript/test/eventbridge-scheduled-lambda-cdk.test.ts
+++ b/eventbridge-scheduled-lambda-cdk-typescript/test/eventbridge-scheduled-lambda-cdk.test.ts
@@ -1,13 +1,12 @@
-import { expect as expectCDK, matchTemplate, MatchStyle } from '@aws-cdk/assert';
-import * as cdk from '@aws-cdk/core';
+import { Template } from 'aws-cdk-lib/assertions';
+import * as cdk from 'aws-cdk-lib';
 import * as EventbridgeScheduledLambdaCdk from '../lib/eventbridge-scheduled-lambda-cdk-stack';
 
 test('Empty Stack', () => {
     const app = new cdk.App();
+
     // WHEN
     const stack = new EventbridgeScheduledLambdaCdk.EventbridgeScheduledLambdaCdkStack(app, 'MyTestStack');
     // THEN
-    expectCDK(stack).to(matchTemplate({
-      "Resources": {}
-    }, MatchStyle.EXACT))
+    Template.fromStack(stack).hasResource("AWS::Lambda::Function", {});
 });


### PR DESCRIPTION
*Issue #, if available:* closes #495

*Description of changes:*
Migrated pattern from CDK v1 to CDK v2.

Changes include:

* updating feature flags in cdk.json
* dependency updates in package.json
* updating imports to use the new constructs and consolidated aws-cdk-lib libraries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
