### PR TITLE
Fixing invalid JSON - example-pattern for lambda-function-url-cdk

### DIFF
--- a/lambda-function-url-cdk/example-pattern.json
+++ b/lambda-function-url-cdk/example-pattern.json
@@ -14,7 +14,7 @@
     "template": {
       "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/lambda-function-url-cdk",
       "templateURL": "serverless-patterns/lambda-function-url-cdk",
-      "projectFolder": "lambda-function-url-cdk",
+      "projectFolder": "lambda-function-url-cdk"
     }
   },
   "resources": {


### PR DESCRIPTION
Small fix fixing the JSON file for this pattern, removed the additional comma that was in the file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
