### PR TITLE
migrated to AWS CDK v2 (typescript)

### DIFF
--- a/lambda-dynamodb-cdk/cdk/bin/cdk.ts
+++ b/lambda-dynamodb-cdk/cdk/bin/cdk.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
 import { CdkStack } from '../lib/cdk-stack';
 
 const app = new cdk.App();

--- a/lambda-dynamodb-cdk/cdk/cdk.json
+++ b/lambda-dynamodb-cdk/cdk/cdk.json
@@ -1,18 +1,32 @@
 {
   "app": "npx ts-node --prefer-ts-exts bin/cdk.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
+    "@aws-cdk/core:stackRelativeExports": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
     "@aws-cdk/aws-lambda:recognizeVersionProps": true,
-    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
   }
 }

--- a/lambda-dynamodb-cdk/cdk/lib/cdk-stack.ts
+++ b/lambda-dynamodb-cdk/cdk/lib/cdk-stack.ts
@@ -1,7 +1,8 @@
-import { CfnOutput, Construct, Duration, RemovalPolicy, Stack, StackProps} from '@aws-cdk/core';
-import { Table, BillingMode, AttributeType } from '@aws-cdk/aws-dynamodb';
-import { NodejsFunction } from '@aws-cdk/aws-lambda-nodejs';
-import { Runtime } from '@aws-cdk/aws-lambda';
+import { CfnOutput, Duration, RemovalPolicy, Stack, StackProps} from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Table, BillingMode, AttributeType } from 'aws-cdk-lib/aws-dynamodb';
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import path = require('path');
 
 export class CdkStack extends Stack {

--- a/lambda-dynamodb-cdk/cdk/package.json
+++ b/lambda-dynamodb-cdk/cdk/package.json
@@ -11,20 +11,17 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.131.0",
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
-    "aws-cdk": "1.131.0",
+    "aws-cdk": "^2.13.0",
     "ts-node": "^9.0.0",
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-dynamodb": "1.131.0",
-    "@aws-cdk/aws-lambda": "1.131.0",
-    "@aws-cdk/aws-lambda-nodejs": "1.131.0",
-    "@aws-cdk/core": "1.131.0",
+    "aws-cdk-lib": "^2.13.0",
+    "constructs": "^10.0.0",
     "moment": "^2.29.1",
     "source-map-support": "^0.5.16"
   }

--- a/lambda-dynamodb-cdk/cdk/test/cdk.test.ts
+++ b/lambda-dynamodb-cdk/cdk/test/cdk.test.ts
@@ -1,11 +1,11 @@
-import { expect as expectCDK, matchTemplate, MatchStyle, haveResource } from '@aws-cdk/assert';
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
 import { CdkStack } from '../lib/cdk-stack';
 
 test('Validate stack resources', () => {
   const app = new cdk.App();
   const stack = new CdkStack(app, 'MyTestStack');
 
-  expectCDK(stack).to(haveResource('AWS::DynamoDB::Table'));
-  expectCDK(stack).to(haveResource('AWS::Lambda::Function'));
+  Template.fromStack(stack).hasResource('AWS::DynamoDB::Table', {});
+  Template.fromStack(stack).hasResource('AWS::Lambda::Function', {});
 });


### PR DESCRIPTION
*Issue #, if available:* closes #502

*Description of changes:*
Migrated pattern from CDK v1 to CDK v2.

Changes include:

* updating feature flags in cdk.json
* dependency updates in package.json
* updating imports to use the new constructs and consolidated aws-cdk-lib libraries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
