### PR TITLE
Added automation for cfn-nag on pull requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,41 @@
+name: "Lint Serverless Pattern"
+
+on: [pull_request]
+
+jobs:
+  verify-template:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Get changed files using defaults
+        id: changed-files
+        uses: tj-actions/changed-files@v19
+        with:
+          separator: ","
+
+      - name: Validate Templates
+        uses: ./ # Uses an action in the root directory
+        id: validate-templates
+        with:
+          new-files: ${{ steps.changed-files.outputs.added_files }}
+          modified-files: ${{ steps.changed-files.outputs.modified_files }}
+      
+      - name: Comment
+        if: failure()
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `**Failed to verify your serverless pattern**
+
+              Please check the GitHub Actions and make the changes required to your template.`
+            })     

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `**Failed to verify your serverless pattern**
-
-              Please check the GitHub Actions and make the changes required to your template.`
+              body: `**Failed to verify your serverless pattern**: Please check the GitHub Actions and make the changes required to your template.`
             })     

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Docker file used for custom GitHub Action to run cfn-nag
+FROM beevelop/nodejs-python-ruby:latest
+
+RUN gem install cfn-nag -v 0.8.9
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY . ./
+
+RUN ["chmod", "+x", "/usr/src/app/cfn-nag-action/entrypoint.sh"]
+
+# Code file to execute when the docker container starts up (`entrypoint.sh`)
+ENTRYPOINT ["/usr/src/app/cfn-nag-action/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,16 @@
+# action.yml
+name: 'Serverless Patterns Action'
+description: 'Run validation scripts against patterns'
+inputs:
+  modified-files: # list of modified files in the PR
+    description: 'List of files that have been modified'
+    default: ""
+  new-files: # list of new files in the PR
+    description: 'List of files that have been added'
+    default: ""
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.new-files }}
+    - ${{ inputs.modified-files }}

--- a/cfn-nag-action/entrypoint.sh
+++ b/cfn-nag-action/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh -l
+echo "New files $1"
+echo "Modfied Files $2"
+
+node /usr/src/app/cfn-nag-action/src/index.js $1 $2
+exitcode=$?
+
+echo "::set-output name=failed::$exitcode"
+
+# Exit with value from node
+exit $exitcode
+

--- a/cfn-nag-action/src/cfg-nag.js
+++ b/cfn-nag-action/src/cfg-nag.js
@@ -1,0 +1,15 @@
+const { execSync } = require('child_process');
+
+const path = '/usr/src/app';
+
+module.exports = (pathToTemplate) => {
+  try {
+    console.log(`Verifying ${pathToTemplate}`);
+    execSync(`cfn_nag ${path}/${pathToTemplate} --output-format json`);
+    return [];
+  } catch (error) {
+    const errorFromCFNNAG = error.output[1].toString();
+    const response = JSON.parse(errorFromCFNNAG);
+    return response;
+  }
+};

--- a/cfn-nag-action/src/index.js
+++ b/cfn-nag-action/src/index.js
@@ -1,0 +1,46 @@
+const cfnNag = require('./cfg-nag');
+const filesToCheck = ['template.yml', 'template.yaml'];
+
+const args = process.argv.slice(2);
+
+const newFiles = args[0].split(',');
+const modifiedFiles = args[1].split(',');
+
+const getValidFilesForCfnNag = (files) => files.filter((file) => filesToCheck.some((validFile) => file.includes(validFile)));
+
+const filesToVerify = [...getValidFilesForCfnNag(newFiles), ...getValidFilesForCfnNag(modifiedFiles)];
+
+if (!filesToVerify.length) {
+  console.log('No new or modified files found to verify');
+  process.exit(0);
+}
+
+const resultsFromAllPatterns = filesToVerify.reduce((acc, pathToTemplate) => {
+  console.log(`Processing ${pathToTemplate}...`);
+  const result = cfnNag(pathToTemplate);
+
+  // Just get the errors from the response (ignore warnings)
+  const errors = result.reduce((errors, response) => {
+    const {
+      filename,
+      file_results: { failure_count, violations },
+    } = response;
+
+    // only failures, ignore warnings.
+    if (failure_count === 0) return errors;
+
+    const violationsWithErrors = violations.filter((violation) => violation.type === 'FAIL');
+
+    return errors.concat({ filename, violationsWithErrors });
+  }, []);
+
+  return acc.concat(errors);
+}, []);
+
+// We have errors with the templates
+if(resultsFromAllPatterns.length > 0){
+    console.log('Errors found with new or modified templates, please review')
+    console.log(JSON.stringify(resultsFromAllPatterns, null, 4));
+    process.exit(1);
+}
+


### PR DESCRIPTION
## Description of changes

This pull request is to introduce automating [cfn-nag](https://github.com/stelligent/cfn_nag) as part of the pull request process for serverless patterns.

## Why

When users add new patterns, there is currently a manual process that takes place to run [cfn-nag](https://github.com/stelligent/cfn_nag) to verify the given template file is valid (without errors).

This workflow / GitHub Action will now run this check on any **modified or new** template files added to pull requests.

If no template files have been added to the pull request `cfn-nag` will not be run.

## How it works

1. On every pull request the workflow **Lint Serverless Pattern** is triggered
2. All changed/added files are gathered and passed into the custom GitHub Action, and templates are filtered.
3. A custom script (inside a docker container with cfn-nag) runs `cfn-nag` against any template that has been found (from Step 2).
4. Warnings are stripped from the result of `cfn-nag` and if there is any *errors* then the **GitHub action will fail**
5. Comment is raised back on the issue telling users to check the output from `cfn-nag` and make the changes.

## How will this improve the process?

Hopefully this automation will give users faster feedback on their template and give them the option and feedback to fix the errors and remove the manual need to run this process for maintainers of the project.

### Things to note

To get custom GitHub actions running and working, the `DockerFile` and `action.yml` file needs to be in the root of the project. 

### Future automation

If this GitHub action works and provides value, we can also extend it to:

- Make sure README is added to pattern
- Make sure `example-pattern.json` is added to pattern
- Make sure PR < 500kb (to keep repo size down)

---
Let me know if you have any feedback or thoughts. I tested this locally in my own repo and it worked OK. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
