### PR TITLE
APIGW EventBridge Lambda - Serverless Framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,7 +178,8 @@ var/
 *.egg
 
 # Serverless directories
-.serverless%
+/*/.serverless/
+/*/.build/
 =======
 # Terraform
 **/*.terraform*

--- a/apigw-http-api-eventbridge-lambda-sls/README.md
+++ b/apigw-http-api-eventbridge-lambda-sls/README.md
@@ -1,0 +1,111 @@
+# Amazon API Gateway HTTP API to Amazon EventBridge
+
+This pattern creates an HTTP API endpoint that directly integrates with Amazon EventBridge
+
+Learn more about this pattern at Serverless Land Patterns: [https://serverlessland.com/patterns/apigateway-http-eventbridge-lambda-sls](https://serverlessland.com/patterns/apigateway-http-eventbridge-lambda-sls).
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git CLI](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) installed
+* [NodeJS](https://nodejs.org/en/download/) (LTS version) installed
+* [Serverless Framework CLI](https://www.serverless.com/framework/docs/getting-started) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+
+    ``` sh
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+
+1. Change directory to the pattern directory:
+
+    ``` sh
+    cd serverless-patterns/apigw-http-api-eventbridge-lambda-sls
+    ```
+
+1. From the command line, use npm to install the development dependencies:
+
+    ``` sh
+    npm install
+    ```
+
+1. From the command line, use Serverless Framework to deploy the AWS resources for the pattern as specified in the serverless.yml file:
+
+    ``` sh
+    serverless deploy --verbose
+    ```
+
+    The above command will deploy resources to `us-east-1` region by default. You can override the target region with `--region <region>` CLI option, e.g.
+
+    ``` sh
+    serverless deploy --verbose --region us-west-2
+    ```
+
+1. Note the `ApiEndpoint` output from the Serverless Framework deployment process. You will use this value for testing.
+
+## How it works
+
+This pattern creates an Amazon API gateway HTTP API endpoint. The endpoint uses service integrations to directly connect to Amazon EventBridge.
+
+Once a new event is published to EventBridge `WebApp` custom event bus it is delivered to a Lambda function, which will simply log that event to EventLog.
+Lambda function is written in TypeScript and deployed to ARM64 architecture for demo purposes.
+
+## Testing
+
+### Sending a new test message to API Gateway endpoint
+
+To test the endpoint first send data using the following command. Be sure to update the endpoint with endpoint of your stack.
+
+``` sh
+curl --location --request POST 'ApiEndpoint output value' --header 'Content-Type: application/json' \
+--data-raw '{
+    "Detail":{
+        "message": "This is my test"
+    }
+}'
+```
+
+### Expected result
+
+```json
+{"Entries":[{"EventId":"Event_UUID"}],"FailedEntryCount":0}
+```
+
+### CloudWatch logs
+
+Open AWS CloudWatch Console and navigate to [/aws/lambda/apigw-http-api-eventbridge-lambda-sls-prod-logEvent](https://console.aws.amazon.com/cloudwatch/home#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fapigw-http-api-eventbridge-lambda-sls-prod-logEvent) log group.
+You should be able to see a new Event Stream with the Received Event information, and Event Message, logged into the stream.
+
+## Cleanup
+
+1. Delete the stack
+
+    ```sh
+    serverless remove --verbose
+    ```
+
+1. Confirm the stack has been deleted
+
+    ```sh
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'apigw-http-api-eventbridge-lambda-sls-prod')].StackStatus"
+    ```
+
+    Expected output
+
+    ```json
+    [
+        "DELETE_COMPLETE"
+    ]
+    ```
+
+    NOTE: You might need to add `--region <region>` option to AWS CLI command if you AWS CLI default region does not match the one, that you used for the Serverless Framework deployment.
+
+----
+Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/apigw-http-api-eventbridge-lambda-sls/api.json
+++ b/apigw-http-api-eventbridge-lambda-sls/api.json
@@ -1,0 +1,29 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+        "title": "API Gateway HTTP API to EventBridgePI"
+    },
+    "paths": {
+        "/": {
+            "post": {
+                "responses": {
+                    "default": {
+                        "description": "Successful operation"
+                    }                          
+                },
+                "x-amazon-apigateway-integration": {
+                    "integrationSubtype": "EventBridge-PutEvents",
+                    "credentials": { "Fn::GetAtt" : [ "MyHttpApiRole", "Arn" ] },
+                    "requestParameters": {
+                        "Detail": "$request.body.Detail",
+                        "DetailType": "MyDetailType",
+                        "Source": "WebApp"
+                    },
+                    "payloadFormatVersion": "1.0",
+                    "type": "aws_proxy",
+                    "connectionType": "INTERNET"
+                }
+            }
+        }
+    }
+}

--- a/apigw-http-api-eventbridge-lambda-sls/example-pattern.json
+++ b/apigw-http-api-eventbridge-lambda-sls/example-pattern.json
@@ -1,0 +1,66 @@
+{
+    "title": "HTTP API Gateway to EventBridge",
+    "description": "Create an HTTP API Gateway that sends events to EventBridge.",
+    "language": "Node.js, TypeScript",
+    "architectureURL": "",
+    "videoId": "",
+    "level": "100",
+    "framework": "Serverless Framework",
+    "services": {
+        "from": "apigatewayv2",
+        "to": "eventbridge"
+    },
+    "introBox": {
+        "headline": "How it works",
+        "text": [
+            "This pattern creates an Amazon API gateway HTTP API endpoint. The endpoint uses service integrations to directly connect to Amazon EventBridge. ",
+            "",
+            "Once a new event is published to EventBridge \"WebApp\" custom event bus it is delivered to a Lambda function, which will simply log that event to EventLog. ",
+            "Lambda function is written in TypeScript and deployed to ARM64 architecture for demo purposes."
+        ]
+    },
+    "gitHub": {
+        "template": {
+            "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/apigw-http-api-eventbridge-lambda-sls",
+            "templateURL": "serverless-patterns/apigw-http-api-eventbridge-lambda-sls",
+            "projectFolder": "apigw-http-api-eventbridge-lambda-sls",
+            "templateFile": "serverless.yml"
+        }
+    },
+    "resources": {
+        "headline": "Additional resources",
+        "bullets": [
+            {
+                "text": "Integrating Amazon EventBridge into your serverless applications",
+                "link": "https://aws.amazon.com/blogs/compute/integrating-amazon-eventbridge-into-your-serverless-applications/"
+            },
+            {
+                "text": "Use Amazon EventBridge to Build Decoupled, Event-Driven Architectures",
+                "link": "https://serverlessland.com/learn/eventbridge"
+            }
+        ]
+    },
+    "deploy": {
+        "text": [
+            "<code>serverless deploy --verbose</code>"
+        ]
+    },
+    "testing": {
+        "text": [
+            "See the Github repo for detailed testing instructions."
+        ]
+    },
+    "cleanup": {
+        "text": [
+            "<code>serverless remove --verbose</code>."
+        ]
+    },
+    "authors": [
+        {
+            "headline": "Presented by Dmitry Gulin, Modernization Architect, AWS",
+            "name": "Dmitry Gulin",
+            "bio": "Dmitry is a modernization architect for Professional Services at Amazon Web Services based in the US.",
+            "imageURL": "https://www.gravatar.com/avatar/223055bd132d244f6a96c3aef7453a5a?s=200"
+        }
+    ]
+}

--- a/apigw-http-api-eventbridge-lambda-sls/package.json
+++ b/apigw-http-api-eventbridge-lambda-sls/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "apigw-http-api-eventbridge-lambda-sls",
+  "version": "1.0.0",
+  "license": "MIT-0",
+  "type": "module",
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.93",
+    "serverless-plugin-typescript": "^2.1.1",
+    "typescript": "^4.6.3"
+  }
+}

--- a/apigw-http-api-eventbridge-lambda-sls/serverless.yml
+++ b/apigw-http-api-eventbridge-lambda-sls/serverless.yml
@@ -1,0 +1,80 @@
+service: apigw-http-api-eventbridge-lambda-sls
+frameworkVersion: '^3' # require serverless v3 or later
+
+# enable TypeScript support for Lambda functions
+plugins:
+  - serverless-plugin-typescript
+
+provider:
+  name: aws
+
+  # common configuration for all Lambda functions in this stack
+  runtime: nodejs14.x
+  architecture: arm64 # use Graviton for running all Lambda functions
+
+  # override the default stage (dev) to be `prod`, or you can use the `--stage` CLI option
+  stage: ${opt:stage, "prod"}
+
+  # use the `--region` CLI option value or the default (us-east-1)
+  region: ${opt:region, "us-east-1"}
+
+# Lambda function triggered with events from the default EventBridge topic
+functions:
+  logEvent:
+    handler: src/handler.logEvent
+    memorySize: 256 # optional, in MB, default is 1024
+    events:
+      - eventBridge:
+          pattern:
+            source:
+              - "WebApp"
+
+resources:
+  # Override the default description
+  Description: API Gateway HTTP API to EventBridge, triggering a Lambda function (Serverless Framework).
+
+  Resources:
+    # Create an API Gateway HTTP API
+    MyHttpApi:
+      Type: AWS::ApiGatewayV2::Api
+      Properties:
+        Body: ${file(./api.json)}
+
+    # Create the default stage and configure it to automatically deploy
+    MyHttpApiStage:
+      Type: AWS::ApiGatewayV2::Stage    
+      Properties:
+        ApiId: !Ref MyHttpApi
+        # we use default stage, instead of the stage name for simplicity.
+        # Use ${sls:stage} to get the stage name.
+        StageName: '$default'
+        AutoDeploy: true
+
+    # Create the role for API Gateway access to EventBridge
+    MyHttpApiRole:
+      Type: "AWS::IAM::Role"
+      Properties:
+        AssumeRolePolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+            - Effect: "Allow"
+              Principal:
+                Service: "apigateway.amazonaws.com"
+              Action: 
+                - "sts:AssumeRole"
+        Policies:
+          - PolicyName: ApiDirectWriteEventBridge
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                Action:
+                - events:PutEvents
+                Effect: Allow
+                Resource:
+                  - arn:aws:events:${self:provider.region}:${aws:accountId}:event-bus/default
+
+  Outputs:
+    ApiEndpoint:
+      Description: "HTTP API endpoint URL"
+      Value: !Sub "https://${MyHttpApi}.execute-api.${AWS::Region}.amazonaws.com"
+

--- a/apigw-http-api-eventbridge-lambda-sls/src/handler.ts
+++ b/apigw-http-api-eventbridge-lambda-sls/src/handler.ts
@@ -1,0 +1,24 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+// //
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify,
+// merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so.
+// //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import { EventBridgeHandler } from 'aws-lambda';
+
+export const logEvent: EventBridgeHandler<string, {message: string}, boolean> = async (event) => {
+    console.log(`Received event: ${JSON.stringify(event)}`);
+    console.log(`Event message: ${event.detail.message}`); // strongly typed access to event message
+
+    return true;
+};

--- a/apigw-http-api-eventbridge-lambda-sls/tsconfig.json
+++ b/apigw-http-api-eventbridge-lambda-sls/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    /* Language and Environment */
+    "target": "ES2021",                         /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "lib": [
+        "ES2021"
+    ],                                          /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+
+    /* Modules */
+    "module": "ES2022",                         /* Specify what module code is generated. */
+    "moduleResolution": "node",                 /* Specify how TypeScript looks up a file from a given module specifier. */
+
+    /* JavaScript Support */
+    "allowJs": true,                            /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
+    "checkJs": true,                            /* Enable error reporting in type-checked JavaScript files. */
+
+    /* Emit */
+    "preserveConstEnums": true,                 /* Disable erasing `const enum` declarations in generated code. */
+
+    /* Interop Constraints */
+    "esModuleInterop": true,                    /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */
+    "forceConsistentCasingInFileNames": true,   /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                             /* Enable all strict type-checking options. */
+    "strictNullChecks": true,                   /* When type checking, take into account `null` and `undefined`. */
+  }
+}


### PR DESCRIPTION
#566 

- Add support for APIGW (HTTP API) - EventBridge - Lambda pattern, implemented with Serverless Framework
- replace `.serverless%` with `/*/.serverless/` in .gitignore
- add `/*/.build/` to .gitignore, so that temp folders, created by the `serverless-plugin-typescript` plugin, are not committed to the shared Git repo.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
