### PR TITLE
Updated the Cognito User Pool Domain name to include the AWS Account Id.

### DIFF
--- a/cognito-user-pool/template.yaml
+++ b/cognito-user-pool/template.yaml
@@ -54,7 +54,7 @@ Resources:
   CognitoAuthorizerUserPoolDomain:
     Type: AWS::Cognito::UserPoolDomain
     Properties: 
-      Domain: user-pool-domain
+      Domain: !Sub user-pool-domain-${AWS::AccountId}
       UserPoolId: !Ref CognitoAuthorizerUserPool
 
 Outputs:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updated the Cognito User Pool domain name to include the AWS Account Id. The domain name must be unique across all customers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
