### PR TITLE
New Pattern: CloudFront failover with two apigw http api lambda rust in different regions

### DIFF
--- a/cloudfront-apigw-http-api-lambda-rust/README.md
+++ b/cloudfront-apigw-http-api-lambda-rust/README.md
@@ -51,7 +51,7 @@ This pattern deploys an Amazon Cloudfront distribution, an Amazon API Gateway HT
 
 Once the application is deployed, retrieve the CloudFront value from CloudFormation Outputs. Either browse to the endpoint in a web browser or call the endpoint from Postman.
 
-Example GET Request: https://{DistributionDomainName}.execute-api.{region}.amazonaws.com/mypath
+Example GET Request: https://{DistributionDomainName}/mypath
 
 Response:
 ```
@@ -64,7 +64,7 @@ X-Cache: Miss from cloudfront
 If you try again:
 X-Cache: Hit from cloudfront
 
-Example GET Request: https://{DistributionDomainName}.execute-api.{region}.amazonaws.com/mypath?allowed_query_string_param=Daniele
+Example GET Request: https://{DistributionDomainName}/mypath?allowed_query_string_param=Daniele
 
 Response:
 ```

--- a/cloudfront-failover-apigw-http-api-lambda-rust/Cargo.toml
+++ b/cloudfront-failover-apigw-http-api-lambda-rust/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "cloudfront-failover-apigw-http-api-lambda-rust"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[[bin]]
+name = "handler"
+path = "src/bin/handler.rs"
+
+[dependencies]
+lambda_http = "0.5.0"
+lambda_runtime = "0.5.0"
+serde_json = "1.0.68"
+tokio = { version = "1", features = ["full"] }
+tracing-subscriber = "0.3"

--- a/cloudfront-failover-apigw-http-api-lambda-rust/Makefile
+++ b/cloudfront-failover-apigw-http-api-lambda-rust/Makefile
@@ -1,0 +1,20 @@
+FUNCTIONS := handler
+ARCH := aarch64-unknown-linux-gnu
+ARCH_SPLIT = $(subst -, ,$(ARCH))
+
+build:
+ifeq ("$(shell zig targets | jq -r .native.cpu.arch)-$(shell zig targets | jq -r .native.os)-$(shell zig targets | jq -r .native.abi)", "$(word 1,$(ARCH_SPLIT))-$(word 3,$(ARCH_SPLIT))-$(word 4,$(ARCH_SPLIT))")
+	@echo "Same host and target. Using native build"
+	cargo build --release --target $(ARCH)
+else
+	@echo "Different host and target. Using zigbuild"
+	cargo zigbuild --release --target $(ARCH)
+endif
+
+	rm -rf ./build
+	mkdir -p ./build
+	${MAKE} ${MAKEOPTS} $(foreach function,${FUNCTIONS}, build-${function})
+
+build-%:
+	mkdir -p ./build/$*
+	cp -v ./target/$(ARCH)/release/$* ./build/$*/bootstrap

