### PR TITLE
Java port of APIGW HTTP to Event Bridge to Lambda Pattern

### DIFF
--- a/apigw-http-api-eventbridge-java/README.md
+++ b/apigw-http-api-eventbridge-java/README.md
@@ -1,0 +1,76 @@
+# Amazon API Gateway HTTP API to Amazon EventBridge
+
+This pattern is a Java port of the original [pattern](https://serverlessland.com/patterns/apigateway-http-eventbridge).
+
+This pattern creates an HTTP API endpoint that directly integrates with Amazon EventBridge. A Lambda function is triggered by the events published to Event Bridge. 
+
+Learn more about this pattern at Serverless Land Patterns: << Add the live URL here >>
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ```
+    cd serverless-patterns/apigw-http-api-eventbridge-java
+    ```
+1. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yaml file:
+    ```
+    sam deploy --guided
+    ```
+1. During the prompts:
+    * Enter a stack name
+    * Enter the desired AWS Region
+    * Allow SAM CLI to create IAM roles with the required permissions.
+
+    Once you have run `sam deploy --guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+
+1. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## How it works
+
+This pattern creates an Amazon API gateway HTTP API endpoint. The endpoint uses service integrations to directly connect to Amazon EventBridge.
+
+## Testing
+
+To test the endpoint first send data using the following command. Be sure to update the endpoint with endpoint of your stack.
+
+```
+curl --location --request POST '<your api endpoint>' --header 'Content-Type: application/json' \
+--data-raw '{
+    "Detail":{
+        "message": "This is my test"
+    }
+}'
+```
+
+Then check the logs for the Lambda function using the `sam logs` command. Change the stack name to your stack name.
+```
+sam logs --stack-name <your stack name> -n MyTriggeredLambda
+```
+
+## Cleanup
+ 
+1. Delete the stack
+    ```bash
+    aws cloudformation delete-stack --stack-name STACK_NAME
+    ```
+1. Confirm the stack has been deleted
+    ```bash
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus"
+    ```
+----
+Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/apigw-http-api-eventbridge-java/TriggeredLambda/pom.xml
+++ b/apigw-http-api-eventbridge-java/TriggeredLambda/pom.xml
@@ -1,0 +1,46 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>TriggeredLambda</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+    <name>Lambda function triggered by Event Bridge.</name>
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-core</artifactId>
+            <version>1.2.1</version>
+        </dependency>
+        <dependency>
+          <groupId>com.amazonaws</groupId>
+          <artifactId>aws-lambda-java-events</artifactId>
+          <version>3.11.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>3.2.4</version>
+          <configuration>
+          </configuration>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                <goal>shade</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </build>
+</project>

--- a/apigw-http-api-eventbridge-java/TriggeredLambda/src/main/java/com/example/App.java
+++ b/apigw-http-api-eventbridge-java/TriggeredLambda/src/main/java/com/example/App.java
@@ -1,0 +1,16 @@
+package com.example;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+import com.amazonaws.services.lambda.runtime.events.ScheduledEvent;
+
+public class App {
+
+    public void handleRequest(final ScheduledEvent event, final Context context) {
+        LambdaLogger logger = context.getLogger();
+
+        logger.log(String.format("Received event with DetailType: %s and Detail: %s",
+                event.getDetailType(),
+                event.getDetail().toString()));
+    }
+}

--- a/apigw-http-api-eventbridge-java/api.yaml
+++ b/apigw-http-api-eventbridge-java/api.yaml
@@ -1,0 +1,20 @@
+openapi: "3.0.1"
+info:
+  title: "API Gateway HTTP API to EventBridge"
+paths:
+  /:
+    post:
+      responses:
+        default:
+          description: "EventBridge response"
+      x-amazon-apigateway-integration:
+        integrationSubtype: "EventBridge-PutEvents"
+        credentials:
+          Fn::GetAtt: [MyHttpApiRole, Arn]
+        requestParameters:
+          Detail: "$request.body.Detail"
+          DetailType: MyDetailType
+          Source: WebApp
+        payloadFormatVersion: "1.0"
+        type: "aws_proxy"
+        connectionType: "INTERNET"

--- a/apigw-http-api-eventbridge-java/example-pattern.json
+++ b/apigw-http-api-eventbridge-java/example-pattern.json
@@ -1,0 +1,58 @@
+{
+  "title": "API Gateway HTTP API to Amazon EventBridge",
+  "description": "Create an HTTP API endpoint that directly integrates with Amazon EventBridge.",
+  "language": "Java",
+  "level": "200",
+  "framework": "SAM",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "This pattern creates an Amazon API Gateway HTTP API endpoint.",
+      "The endpoint uses service integrations to directly connect to Amazon EventBridge."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/apigw-http-api-eventbridge-java",
+      "templateURL": "serverless-patterns/apigw-http-api-eventbridge-java",
+      "projectFolder": "apigw-http-api-eventbridge-java"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "Working with AWS service integrations for HTTP APIs",
+        "link": "https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-aws-services.html"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "sam deploy --guided"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the Github repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>sam delete --stack-name STACK_NAME</code>.",
+      "Confirm the stack has been deleted: <code>aws cloudformation list-stacks --query \"StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus\"</code>"
+    ]
+  },
+  "authors": [
+    {
+      "name": "Eric Johnson",
+      "image": "https://serverlessland.com/assets/images/resources/ericdj.jpg",
+      "bio": "Eric Johnson is a Principal Developer Advocate for Serverless Applications at Amazon Web Services and is based in Northern Colorado. Eric is a fanatic about serverless and enjoys helping developers understand how serverless technologies introduces a major paradigm shift in how they approach building and running applications at massive scale with minimal administration overhead. Prior to this, Eric has worked as a developer, solutions architect and AWS Evangelist for an AWS partner company.",
+      "linkedin": "singledigit",
+      "twitter": "@edjgeek"
+    },
+    {
+      "name": "Steven Cook",
+      "bio": "Snr Solutions Architect at AWS."
+    }
+  ]
+}

--- a/apigw-http-api-eventbridge-java/template.yaml
+++ b/apigw-http-api-eventbridge-java/template.yaml
@@ -1,0 +1,64 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: API Gateway HTTP API to EventBridge
+
+Resources:
+  # Creates an HTTP API endpoint
+  MyHttpApi:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      DefinitionBody:
+        'Fn::Transform':
+          Name: 'AWS::Include'
+          Parameters:
+            Location: './api.yaml'
+          
+  # Create the role for API Gateway access to EventBridge
+  MyHttpApiRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service: "apigateway.amazonaws.com"
+            Action: 
+              - "sts:AssumeRole"
+      Policies:
+        - PolicyName: ApiDirectWriteEventBridge
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              Action:
+              - events:PutEvents
+              Effect: Allow
+              Resource:
+                - !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/default
+  
+  # Lambda function invoked from EventBridge
+  MyTriggeredLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: TriggeredLambda/
+      Handler: com.example.App::handleRequest
+      Runtime: java11
+      Architectures:
+        - x86_64
+      Timeout: 30
+      MemorySize: 512
+      Environment:
+        Variables:
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 
+      Events:
+        EventBridgeTrigger:
+          Type: EventBridgeRule
+          Properties:
+            Pattern:
+              source:
+                - "WebApp"
+
+Outputs:
+  ApiEndpoint:
+    Description: "HTTP API endpoint URL"
+    Value: !Sub "https://${MyHttpApi}.execute-api.${AWS::Region}.amazonaws.com"


### PR DESCRIPTION
*Description of changes:*

A Java port of the pattern showing APIGW HTTP API publishing body to Event Bridge, with a Lambda function triggered from the event. This original pattern is https://serverlessland.com/patterns/apigateway-http-eventbridge. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
