### PR TITLE
Java based pattern for CloudFront and Lambda URLs

### DIFF
--- a/cloudfront-lambda-url-java/LambdaFunction/pom.xml
+++ b/cloudfront-lambda-url-java/LambdaFunction/pom.xml
@@ -1,0 +1,46 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>LambdaFunction</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+    <name>Lambda function with function URL.</name>
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-core</artifactId>
+            <version>1.2.1</version>
+        </dependency>
+        <dependency>
+          <groupId>com.amazonaws</groupId>
+          <artifactId>aws-lambda-java-events</artifactId>
+          <version>3.11.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>3.2.4</version>
+          <configuration>
+          </configuration>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                <goal>shade</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </build>
+</project>

--- a/cloudfront-lambda-url-java/LambdaFunction/src/main/java/com/example/App.java
+++ b/cloudfront-lambda-url-java/LambdaFunction/src/main/java/com/example/App.java
@@ -1,0 +1,25 @@
+package com.example;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPResponse;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
+
+import java.util.Map;
+
+
+public class App implements RequestHandler<APIGatewayV2HTTPEvent, APIGatewayV2HTTPResponse> {
+
+    public APIGatewayV2HTTPResponse handleRequest(final APIGatewayV2HTTPEvent event, final Context context) {
+        LambdaLogger logger = context.getLogger();
+
+        logger.log(event.toString());
+
+        return APIGatewayV2HTTPResponse.builder()
+                .withStatusCode(200)
+                .withHeaders(Map.of("Content-Type", "text/plain"))
+                .withBody("Hello, World")
+                .build();
+    }
+}

