### PR TITLE
New serverless pattern: Lambda partial batch response for SQS as an event source with AWS SAM and Rust

### DIFF
--- a/sqs-lambda-report-batchItem-failures-rust/Cargo.toml
+++ b/sqs-lambda-report-batchItem-failures-rust/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "sqs-lambda-report-batchItem-failures-rust"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[[bin]]
+name = "handler"
+path = "src/bin/handler.rs"
+
+[dependencies]
+aws_lambda_events = "0.6.1"
+futures = "0.3.17"
+lambda_runtime = "0.5.1"
+serde = {version = "1.0", features = ["derive"] }
+serde_json = "1.0.68"
+simple-error = "0.2"
+tokio = { version = "1", features = ["full"] }
+tracing-subscriber = "0.3"

--- a/sqs-lambda-report-batchItem-failures-rust/Makefile
+++ b/sqs-lambda-report-batchItem-failures-rust/Makefile
@@ -1,0 +1,29 @@
+FUNCTIONS := handler
+ARCH := aarch64-unknown-linux-gnu
+ARCH_SPLIT = $(subst -, ,$(ARCH))
+
+build:
+ifeq ("$(shell zig targets | jq -r .native.cpu.arch)-$(shell zig targets | jq -r .native.os)-$(shell zig targets | jq -r .native.abi)", "$(word 1,$(ARCH_SPLIT))-$(word 3,$(ARCH_SPLIT))-$(word 4,$(ARCH_SPLIT))")
+	@echo "Same host and target. Using native build"
+	cargo build --release --target $(ARCH)
+else
+	@echo "Different host and target. Using zigbuild"
+	cargo zigbuild --release --target $(ARCH)
+endif
+
+	rm -rf ./build
+	mkdir -p ./build
+	${MAKE} ${MAKEOPTS} $(foreach function,${FUNCTIONS}, build-${function})
+
+build-%:
+	mkdir -p ./build/$*
+	cp -v ./target/$(ARCH)/release/$* ./build/$*/bootstrap
+
+deploy:
+	if [ -f samconfig.toml ]; \
+		then sam deploy; \
+		else sam deploy -g; \
+	fi
+
+delete:
+	sam delete

