### PR TITLE
migrated to AWS CDK v2 (typescript)

### DIFF
--- a/msk-lambda-cdk/bin/msk-lambda-cdk.ts
+++ b/msk-lambda-cdk/bin/msk-lambda-cdk.ts
@@ -3,7 +3,7 @@
  *  SPDX-License-Identifier: MIT-0
  */
 
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
 
 import { MskLambdaCdkStack } from '../lib/msk-lambda-cdk-stack';
 

--- a/msk-lambda-cdk/cdk.json
+++ b/msk-lambda-cdk/cdk.json
@@ -21,6 +21,12 @@
     "@aws-cdk/core:stackRelativeExports": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
     "@aws-cdk/aws-lambda:recognizeVersionProps": true,
-    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
   }
 }

--- a/msk-lambda-cdk/lib/msk-lambda-cdk-stack.ts
+++ b/msk-lambda-cdk/lib/msk-lambda-cdk-stack.ts
@@ -1,24 +1,24 @@
 /*! Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  SPDX-License-Identifier: MIT-0
  */
-
-import * as lambda from '@aws-cdk/aws-lambda';
-import * as msk from "@aws-cdk/aws-msk"
-import {NodejsFunction} from "@aws-cdk/aws-lambda-nodejs";
-import {Runtime} from "@aws-cdk/aws-lambda";
-
-import * as ec2 from '@aws-cdk/aws-ec2';
-
-import { ManagedKafkaEventSource } from "@aws-cdk/aws-lambda-event-sources";
+import { Stack, StackProps, Duration } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { aws_iam as iam } from 'aws-cdk-lib';
+import { aws_lambda as lambda } from 'aws-cdk-lib';
+import * as msk from '@aws-cdk/aws-msk-alpha';
+import { aws_ec2 as ec2 } from 'aws-cdk-lib';
+import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import { Runtime } from "aws-cdk-lib/aws-lambda";
+import { ManagedKafkaEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 
 import path = require('path');
 
-import * as iam from '@aws-cdk/aws-iam';
 
-import * as cdk from '@aws-cdk/core';
 
-export class MskLambdaCdkStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+
+
+export class MskLambdaCdkStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
     let topicName: string;
@@ -44,7 +44,7 @@ export class MskLambdaCdkStack extends cdk.Stack {
       handler: 'handler',
       vpc: vpc,
       functionName: 'TransactionHandler',
-      timeout: cdk.Duration.minutes(1),
+      timeout: Duration.minutes(1),
     });
 
     

--- a/msk-lambda-cdk/package.json
+++ b/msk-lambda-cdk/package.json
@@ -13,21 +13,16 @@
   "devDependencies": {
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
-    "aws-cdk": "^2.1.0",
+    "aws-cdk": "^2.13.0",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-ec2": "^1.136.0",
-    "@aws-cdk/aws-lambda-event-sources": "^1.136.0",
-    "@aws-cdk/aws-lambda-nodejs": "^1.136.0",
-    "@aws-cdk/aws-msk": "^1.136.0",
-    "@aws-cdk/aws-sqs": "^1.136.0",
-    "@aws-cdk/core": "^1.136.0",
-    "aws-cdk-lib": "2.1.0",
-    "constructs": "^10.0.12",
+    "@aws-cdk/aws-msk-alpha": "^2.16.0-alpha.0",
+    "aws-cdk-lib": "^2.13.0",
+    "constructs": "^10.0.0",
     "package.json": "^2.0.1"
   }
 }


### PR DESCRIPTION
*Issue #, if available:* closes #503

*Description of changes:*
Migrated pattern from CDK v1 to CDK v2.

Changes include:

* updating feature flags in cdk.json
* dependency updates in package.json
* updating imports to use the new constructs and consolidated aws-cdk-lib libraries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
