### PR TITLE
migrated to AWS CDK v2 (typescript)

### DIFF
--- a/fargate-aurora-serverless-cdk/cdk/bin/cdk.ts
+++ b/fargate-aurora-serverless-cdk/cdk/bin/cdk.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
 import { CdkStack } from '../lib/cdk-stack';
 
 const app = new cdk.App();

--- a/fargate-aurora-serverless-cdk/cdk/cdk.json
+++ b/fargate-aurora-serverless-cdk/cdk/cdk.json
@@ -1,18 +1,32 @@
 {
   "app": "npx ts-node --prefer-ts-exts bin/cdk.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": true,
-    "aws-cdk:enableDiffNoFail": true,
     "@aws-cdk/core:stackRelativeExports": true,
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
     "@aws-cdk/aws-lambda:recognizeVersionProps": true,
-    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
   }
 }

--- a/fargate-aurora-serverless-cdk/cdk/lib/cdk-stack.ts
+++ b/fargate-aurora-serverless-cdk/cdk/lib/cdk-stack.ts
@@ -1,9 +1,10 @@
-import { Construct, Duration, Stack, StackProps} from '@aws-cdk/core';
-import { AuroraCapacityUnit, Credentials, DatabaseClusterEngine, ServerlessCluster } from '@aws-cdk/aws-rds';
-import { Vpc } from '@aws-cdk/aws-ec2';
-import { Secret } from '@aws-cdk/aws-secretsmanager';
-import { Cluster, ContainerImage } from '@aws-cdk/aws-ecs';
-import { ApplicationLoadBalancedFargateService } from '@aws-cdk/aws-ecs-patterns';
+import { Duration, Stack, StackProps} from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { AuroraCapacityUnit, Credentials, DatabaseClusterEngine, ServerlessCluster } from 'aws-cdk-lib/aws-rds';
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
+import { Cluster, ContainerImage } from 'aws-cdk-lib/aws-ecs';
+import { ApplicationLoadBalancedFargateService } from 'aws-cdk-lib/aws-ecs-patterns';
 import path = require('path');
 
 export class CdkStack extends Stack {

--- a/fargate-aurora-serverless-cdk/cdk/package.json
+++ b/fargate-aurora-serverless-cdk/cdk/package.json
@@ -11,22 +11,17 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/assertions": "1.132.0",
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
-    "aws-cdk": "1.132.0",
+    "aws-cdk": "^2.13.0",
     "ts-node": "^9.0.0",
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-ec2": "1.132.0",
-    "@aws-cdk/aws-ecs": "1.132.0",
-    "@aws-cdk/aws-ecs-patterns": "1.132.0",
-    "@aws-cdk/aws-rds": "1.132.0",
-    "@aws-cdk/aws-secretsmanager": "1.132.0",
-    "@aws-cdk/core": "1.132.0",
+    "aws-cdk-lib": "^2.13.0",
+    "constructs": "^10.0.0",
     "source-map-support": "^0.5.16"
   }
 }

--- a/fargate-aurora-serverless-cdk/cdk/test/cdk.test.ts
+++ b/fargate-aurora-serverless-cdk/cdk/test/cdk.test.ts
@@ -1,5 +1,5 @@
-import { Template } from '@aws-cdk/assertions';
-import * as cdk from '@aws-cdk/core';
+import { Template } from 'aws-cdk-lib/assertions';
+import * as cdk from 'aws-cdk-lib';
 import * as Cdk from '../lib/cdk-stack';
 
 test('Validate stack resources', () => {


### PR DESCRIPTION
*Issue #, if available:* closes #496

*Description of changes:*

Migrated pattern from CDK v1 to CDK v2.

Changes include:

* updating feature flags in cdk.json
* dependency updates in package.json
* updating imports to use the new constructs and consolidated aws-cdk-lib libraries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