--- a/cloudfront-lambda-url-java/README.md
+++ b/cloudfront-lambda-url-java/README.md
@@ -1,0 +1,100 @@
+# Amazon CloudFront to AWS Lambda URLs
+
+This pattern demonstrates how to setup Amazon CloudFront to proxy and cache traffic to AWS Lambda Function URLs. 
+
+A function URL is a dedicated endpoint for your Lambda function. When you create a function URL, Lambda automatically generates a unique URL endpoint for you.
+
+By configuring CloudFront infront of the Lambda Function URL endpoint you can use custom domain names, AWS Web Application Firewall (WAF) and AWS Shield Advanced to protect your endpoint from attacks.
+
+Learn more about this pattern at Serverless Land Patterns: << Add the live URL here >>
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ```
+    cd cloudfront-lambda-url-java
+    ```
+1. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
+    ```
+    sam deploy --guided
+    ```
+1. During the prompts:
+    * Enter a stack name
+    * Enter the desired AWS Region
+    * Allow SAM CLI to create IAM roles with the required permissions.
+
+    Once you have run `sam deploy --guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+
+1. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## How it works
+
+An Amazon CloudFront distribution is created that forwards requests to the domain name of the deployed AWS Lambda function URL. Amazon CloudFront also caches responses from the Lambda function. 
+
+## Testing
+
+Getting the CloudFront domain from the stack deployment we can test it using Curl. 
+
+```bash
+curl -D - https://dsd6hgzvwqfxn.cloudfront.net/
+HTTP/2 200 
+content-type: text/plain
+content-length: 12
+date: Thu, 21 Apr 2022 04:20:14 GMT
+x-amzn-requestid: 0f803e2e-dc5e-4c3e-8f90-8ab3a1b0f337
+x-amzn-trace-id: root=1-6260db7e-685b10df5828b0284f923adb;sampled=0
+x-cache: Miss from cloudfront
+via: 1.1 a63f63c0130cd2db055700cdbe2c6c88.cloudfront.net (CloudFront)
+x-amz-cf-pop: SYD62-P1
+x-amz-cf-id: Jw_dYSCio5elb-XgDYILECjKH9yPr9YNg91TrLFod70hpMn_frUD8Q==
+age: 103
+
+Hello, World
+```
+
+Note that if we make a second request we get a hit from the cache. 
+
+```bash
+curl -D - https://dsd6hgzvwqfxn.cloudfront.net/
+HTTP/2 200 
+content-type: text/plain
+content-length: 12
+date: Thu, 21 Apr 2022 04:20:14 GMT
+x-amzn-requestid: 0f803e2e-dc5e-4c3e-8f90-8ab3a1b0f337
+x-amzn-trace-id: root=1-6260db7e-685b10df5828b0284f923adb;sampled=0
+x-cache: Hit from cloudfront
+via: 1.1 3437ef72cec711eb0ebed9222a22cf66.cloudfront.net (CloudFront)
+x-amz-cf-pop: SYD62-P1
+x-amz-cf-id: cNb50PRL1QrfFk-OWOggN3QN738Y0SL8t7_xkNjTVk-Sr-IMOqjRsg==
+age: 401
+
+Hello, World
+```
+
+## Cleanup
+ 
+1. Delete the stack
+    ```bash
+    aws cloudformation delete-stack --stack-name STACK_NAME
+    ```
+1. Confirm the stack has been deleted
+    ```bash
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus"
+    ```
+----
+Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/cloudfront-lambda-url-java/example-pattern.json
+++ b/cloudfront-lambda-url-java/example-pattern.json
@@ -1,0 +1,53 @@
+{
+  "title": "Amazon CloudFront to AWS Lambda URLs",
+  "description": "Front AWS Lamda Function URLs with Amazon CloudFront",
+  "language": "Java",
+  "level": "200",
+  "framework": "SAM",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "An Amazon CloudFront distribution is created that forwards requests to the domain name of the deployed AWS Lambda function URL.",
+      "Amazon CloudFront also allows for custom domain names, AWS Web Application Firewall (WAF) and AWS Shield Advanced to protect your endpoint from attacks."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/cloudfront-lambda-url-java",
+      "templateURL": "serverless-patterns/cloudfront-lambda-url-java"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "Using Amazon CloudFront with AWS Lambda as origin to accelerate your web applications",
+        "link": "https://aws.amazon.com/blogs/networking-and-content-delivery/using-amazon-cloudfront-with-aws-lambda-as-origin-to-accelerate-your-web-applications/"
+      },
+      {
+        "text": "Lambda function URLs",
+        "link": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-urls.html"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "sam deploy --guided"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the Github repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>sam delete --stack-name STACK_NAME</code>."
+    ]
+  },
+  "authors": [
+    {
+      "name": "Steven Cook",
+      "bio": "Senior Solutions Architect at AWS."
+    }
+  ]
+}

--- a/cloudfront-lambda-url-java/template.yml
+++ b/cloudfront-lambda-url-java/template.yml
@@ -1,0 +1,54 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  LambdaFunction:
+    Type: AWS::Serverless::Function 
+    Properties:
+      CodeUri: LambdaFunction/
+      Handler: com.example.App::handleRequest
+      Runtime: java11
+      Architectures:
+        - x86_64
+      Timeout: 30
+      MemorySize: 512
+      Environment:
+        Variables:
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 
+      FunctionUrlConfig:
+        AuthType: NONE
+
+  CloudFrontDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        PriceClass: PriceClass_All
+        HttpVersion: http2
+        IPV6Enabled: true
+        Comment: Distribution with Lambda Function URL
+        Origins:
+        - DomainName: !Select [2, !Split ["/", !GetAtt LambdaFunctionUrl.FunctionUrl]] # Remove https:// from URL. 
+          Id: LambdaOrigin
+          CustomOriginConfig:
+            HTTPSPort: 443
+            OriginProtocolPolicy: https-only
+        Enabled: 'true'
+        DefaultCacheBehavior:
+          TargetOriginId: LambdaOrigin
+          CachePolicyId: '658327ea-f89d-4fab-a63d-7e88639e58f6'
+          ViewerProtocolPolicy: redirect-to-https
+          SmoothStreaming: 'false'
+          Compress: 'true'
+
+
+Outputs:
+  LambdaFunction:
+    Description: "Lambda Function ARN"
+    Value: !GetAtt LambdaFunction.Arn
+  LambdaFunctionURL:
+    Description: "Lambda function URL"
+    Value: !GetAtt LambdaFunctionUrl.FunctionUrl
+  CloudFrontDomain:
+    Description: CloudFront domain name 
+    Value: !Sub https://${CloudFrontDistribution.DomainName}/
+


### PR DESCRIPTION
*Description of changes:*

New pattern showing how to use Lambda function URLs behind CloudFront distribution with Java. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