--- a/cloudfront-failover-apigw-http-api-lambda-rust/README.md
+++ b/cloudfront-failover-apigw-http-api-lambda-rust/README.md
@@ -1,0 +1,134 @@
+# Amazon Cloudfront distribution on front of an Amazon API Gateway HTTP API to AWS Lambda
+
+This pattern creates an Amazon Cloudfront failover distribution on front of an Amazon API Gateway HTTP API and an AWS Lambda function in two different regions.
+
+Learn more about this pattern at [Serverless Land Patterns](https://serverlessland.com/patterns/cloudfront-failover-apigw-http-lambda-rust).
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+* [Rust](https://www.rust-lang.org/) 1.56.0 or higher
+* [cargo-zigbuild](https://github.com/messense/cargo-zigbuild) and [Zig](https://ziglang.org/) for cross-compilation
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+2. Change directory to the pattern directory:
+    ```
+    cd cloudfront-failover-apigw-http-lambda-rust
+    ```
+3. Install dependencies and build:
+    ```
+    make build
+    ```
+4. Deploy the api on the PrimaryRegion region.
+    ```
+    sam deploy --guided --region {PrimaryRegion} --stack-name sam-api-primary --template-file api.yml
+    ```
+5. During the prompts:
+    * Enter a stack name
+    * Enter the desired AWS Region
+    * Allow SAM CLI to create IAM roles with the required permissions.
+
+    Once you have run `sam deploy -guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+
+6. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+7. Deploy the api on the SecondaryRegion region.
+    ```
+    sam deploy --guided --region {SecondaryRegion} --stack-name sam-api-primary --template-file api.yml
+    ```
+8. During the prompts:
+    * Enter a stack name
+    * Enter the desired AWS Region
+    * Allow SAM CLI to create IAM roles with the required permissions.
+
+    Once you have run `sam deploy -guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+
+9. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+10. Deploy CloudFront with failvoer policy.
+    ```
+    sam deploy --guided --region {PrimaryRegion} --stack-name sam-cf-primary --template-file cloudfront.yml --parameter-overrides PrimaryEndpoint={HTTP_API_ID}.execute-api.{PrimaryRegion}.amazonaws.com SecondaryEndpoint={HTTP_API_ID}.execute-api.{SecondaryRegion}.amazonaws.com
+    ```
+11. During the prompts:
+    * Enter a stack name
+    * Enter the desired AWS Region
+    * Allow SAM CLI to create IAM roles with the required permissions.
+
+    Once you have run `sam deploy -guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+
+12. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+   
+
+## How it works
+
+This pattern deploys an Amazon Cloudfront distribution on front of two Amazon API Gateway HTTP API with a default route and basic CORS configuration in different regions. The default route is integrated with an AWS Lambda function written in Rust. The function logs the incoming API event (v2) and context object to an Amazon CloudWatch Logs log group and returns basic information about the event to the caller.
+
+## Testing
+
+Once the application is deployed, retrieve the CloudFront value from CloudFormation Outputs. Either browse to the endpoint in a web browser or call the endpoint from Postman.
+
+Example GET Request: https://{DistributionDomainName}/api
+
+Response:
+```
+hello {IP}
+```
+
+If you check the headers back from the call you will see:
+X-Cache: Miss from cloudfront
+
+If you try again:
+X-Cache: Hit from cloudfront
+
+Example GET Request: https://{DistributionDomainName}/api?allowed_query_string_param=Daniele
+
+Response:
+```
+hello Daniele ip: {IP}
+```
+
+If you check the headers back from the call you will see:
+X-Cache: Miss from cloudfront
+
+If you try again:
+X-Cache: Hit from cloudfront
+
+
+## Documentation
+- [Working with HTTP APIs](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api.html)
+- [Working with AWS Lambda proxy integrations for HTTP APIs](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html)
+- [AWS Lambda - the Basics](https://docs.aws.amazon.com/whitepapers/latest/serverless-architectures-lambda/aws-lambdathe-basics.html)
+- [Lambda Function Handler](https://docs.aws.amazon.com/whitepapers/latest/serverless-architectures-lambda/the-handler.html)
+- [Function Event Object - Overview](https://docs.aws.amazon.com/whitepapers/latest/serverless-architectures-lambda/the-event-object.html)
+- [Function Event Object - HTTP API v2 Event](https://github.com/awsdocs/aws-lambda-developer-guide/blob/master/sample-apps/nodejs-apig/event-v2.json)
+- [Function Context Object - Overview](https://docs.aws.amazon.com/whitepapers/latest/serverless-architectures-lambda/the-context-object.html)
+- [Function Context Object in Node.js - Properties](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-context.html)
+- [Function Environment Variables](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html)
+- [Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Introduction.html)
+
+## Cleanup
+ 
+1. Delete the stack
+    ```bash
+    aws cloudformation delete-stack --stack-name STACK_NAME
+    ```
+2. Confirm the stack has been deleted
+    ```bash
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus"
+    ```
+
+----
+Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0
+

--- a/cloudfront-failover-apigw-http-api-lambda-rust/api.yml
+++ b/cloudfront-failover-apigw-http-api-lambda-rust/api.yml
@@ -1,0 +1,86 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+##########################################################################
+#  Parameters                                                            #
+##########################################################################
+Parameters:
+  StageName:
+    Description: The name of the stage is the first path segment in the Uniform Resource Identifier (URI) of a call to API Gateway
+    Type: String
+    Default: dev
+
+##########################################################################
+#  Global values that are applied to all resources                       #
+##########################################################################
+Globals:
+  Function:
+    MemorySize: 1024
+    Architectures: ["arm64"]
+    Handler: bootstrap
+    Runtime: provided.al2
+    Timeout: 29
+    Layers:
+      - !Sub arn:aws:lambda:${AWS::Region}:580247275435:layer:LambdaInsightsExtension-Arm64:1
+    Environment:
+      Variables:
+        RUST_BACKTRACE: 1
+        RUST_LOG: info
+
+Resources:
+##########################################################################
+#  API Gateway HTTP API                                                  #
+# ##########################################################################
+  AccessLogs:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 1
+      LogGroupName: !Sub "/api-gateway/${AWS::StackName}/APIAccessLogs-rust"
+
+  HttpApi:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      AccessLogSettings:
+        DestinationArn: !GetAtt AccessLogs.Arn
+        Format: '{ "requestId":"$context.requestId", "ip": "$context.identity.sourceIp", "requestTime":"$context.requestTime", "httpMethod":"$context.httpMethod","routeKey":"$context.routeKey", "status":"$context.status","protocol":"$context.protocol", "responseLength":"$context.responseLength" }'
+      CorsConfiguration:
+        AllowOrigins:
+          - '*'
+        AllowMethods:
+          - GET
+          - HEAD
+          - OPTIONS
+          - POST
+      Tags:
+        name: !Ref AWS::StackName
+
+##########################################################################
+#   Lambda Function                                                      #
+##########################################################################
+  LambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./build/handler
+      Policies:
+        - AWSLambdaBasicExecutionRole
+      Events:
+        api:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref HttpApi
+            Path: /api
+            Method: GET
+        proxy:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref HttpApi
+            Path: /api/{proxy+}
+            Method: GET
+      Tags:
+        name: !Ref AWS::StackName
+        env: !Ref StageName
+
+Outputs:
+  HttpApiEndpoint:
+    Description: The api endpoint.
+    Value: !GetAtt HttpApi.ApiEndpoint

--- a/cloudfront-failover-apigw-http-api-lambda-rust/cloudfront.yml
+++ b/cloudfront-failover-apigw-http-api-lambda-rust/cloudfront.yml
@@ -1,0 +1,125 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+##########################################################################
+#  Parameters                                                            #
+##########################################################################
+Parameters:
+  PrimaryEndpoint:
+    Type: String
+  SecondaryEndpoint:
+    Type: String
+
+Resources:
+##########################################################################
+#  CloudFront::CachePolicy                                               #
+##########################################################################
+  1hCachePolicy:
+    Type: AWS::CloudFront::CachePolicy
+    Properties:
+      CachePolicyConfig:
+        Comment: Cache for 1h
+        Name: !Ref AWS::StackName
+        DefaultTTL: 360
+        MaxTTL: 360
+        MinTTL: 360
+        Name: 1h
+        ParametersInCacheKeyAndForwardedToOrigin:
+          CookiesConfig:
+            CookieBehavior: none
+          EnableAcceptEncodingBrotli: false
+          EnableAcceptEncodingGzip: false
+          HeadersConfig:
+            HeaderBehavior: whitelist
+            Headers:
+              - x-forwarded-for
+          QueryStringsConfig:
+            QueryStringBehavior: whitelist
+            QueryStrings:
+              - allowed_query_string_param
+
+##########################################################################
+#  CloudFront::Distribution                                              #
+##########################################################################
+  CloudfrontDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        #  CNAMEs: # Aliases A complex type that contains information about CNAMEs (alternate domain names), if any, for this distribution.
+        PriceClass: PriceClass_100
+        IPV6Enabled: true
+        HttpVersion: http2
+        OriginGroups: #https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/high_availability_origin_failover.html
+          Items:
+            - Id: Failover
+              FailoverCriteria: 
+                StatusCodes: #403, 404, 500, 502, 503, 504
+                  Items:
+                    - 502 # Bad Gateway Exception
+                    - 503 # Service Unavailable Exception
+                    - 504 # Endpoint Request Timed-out Exception
+                  Quantity: 3
+              Members: 
+                Items: 
+                  - OriginId: Primary
+                  - OriginId: Secondary
+                Quantity: 2
+          Quantity: 1
+        Origins:
+          - Id: Primary
+            DomainName: !Ref PrimaryEndpoint
+            OriginPath: /api
+            CustomOriginConfig:
+              HTTPSPort: 443
+              OriginProtocolPolicy: https-only
+              OriginSSLProtocols: 
+                - TLSv1.2
+          - Id: Secondary
+            DomainName: !Ref SecondaryEndpoint
+            OriginPath: /api
+            CustomOriginConfig:
+              HTTPSPort: 443
+              OriginProtocolPolicy: https-only
+              OriginSSLProtocols: 
+                - TLSv1.2
+        Enabled: true
+        CacheBehaviors:
+          - AllowedMethods:
+              - GET
+              - HEAD
+            CachedMethods:
+              - GET
+              - HEAD
+            Compress: true
+            PathPattern: /api
+            TargetOriginId: Failover
+            ViewerProtocolPolicy: redirect-to-https
+            CachePolicyId: !Ref 1hCachePolicy
+          - AllowedMethods:
+              - GET
+              - HEAD
+            CachedMethods:
+              - GET
+              - HEAD
+            Compress: true
+            PathPattern: /api/?allowed_query_string_param*
+            TargetOriginId: Failover
+            ViewerProtocolPolicy: redirect-to-https
+            CachePolicyId: !Ref 1hCachePolicy
+        DefaultCacheBehavior:
+          AllowedMethods:
+            - GET
+            - HEAD
+          CachedMethods:
+            - GET
+            - HEAD
+          Compress: true
+          TargetOriginId: Primary
+          ViewerProtocolPolicy: redirect-to-https
+          CachePolicyId: !Ref 1hCachePolicy
+
+Outputs:
+  DistributionDomainName:
+    Description: "Distribution domain name"
+    Value: !GetAtt CloudfrontDistribution.DomainName
+    Export:
+      Name: DistributionDomainName

--- a/cloudfront-failover-apigw-http-api-lambda-rust/src/bin/handler.rs
+++ b/cloudfront-failover-apigw-http-api-lambda-rust/src/bin/handler.rs
@@ -1,0 +1,46 @@
+use lambda_http::{
+    http::StatusCode, service_fn, Error, IntoResponse, Request, RequestExt, Response,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt()
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
+        // disabling time is handy because CloudWatch will add the ingestion time.
+        .without_time()
+        .init();
+    lambda_http::run(service_fn(|event: Request| execute(event))).await?;
+    Ok(())
+}
+
+pub async fn execute(event: Request) -> Result<impl IntoResponse, Error> {
+    println!("EVENT {:?}", event);
+    let ip_address = get_ip_address(&event).unwrap_or("stranger".to_string());
+
+    let mut body = format!("hello {}", ip_address);
+    if let Some(allowed_query_string_param) = event
+        .query_string_parameters()
+        .first("allowed_query_string_param")
+    {
+        body = format!("hello {} ip: {}", allowed_query_string_param, ip_address);
+    }
+
+    let response = Response::builder()
+        .status(StatusCode::OK)
+        .header("Content-Type", "application/json")
+        .body(body)
+        .unwrap();
+
+    Ok(response)
+}
+
+fn get_ip_address(event: &Request) -> Option<String> {
+    let header_ip_address = event.headers().get("x-forwarded-for");
+    if let Some(header_ip_address) = header_ip_address {
+        let ips: Vec<&str> = header_ip_address.to_str().unwrap().split(",").collect();
+        return Some(ips[0].to_string());
+    }
+    None
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This pattern follows [Optimizing high availability with CloudFront origin failover](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/high_availability_origin_failover.html)

It will deploy 2 APIGW and 2 Lambda in two different regions, and it will setup a CloudFront distribution on the front with two origins.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
