### PR TITLE
Fix CloudWatch Logs Resource Policy for the eventbridge-cloudwatch…

### DIFF
--- a/eventbridge-cloudwatch/template.yaml
+++ b/eventbridge-cloudwatch/template.yaml
@@ -21,36 +21,47 @@ Resources:
   LogGroupForEvents:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: /aws/events/resource-policy-test
+      LogGroupName: /aws/vendedlogs/events/resource-policy-test
   LogGroupForEventsPolicy:
     Type: AWS::Logs::ResourcePolicy
     Properties:
       PolicyName: EventBridgeToCWLogsPolicy
-      PolicyDocument: !Sub 
-      - >
+      PolicyDocument: !Sub >
         {
           "Version": "2012-10-17",
           "Statement": [
             {
-              "Sid": "EventBridgetoCWLogsPolicy",
+              "Sid": "EventBridgetoCWLogsCreateLogStreamPolicy",
               "Effect": "Allow",
               "Principal": {
                 "Service": [
-                  "delivery.logs.amazonaws.com",
                   "events.amazonaws.com"
                 ]
               },
               "Action": [
-                "logs:CreateLogStream",
+                "logs:CreateLogStream"
+              ],
+              "Resource": [
+                "${LogGroupForEvents.Arn}"
+              ]
+            },
+            {
+              "Sid": "EventBridgetoCWLogsPutLogEventsPolicy",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              },
+              "Action": [
                 "logs:PutLogEvents"
               ],
               "Resource": [
-                "${logArn}"
+                "${LogGroupForEvents.Arn}"
               ],
               "Condition": {
-                "ArnEquals": {"AWS:SourceArn": "${ruleArn}"}
+                "ArnEquals": {"AWS:SourceArn": "${LogsRule.Arn}"}
               }
             }
           ]
         }
-      - { logArn: !GetAtt LogGroupForEvents.Arn, ruleArn:  !GetAtt LogsRule.Arn}


### PR DESCRIPTION
… pattern

*Issue #, if available:*

*Description of changes:*

For the eventbridge-cloudwatch pattern, split the CloudWatch Logs resource policy into two statements.  The conditional ARN for the Rule only applies to logs:PutLogEvents.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
