### PR TITLE
migrated to AWS CDK v2 (typescript)

### DIFF
--- a/parallel-e2e-pipeline-cdk/src/pipeline/app/constructs/end-to-end-tests.ts
+++ b/parallel-e2e-pipeline-cdk/src/pipeline/app/constructs/end-to-end-tests.ts
@@ -1,13 +1,13 @@
-import { Role } from "@aws-cdk/aws-iam";
-import { Construct } from "@aws-cdk/core";
-import { Artifact } from "@aws-cdk/aws-codepipeline";
+import { Role } from "aws-cdk-lib/aws-iam";
+import { Construct } from 'constructs';
+import { Artifact } from "aws-cdk-lib/aws-codepipeline";
 import { 
   ComputeType, 
   PipelineProject, 
   BuildSpec, 
   LinuxBuildImage 
-} from "@aws-cdk/aws-codebuild";
-import { CodeBuildAction } from "@aws-cdk/aws-codepipeline-actions";
+} from "aws-cdk-lib/aws-codebuild";
+import { CodeBuildAction } from "aws-cdk-lib/aws-codepipeline-actions";
 
 
 export const getEndToEndTestsActions = (

--- a/parallel-e2e-pipeline-cdk/src/pipeline/app/constructs/roles/e2e-code-build-role.ts
+++ b/parallel-e2e-pipeline-cdk/src/pipeline/app/constructs/roles/e2e-code-build-role.ts
@@ -1,9 +1,9 @@
-import { Construct } from "@aws-cdk/core";
+import { Construct } from 'constructs';
 import { 
   Role,
   ServicePrincipal, 
   ManagedPolicy
-} from "@aws-cdk/aws-iam";
+} from "aws-cdk-lib/aws-iam";
 
 
 export class E2ECodeBuildRole extends Construct {

--- a/parallel-e2e-pipeline-cdk/src/pipeline/app/constructs/roles/pipeline-role.ts
+++ b/parallel-e2e-pipeline-cdk/src/pipeline/app/constructs/roles/pipeline-role.ts
@@ -4,8 +4,8 @@ import {
   Effect,
   Role,
   ServicePrincipal
-} from "@aws-cdk/aws-iam";
-import { Construct } from "@aws-cdk/core";
+} from "aws-cdk-lib/aws-iam";
+import { Construct } from 'constructs';
 
 
 interface PipelineRoleProps { 

--- a/parallel-e2e-pipeline-cdk/src/pipeline/app/pipeline-stack.ts
+++ b/parallel-e2e-pipeline-cdk/src/pipeline/app/pipeline-stack.ts
@@ -1,7 +1,8 @@
-import { App, Stack, StackProps } from "@aws-cdk/core";
-import * as codecommit from "@aws-cdk/aws-codecommit";
-import * as codepipeline from "@aws-cdk/aws-codepipeline";
-import * as codepipeline_actions from "@aws-cdk/aws-codepipeline-actions"
+import { Stack, StackProps, App } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as codecommit from "aws-cdk-lib/aws-codecommit";
+import * as codepipeline from "aws-cdk-lib/aws-codepipeline";
+import * as codepipeline_actions from "aws-cdk-lib/aws-codepipeline-actions"
 
 import { PipelineRole, E2ECodeBuildRole } from "./constructs/roles";
 import { getEndToEndTestsActions } from "./constructs/end-to-end-tests";

--- a/parallel-e2e-pipeline-cdk/src/pipeline/cdk.json
+++ b/parallel-e2e-pipeline-cdk/src/pipeline/cdk.json
@@ -1,4 +1,33 @@
 {
   "app": "npx ts-node main.ts",
-  "output": "dist/cdk.out"
+  "output": "dist/cdk.out",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
+    "@aws-cdk/core:stackRelativeExports": true,
+    "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
+    "@aws-cdk/aws-lambda:recognizeVersionProps": true,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
+  }
 }

--- a/parallel-e2e-pipeline-cdk/src/pipeline/main.ts
+++ b/parallel-e2e-pipeline-cdk/src/pipeline/main.ts
@@ -1,4 +1,4 @@
-import * as cdk from "@aws-cdk/core";
+import * as cdk from 'aws-cdk-lib';
 import { PipelineStack } from "./app/pipeline-stack";
 
 const app = new cdk.App();

--- a/parallel-e2e-pipeline-cdk/src/pipeline/package.json
+++ b/parallel-e2e-pipeline-cdk/src/pipeline/package.json
@@ -10,16 +10,12 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@aws-cdk/aws-codebuild": "^1.125.0",
-    "@aws-cdk/aws-codecommit": "^1.125.0",
-    "@aws-cdk/aws-codepipeline": "^1.125.0",
-    "@aws-cdk/aws-codepipeline-actions": "^1.125.0",
-    "@aws-cdk/aws-iam": "^1.125.0",
-    "@aws-cdk/core": "^1.125.0"
+    "aws-cdk-lib": "^2.13.0",
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/node": "^16.10.2",
-    "aws-cdk": "^1.125.0",
+    "aws-cdk": "^2.13.0",
     "ts-node": "^10.2.1",
     "typescript": "^4.4.3"
   }


### PR DESCRIPTION
*Issue #, if available:* closes #504

*Description of changes:*
Migrated pattern from CDK v1 to CDK v2.

Changes include:

* updating feature flags in cdk.json
* dependency updates in package.json
* updating imports to use the new constructs and consolidated aws-cdk-lib libraries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
