### PR TITLE
New serverless pattern - apigw-method-cache

### DIFF
--- a/apigw-method-cache/README.md
+++ b/apigw-method-cache/README.md
@@ -1,0 +1,67 @@
+# Amazon API Gateway REST API with cache enabled
+
+The SAM template deploys an Amazon API Gateway REST API endpoint with a method-level cache.
+The GET method on the root resource / is enabled with a cache and TTL (Time-To-Live) of 10 seconds.
+Any requests made within this 10 second period will be a cache hit and the cached response will be returned by API Gateway immediately without invoking the Lambda integration.
+The Lambda integration returns a timestamp in the header so that it is easy to visualize whether a particular response is being returned as a cached response or as a response from the Lambda integration.
+
+
+Note: when deploying this pattern, *CAPABILITY_IAM* is required.
+
+Learn more about this pattern at Serverless Land Patterns: [https://serverlessland.com/patterns/apigw-method-cache](https://serverlessland.com/patterns/apigw-method-cache)
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+2. Change directory to the pattern directory:
+    ```
+    cd apigw-method-cache
+    ```
+3. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
+    ```
+    sam deploy -g
+    ```
+1. During the prompts:
+    * Enter a stack name
+    * Select the desired AWS Region
+    * Allow SAM to create roles with the required permissions if needed.
+
+    Once you have run guided mode once, you can use `sam deploy` in future to use these defaults.
+
+1. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## Testing
+
+The stack will output the **api endpoint**. Please allow a few minutes for the cache to be created. Once the Cache status has switched from **CREATE_IN_PROGRESS** to **AVAILABLE**, you can make an HTTP request to the endpoint using *curl* to test the method-level cache.
+
+```
+curl -i https://{apiId}.execute-api.{region}.amazonaws.com/Prod
+```
+The *-i* flag will output the returned headers. Check the header *timestamp* to determine whether the response is cached or a fresh response from the Lambda integration.   
+
+## Cleanup
+ 
+1. Delete the stack
+    ```bash
+    sam delete
+    ```
+1. Confirm the stack has been deleted
+    ```bash
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus"
+    ```
+----
+Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/apigw-method-cache/example-pattern.json
+++ b/apigw-method-cache/example-pattern.json
@@ -1,0 +1,57 @@
+{
+    "title": "Amazon API Gateway with cache enabled",
+    "description": "Create a REST API Gateway with a method-level cache",
+    "language": "Node.js",
+    "level": "200",
+    "framework": "SAM",
+    "introBox": {
+      "headline": "How it works",
+      "text": [
+        "This pattern deploys an Amazon API Gateway REST API endpoint with a method-level cache.",
+        "The GET method on the root resource / is enabled with a cache and TTL (Time-To-Live) of 10 seconds.",
+        "Any requests made within this 10 second period will be a cache hit and the cached response will be returned by API Gateway immediately without invoking the Lambda integration.",
+        "The Lambda integration returns a timestamp in the header so that it is easy to visualize whether a particular response is being returned as a cached response or as a response from the Lambda integration."
+      ]
+    },
+    "gitHub": {
+      "template": {
+        "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/apigw-method-cache",
+        "templateURL": "serverless-patterns/apigw-method-cache",
+        "projectFolder": "apigw-method-cache",
+        "templateFile": "template.yaml"
+      }
+    },
+    "resources": {
+      "bullets": [
+        {
+          "text": "Create a REST API Gateway with a method-level cache",
+          "link": "https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-caching.html"
+        }
+      ]
+    },
+    "deploy": {
+      "text": [
+        "Deploy the stack: <code>sam deploy</code>."
+      ]
+    },
+    "testing": {
+      "text": [
+        "See the Github repo for detailed testing instructions."
+      ]
+    },
+    "cleanup": {
+      "text": [
+        "Delete the stack: <code>sam delete</code>."
+      ]
+    },
+    "authors": [
+      {
+        "headline": "Presented by Albert Blaya, Solutions Architect",
+        "name": "Albert Blaya",
+        "image": "https://media-exp1.licdn.com/dms/image/C5603AQEw2HXx9zs7yg/profile-displayphoto-shrink_200_200/0/1600474292127?e=1655942400&v=beta&t=SbeIn9psV0BIFkbROTDRIfPMKMtyrrgBdgt0tRHY0BY",
+        "bio": "Albert is a Solutions Architect at Amazon Web Services based in Australia.",
+        "linkedin": "albertblaya"
+      }
+    ]
+  }
+  

--- a/apigw-method-cache/src/app.js
+++ b/apigw-method-cache/src/app.js
@@ -1,0 +1,13 @@
+/*! Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: MIT-0
+ */
+
+'use strict'
+
+exports.handler = async (event, context) => ({
+    "statusCode": 200,
+    "body": JSON.stringify(event),
+    "headers": {
+        "timestamp": +new Date
+    }
+});

--- a/apigw-method-cache/template.yaml
+++ b/apigw-method-cache/template.yaml
@@ -1,0 +1,73 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Serverless patterns - Amazon API Gateway REST API with method-level cache enabled
+
+Globals:
+  Function:
+    Runtime: nodejs14.x
+    CodeUri: src/
+
+Resources:
+  
+  # REST API
+  AppApi:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      Name: apigw-method-cache
+      Description: Cached Method REST API demo
+
+  # GET Method
+  RootMethodGet:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      RestApiId: !Ref AppApi
+      ResourceId: !GetAtt AppApi.RootResourceId
+      HttpMethod: GET
+      AuthorizationType: NONE
+      Integration:
+        Type: AWS_PROXY
+        IntegrationHttpMethod: POST
+        Uri: !Join ['', ['arn:aws:apigateway:', !Ref AWS::Region, ':lambda:path/2015-03-31/functions/', !GetAtt AppFunction.Arn, '/invocations']]
+
+  # Dummy function
+  AppFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: app.handler
+
+  # Permission to allow Lambda invocation from API Gateway
+  AppFunctionPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref AppFunction
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${AppApi}/*/GET/
+
+  Deployment:
+    Type: AWS::ApiGateway::Deployment
+    DependsOn:
+    - RootMethodGet
+    Properties:
+      RestApiId: !Ref AppApi
+  
+  Stage:  
+    Type: AWS::ApiGateway::Stage
+    Properties:
+      StageName: Prod
+      RestApiId: !Ref AppApi
+      DeploymentId: !Ref Deployment
+      CacheClusterEnabled: True
+      CacheClusterSize: 0.5
+      MethodSettings:
+        - CachingEnabled: True
+          CacheTtlInSeconds: 10
+          ResourcePath: /
+          HttpMethod: GET
+
+Outputs:
+
+  # API Gateway endpoint to be used during tests
+  AppApiEndpoint:
+    Description: API Endpoint
+    Value: !Sub "https://${AppApi}.execute-api.${AWS::Region}.amazonaws.com/Prod"


### PR DESCRIPTION
*Issue #, if available:*

Submission of a new serverless pattern that deploys an Amazon API Gateway REST API endpoint with a method-level cache.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