--- a/sqs-lambda-report-batchItem-failures-rust/README.md
+++ b/sqs-lambda-report-batchItem-failures-rust/README.md
@@ -1,0 +1,128 @@
+# Amazon SQS batch error handling with AWS Lambda
+
+The SAM template deploys a Lambda function, an SQS queue and the IAM permissions required to run the application. SQS invokes the Lambda function when new messages are available.
+
+Learn more about this pattern at Serverless Land Patterns: [serverlessland.com/patterns/sqs-lambda-report-batchItem-failures-rust](https://serverlessland.com/patterns/sqs-lambda-report-batchItem-failures-rust)
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+* [Rust](https://www.rust-lang.org/) 1.56.0 or higher
+* [cargo-zigbuild](https://github.com/messense/cargo-zigbuild) and [Zig](https://ziglang.org/) for cross-compilation
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+2. Change directory to the pattern directory:
+    ```
+    cd sqs-lambda-report-batchItem-failures-rust
+    ```
+3. Install dependencies and build:
+    ```
+    make build
+    ```
+4. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
+    ```
+    make deploy
+    ```
+5. During the prompts:
+    * Enter a stack name
+    * Enter the desired AWS Region
+    * Allow SAM CLI to create IAM roles with the required permissions.
+
+    Once you have run `sam deploy -guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+
+6. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## Example event payload from SQS to Lambda
+
+```
+{
+   "payload":"SqsEvent"{
+      "records":[
+         "SqsMessage"{
+            "message_id":"Some(""7697a58e-fab7-4721-818b-7e0483324012"")",
+            "receipt_handle":"Some(""AQEB8Eh+8C+Jp9VolnTbHSAY0szz5cHO7kOS6Far2HDlvdjqvT46biZwf6UX1zSJdY/AUaoM+B3g0IdF9xhKqFZkYoGp2FhPN4rZ9hb40YAK1U/818PIznkGjG8iGsoqFrmxY9D85Ip9+82tuTv79vc5jbn3w2LANU9V2fe+0Ge1XRwgHUf3l/677AYp77pWy2/nPGpRJ2EEGRh37OwQHr5HXM2rQK5Wercm9B6+FrSf+k/Vnza+rUwNhaCd/XUgiPu7DtQGQzN5Ooc3we+8bKuhzjlA9onINOdi/NiSMHASsU5cGQgvLDYC3PE7naeoBP/l8bFb/XuhVMC86aV4krQmgT4YVlE9Ptr+ftpBgsNXyqi3jGKxXLum3fMfZAWRCJ1w1KCDjb857C/z3jMmPdj5NmnTbJqaDzc/cishAFy5R/4="")",
+            "body":"Some(""{\"to_error\":\"Boom\",\"surname\":\"Kaboom\"}"")",
+            "md5_of_body":"Some(""7ac8a6db4f6530a9e634d14d975e0c3a"")",
+            "md5_of_message_attributes":"None",
+            "attributes":{
+               "SenderId":"AROAYKMZLNCDSKNYVGYUR:botocore-session-1650176085",
+               "SentTimestamp":"1650176093155",
+               "ApproximateReceiveCount":"1",
+               "ApproximateFirstReceiveTimestamp":"1650176093156"
+            },
+            "message_attributes":{
+               
+            },
+            "event_source_arn":"Some(""arn:aws:sqs:<AWS_REGION>:<AWS_ACCOUNT_ID>:<QUEUE_NAME>"")",
+            "event_source":"Some(""aws:sqs"")",
+            "aws_region":"Some(""<AWS_REGION>"")"
+         }
+      ]
+   },
+   "context":"Context"{
+      "request_id":"92d6a05d-d85f-532b-94b4-fa886ad0ff36",
+      "deadline":1650176123407,
+      "invoked_function_arn":"arn:aws:lambda:<AWS_REGION>:<AWS_ACCOUNT_ID>:function:<LAMBDA_NAME>",
+      "xray_trace_id":"Root=1-625bb05d-1a3aa99c0aad77281463141e;Parent=66a523bf7ff75ec5;Sampled=0",
+      "client_context":"None",
+      "identity":"None",
+      "env_config":"Config"{
+         "function_name":"<LAMBDA_NAME>",
+         "memory":128,
+         "version":"$LATEST",
+         "log_stream":"2022/04/17/[$LATEST]c989cfef07364511a0a628e8bbdb40a1",
+         "log_group":"/aws/lambda/<LAMBDA_NAME>"
+      }
+   }
+}
+```
+### Testing
+
+Use the [AWS CLI](https://aws.amazon.com/cli/) to send a message to the SNS topic and observe the event delivered to the Lambda function:
+
+1. Send the SQS message:
+
+```bash
+aws sqs send-message-batch --queue-url ENTER_YOUR_SQS_QUEUE_URL --entries file://event.json
+
+```
+
+2. Then check the logs in Cloudwatch logs, you should see something like
+
+```bash
+do_something MyStruct { name: "Daniele", surname: "Frasca" }
+```
+
+3. Then check the dead letter, you should see one message there
+
+```bash
+  {
+    "to_error": "Boom",
+    "surname": "Kaboom"
+  }
+```
+
+## Cleanup
+ 
+1. Delete the stack
+    ```bash
+    make delete
+    ```
+2. Confirm the stack has been deleted
+    ```bash
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus"
+    ```
+----
+Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/sqs-lambda-report-batchItem-failures-rust/README.md
+++ b/sqs-lambda-report-batchItem-failures-rust/README.md
@@ -14,6 +14,7 @@ Important: this application uses various AWS services and there are costs associ
 * [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
 * [Rust](https://www.rust-lang.org/) 1.56.0 or higher
 * [cargo-zigbuild](https://github.com/messense/cargo-zigbuild) and [Zig](https://ziglang.org/) for cross-compilation
+* Make sure to run "rustup target add aarch64-unknown-linux-gnu;"
 
 ## Deployment Instructions
 

--- a/sqs-lambda-report-batchItem-failures-rust/event.json
+++ b/sqs-lambda-report-batchItem-failures-rust/event.json
@@ -1,0 +1,10 @@
+[
+  {
+    "Id": "1",
+    "MessageBody": "{\"name\":\"Daniele\",\"surname\":\"Frasca\"}"
+  },
+  {
+    "Id": "2",
+    "MessageBody": "{\"to_error\":\"Boom\",\"surname\":\"Kaboom\"}"
+  }
+]

--- a/sqs-lambda-report-batchItem-failures-rust/src/bin/handler.rs
+++ b/sqs-lambda-report-batchItem-failures-rust/src/bin/handler.rs
@@ -1,0 +1,95 @@
+use aws_lambda_events::event::sqs::SqsEvent;
+use futures::future::join_all;
+use lambda_runtime::{service_fn, Error, LambdaEvent};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::sync::{Arc, Mutex};
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    // required to enable CloudWatch error logging by the runtime
+    tracing_subscriber::fmt()
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
+        // disabling time is handy because CloudWatch will add the ingestion time.
+        .without_time()
+        .init();
+
+    lambda_runtime::run(service_fn(|event: LambdaEvent<SqsEvent>| execute(event))).await?;
+
+    Ok(())
+}
+
+pub async fn execute(event: LambdaEvent<SqsEvent>) -> Result<Value, Error> {
+    println!("Input {:?}", event);
+    let failed_message: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let mut tasks = Vec::with_capacity(event.payload.records.len());
+
+    for record in event.payload.records.into_iter() {
+        let failed_message = failed_message.clone();
+
+        tasks.push(tokio::spawn(async move {
+            if let Some(body) = &record.body {
+                let request = serde_json::from_str::<MyStruct>(&body);
+                if let Ok(request) = request {
+                    do_something(&request).await.map_or_else(
+                        |_e| {
+                            failed_message
+                                .lock()
+                                .unwrap()
+                                .push(record.message_id.unwrap().clone());
+                        },
+                        |_| (),
+                    );
+                } else {
+                    failed_message
+                        .lock()
+                        .unwrap()
+                        .push(record.message_id.unwrap().clone());
+                }
+            }
+        }));
+    }
+
+    join_all(tasks).await;
+
+    let response = BatchItemFailures {
+        batch_item_failures: failed_message
+            .lock()
+            .unwrap()
+            .clone()
+            .into_iter()
+            .map(|message_id| {
+                return ItemIdentifier {
+                    item_identifier: message_id,
+                };
+            })
+            .collect(),
+    };
+
+    Ok(serde_json::to_value(response).unwrap())
+}
+
+async fn do_something(request: &MyStruct) -> Result<(), Error> {
+    println!("do_something {:?}", request);
+    Ok(())
+}
+
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct MyStruct {
+    pub name: String,
+    pub surname: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct BatchItemFailures {
+    #[serde(rename = "batchItemFailures")]
+    pub batch_item_failures: Vec<ItemIdentifier>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct ItemIdentifier {
+    #[serde(rename = "itemIdentifier")]
+    pub item_identifier: String,
+}

--- a/sqs-lambda-report-batchItem-failures-rust/template.yaml
+++ b/sqs-lambda-report-batchItem-failures-rust/template.yaml
@@ -1,0 +1,57 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Serverless patterns - SQS to Lambda with ReportBatchItemFailures
+
+Globals:
+  Function:
+    MemorySize: 128
+    Architectures: ["arm64"]
+    Handler: bootstrap
+    Runtime: provided.al2
+    Timeout: 30
+    Environment:
+      Variables:
+        RUST_BACKTRACE: 1
+        RUST_LOG: info
+
+Resources:
+##########################################################################
+#   SQS                                                                  #
+##########################################################################
+  MyDeadSqsQueue:
+    Type: AWS::SQS::Queue
+
+  MySqsQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt MyDeadSqsQueue.Arn
+        maxReceiveCount: 1
+          
+##########################################################################
+#   Lambda Function                                                      #
+##########################################################################
+  MyFunction:
+    Type: AWS::Serverless::Function 
+    Properties:
+      CodeUri: ./build/handler
+      Events:
+        MySQSEvent:
+          Type: SQS
+          Properties:
+            Queue: !GetAtt MySqsQueue.Arn
+            BatchSize: 10
+            FunctionResponseTypes:
+              - ReportBatchItemFailures
+
+Outputs:
+  MySqsQueueName:
+    Description: SQS queue name
+    Value: !GetAtt MySqsQueue.QueueName
+  MySqsQueueArn:
+    Description: SQS queue ARN
+    Value: !GetAtt MySqsQueue.Arn
+  MySqsQueueURL:
+    Description: SQS queue URL
+    Value: !Ref MySqsQueue
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- AWS Lambda now supports partial batch response for SQS as an event source. 
- This example shows how to handle a batch of SQS messages in parallel
- This example shows how to handle a partial batch failure 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
