### PR TITLE
add missing --capabilities CAPABILITY_NAMED_IAM to sam deploy

### DIFF
--- a/systems-manager-automation-to-lambda/README.md
+++ b/systems-manager-automation-to-lambda/README.md
@@ -29,14 +29,14 @@ Important: this application uses various AWS services and there are costs associ
     ```
 3. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
     ```
-    sam deploy --guided
+    sam deploy --guided --capabilities CAPABILITY_NAMED_IAM
     ```
 4. During the prompts:
     * Enter a stack name
     * Enter the desired AWS Region
     * Allow SAM CLI to create IAM roles with the required permissions.
 
-    Once you have run `sam deploy --guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+    Once you have run `sam deploy --guided --capabilities CAPABILITY_NAMED_IAM` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
 
 5. Note the following output Values from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
 


### PR DESCRIPTION
*Issue #, if available:*
Regarding the `systems-manager-automation-to-lambda` example, `sam deploy` fails with the error:
```
Error: Failed to create changeset for the stack: sam-app, ex: Waiter ChangeSetCreateComplete failed: Waiter encountered a terminal failure state: For expression "Status" we matched expected path: "FAILED" Status: FAILED. Reason: Requires capabilities : [CAPABILITY_NAMED_IAM]
```

*Description of changes:*
Add  missing `--capabilities CAPABILITY_NAMED_IAM` to `sam deploy` in the README.md

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
