### PR TITLE
migrated to AWS CDK v2 (typescript)

### DIFF
--- a/fargate-s3-cdk/cdk/bin/cdk.ts
+++ b/fargate-s3-cdk/cdk/bin/cdk.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
 import { CdkStack } from '../lib/cdk-stack';
 
 const app = new cdk.App();

--- a/fargate-s3-cdk/cdk/cdk.json
+++ b/fargate-s3-cdk/cdk/cdk.json
@@ -1,18 +1,32 @@
 {
   "app": "npx ts-node --prefer-ts-exts bin/cdk.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
+    "@aws-cdk/core:stackRelativeExports": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
     "@aws-cdk/aws-lambda:recognizeVersionProps": true,
-    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
   }
 }

--- a/fargate-s3-cdk/cdk/lib/cdk-stack.ts
+++ b/fargate-s3-cdk/cdk/lib/cdk-stack.ts
@@ -1,9 +1,10 @@
-import { Construct, RemovalPolicy, Stack, StackProps} from '@aws-cdk/core';
-import { BlockPublicAccess, Bucket, BucketEncryption, } from '@aws-cdk/aws-s3';
-import { GatewayVpcEndpointAwsService, Vpc } from '@aws-cdk/aws-ec2';
-import { Cluster, ContainerImage } from '@aws-cdk/aws-ecs';
-import { ApplicationLoadBalancedFargateService } from '@aws-cdk/aws-ecs-patterns';
-import { AnyPrincipal, Effect, PolicyStatement } from '@aws-cdk/aws-iam';
+import { RemovalPolicy, Stack, StackProps} from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { BlockPublicAccess, Bucket, BucketEncryption, } from 'aws-cdk-lib/aws-s3';
+import { GatewayVpcEndpointAwsService, Vpc } from 'aws-cdk-lib/aws-ec2';
+import { Cluster, ContainerImage } from 'aws-cdk-lib/aws-ecs';
+import { ApplicationLoadBalancedFargateService } from 'aws-cdk-lib/aws-ecs-patterns';
+import { AnyPrincipal, Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import path = require('path');
 
 export class CdkStack extends Stack {

--- a/fargate-s3-cdk/cdk/package.json
+++ b/fargate-s3-cdk/cdk/package.json
@@ -11,22 +11,17 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.130.0",
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
-    "aws-cdk": "1.130.0",
+    "aws-cdk": "^2.13.0",
     "ts-node": "^9.0.0",
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-ec2": "^1.130.0",
-    "@aws-cdk/aws-ecs": "^1.130.0",
-    "@aws-cdk/aws-ecs-patterns": "^1.130.0",
-    "@aws-cdk/aws-iam": "^1.130.0",
-    "@aws-cdk/aws-s3": "^1.130.0",
-    "@aws-cdk/core": "1.130.0",
+    "aws-cdk-lib": "^2.13.0",
+    "constructs": "^10.0.0",
     "source-map-support": "^0.5.16"
   }
 }

--- a/fargate-s3-cdk/cdk/test/cdk.test.ts
+++ b/fargate-s3-cdk/cdk/test/cdk.test.ts
@@ -1,14 +1,14 @@
-import { expect as expectCDK, haveResource } from '@aws-cdk/assert';
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
 import { CdkStack } from '../lib/cdk-stack';
 
 test('Validate stack resources', () => {
   const app = new cdk.App();
   const stack = new CdkStack(app, 'MyTestStack');
 
-  expectCDK(stack).to(haveResource('AWS::S3::Bucket'));
-  expectCDK(stack).to(haveResource('AWS::ECS::Cluster'));
-  expectCDK(stack).to(haveResource('AWS::ECS::TaskDefinition'));
-  expectCDK(stack).to(haveResource('AWS::ECS::Service'));
-  expectCDK(stack).to(haveResource('AWS::ElasticLoadBalancingV2::LoadBalancer'));
+  Template.fromStack(stack).hasResource('AWS::S3::Bucket', {});
+  Template.fromStack(stack).hasResource('AWS::ECS::Cluster', {});
+  Template.fromStack(stack).hasResource('AWS::ECS::TaskDefinition', {});
+  Template.fromStack(stack).hasResource('AWS::ECS::Service', {});
+  Template.fromStack(stack).hasResource('AWS::ElasticLoadBalancingV2::LoadBalancer', {});
 });


### PR DESCRIPTION
*Issue #, if available:* closes #499

*Description of changes:*
Migrated pattern from CDK v1 to CDK v2.

Changes include:

* updating feature flags in cdk.json
* dependency updates in package.json
* updating imports to use the new constructs and consolidated aws-cdk-lib libraries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
