### PR TITLE
New serverless pattern - apigw-websocket-api-connection-dynamodb

### DIFF
--- a/apigw-websocket-api-connection-dynamodb/README.md
+++ b/apigw-websocket-api-connection-dynamodb/README.md
@@ -1,0 +1,126 @@
+# Amazon API Gateway WebSocket API connection tracking using AWS Service integration type and Amazon DynamoDB
+
+This pattern uses Amazon API Gateway WebSocket API and AWS Service integration type with Amazon DynamoDB for the connection tracking. This approach simplifies architecture by eliminating the need to use additional compute components such as AWS Lambda. 
+
+Learn more about this pattern at Serverless Land Patterns: ["API Gateway WebSocket API connection ID tracking"](https://serverlessland.com/patterns/apigw-websocket-api-connection-dynamodb)
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ```
+    cd apigw-websocket-api-connection-dynamodb
+    ```
+1. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
+    ```
+    sam deploy --guided
+    ```
+1. During the prompts:
+    * Enter a stack name
+    * Enter the desired AWS Region
+    * Allow SAM CLI to create IAM roles with the required permissions.
+
+    Once you have run `sam deploy --guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+
+1. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## How it works
+
+API Gateway forwards initial connection request to the \$connect route, along with headers and query string information. This pattern uses AWS Service integration and data transformation mapping templates to store WebSocket connection IDs in a DynamoDB table instead of a traditional approach that uses AWS Lambda functions to do that. Along with the connection ID in the DynamoDB, it stores headers and query string that are available at the connection time only. It also specifies Time to Live for the object (24 hours) to clean up failed connections if needed. 
+
+In a similar way, $disconnect route uses AWS Service integration along with data transformation mapping templates to delete connection data from the DynamoDB when the client or the server disconnects from the API.
+
+To implement sample business logic, this pattern uses AWS Lambda function as an integration target of the \$default route. It responds with the event data, performing no further actions.
+
+Production implementation of this pattern would include a more complex business logics implementation. It would also read session data (headers, query string parameters) from the DynamoDB table to provide request context to the downstream resources. You can also use connection ID stored in the DynamoDB table in the [@connections command](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-how-to-call-websocket-api-connections.html) to send messages to the connected clients from the backend.
+
+For extended examples of this pattern see [Serverless Samples repository](https://github.com/aws-samples/serverless-samples/tree/main/apigw-ws-integrations)
+
+## Testing
+
+To test this example, connect to the API Gateway WebSocket endpoint using the URL in the stack outputs and wscat (see [documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-how-to-call-websocket-api-wscat.html) for more details how to set it up):
+
+```bash
+wscat -c "<API Endpoint from stack outputs>?foo=bar"
+```
+
+Send a payload to the API by typing it in. Lambda function will respond with the request details. For example:
+```bash
+> {"first_name" : "Jane", "last_name" : "Doe"}
+< {
+    "requestContext": {
+        "routeKey": "$default",
+        "messageId": "SOqIDdzSoAMCEeg=",
+        "eventType": "MESSAGE",
+        "extendedRequestId": "SOqIDEacoAMFaHQ=",
+        "requestTime": "16/May/2022:17:30:27 +0000",
+        "messageDirection": "IN",
+        "stage": "api",
+        "connectedAt": 1652722217711,
+        "requestTimeEpoch": 1652722227357,
+        "identity": {
+            "sourceIp": "123.456.789.123"
+        },
+        "requestId": "SOqIDEacoAMFaHQ=",
+        "domainName": "u9jlm1pv1h.execute-api.us-east-1.amazonaws.com",
+        "connectionId": "SOqGjdZioAMCEeg=",
+        "apiId": "u9jlm1pv1h"
+    },
+    "body": "{\"first_name\" : \"Jane\", \"last_name\" : \"Doe\"}",
+    "isBase64Encoded": false
+}
+```
+
+Note the connectionId field value. Open a new terminal window and check the DynamoDB item corresponding to this connection (use the DynamoDB table name in the stack outputs):
+
+```bash
+aws dynamodb get-item --table-name <DynamoDB table name from stack outputs> \
+  --key '{"connectionid" : {"S":"<connection ID field value from the Lambda function response>"}}'
+
+{
+    "Item": {
+        "connectionid": {
+            "S": "SOqGjdZioAMCEeg="
+        },
+        "ttl": {
+            "N": "1652722304111"
+        },
+        "querystring": {
+            "S": "{foo=bar}"
+        },
+        "headers": {
+            "S": "{Host=u9jlm1pv1h.execute-api.us-east-1.amazonaws.com, Sec-WebSocket-Extensions=permessage-deflate; client_max_window_bits, Sec-WebSocket-Key=oWaeekvolZlFevfyQ7SRRw==, Sec-WebSocket-Version=13, X-Amzn-Trace-Id=Root=1-62828a29-3824232936b70e2306c11218, X-Forwarded-For=123.456.789.123, X-Forwarded-Port=443, X-Forwarded-Proto=https}"
+        }
+    }
+}
+
+```
+
+Disconnect from the WebSocket API and try to get the same DynamoDB item again. It should be deleted automatically and the command should not return any result.
+
+## Cleanup
+ 
+1. Delete the stack
+    ```bash
+    aws cloudformation delete-stack --stack-name STACK_NAME
+    ```
+1. Confirm the stack has been deleted
+    ```bash
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus"
+    ```
+----
+Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/apigw-websocket-api-connection-dynamodb/example-pattern.json
+++ b/apigw-websocket-api-connection-dynamodb/example-pattern.json
@@ -1,0 +1,58 @@
+{
+  "title": "API Gateway WebSocket API connection ID tracking",
+  "description": "Track API Gateway WebSocket API connections using AWS Service integration with DynamoDB",
+  "language": "",
+  "level": "200",
+  "framework": "SAM",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "This pattern uses Amazon API Gateway WebSocket API and AWS Service integration type with AmazonDynamoDB for client connection tracking.",
+      "This approach simplifies architecture by eliminating need to use additional compute components such as AWS Lambda."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/apigw-websocket-api-connection-dynamodb",
+      "templateURL": "serverless-patterns/apigw-websocket-api-connection-dynamodb",
+      "projectFolder": "apigw-websocket-api-connection-dynamodb",
+      "templateFile": "apigw-websocket-api-connection-dynamodb/template.yaml"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "Working with WebSocket APIs",
+        "link": "https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api.html"
+      },
+      {
+        "text": "Extended examples of this pattern implementation",
+        "link": "https://github.com/aws-samples/serverless-samples/tree/main/apigw-ws-integrations"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "sam deploy"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the Github repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>sam delete</code>."
+    ]
+  },
+  "authors": [
+    {
+      "name": "Giedrius Praspaliauskas",
+      "image": "",
+      "bio": "Giedrius is a senior solutions architect focusing on serverless at Amazon Web Services based in the US.",
+      "linkedin": "https://www.linkedin.com/in/gpraspaliauskas/",
+      "twitter": ""
+    }
+  ]
+}

--- a/apigw-websocket-api-connection-dynamodb/template.yaml
+++ b/apigw-websocket-api-connection-dynamodb/template.yaml
@@ -1,0 +1,256 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: > 
+  Serverless patterns - Amazon API Gateway WebSocket API connection
+  tracking using AWS Service integration type and Amazon DynamoDB
+
+Parameters:
+  ApiStageName:
+    Description: Name of WebSockets API stage
+    Type: String
+    Default: api  
+
+# Comment each resource section to explain usage
+Resources:
+#######################################################
+#   API Gateway WebSocket API
+#######################################################
+  WebSocketApi:
+    Type: AWS::ApiGatewayV2::Api
+    Properties:
+      Name: !Sub "${AWS::StackName}-WebSocketApi"
+      ProtocolType: WEBSOCKET
+      RouteSelectionExpression: "$request.body.action"
+
+  Deployment:
+    Type: AWS::ApiGatewayV2::Deployment
+    DependsOn:
+      - DefaultRoute
+    Properties:
+      ApiId: !Ref WebSocketApi
+
+  Stage:
+    Type: AWS::ApiGatewayV2::Stage
+    Properties:
+      StageName: !Ref ApiStageName
+      DeploymentId: !Ref Deployment
+      ApiId: !Ref WebSocketApi
+
+#######################################################
+#   Default route implementation
+#######################################################
+  DefaultRouteFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Runtime: nodejs14.x
+      Handler: index.handler
+      InlineCode: 'exports.handler = async (event) => {return {statusCode: 200, body: JSON.stringify(event)}}'
+
+  DefaultRouteFunctionPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref DefaultRouteFunction
+      Principal: apigateway.amazonaws.com
+
+  DefaultRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref WebSocketApi
+      RouteKey: $default
+      AuthorizationType: NONE
+      OperationName: DefaultRoute
+      Target: !Join 
+        - /
+        - - integrations
+          - !Ref DefaultRouteIntegration
+
+  DefaultRouteIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref WebSocketApi
+      IntegrationType: AWS_PROXY
+      IntegrationUri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DefaultRouteFunction.Arn}/invocations"
+
+  DefaultRouteResponse: 
+    Type: AWS::ApiGatewayV2::RouteResponse
+    Properties:
+      RouteId: !Ref DefaultRoute
+      ApiId: !Ref WebSocketApi
+      RouteResponseKey: $default
+
+  DefaultRouteIntegrationResponse:
+    Type: AWS::ApiGatewayV2::IntegrationResponse
+    Properties: 
+      ApiId: !Ref WebSocketApi
+      IntegrationId: !Ref DefaultRouteIntegration
+      IntegrationResponseKey: $default
+
+
+#######################################################
+#   Connect route implementation
+#######################################################
+  ConnectRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref WebSocketApi
+      RouteKey: $connect
+      AuthorizationType: NONE
+      OperationName: ConnectRoute
+      Target: !Join 
+        - /
+        - - integrations
+          - !Ref ConnectRouteIntegration
+
+  ConnectRouteIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref WebSocketApi
+      IntegrationType: AWS
+      IntegrationMethod: POST
+      IntegrationUri: !Sub "arn:aws:apigateway:${AWS::Region}:dynamodb:action/PutItem"
+      CredentialsArn: !Sub "${SessionsTableAccessRole.Arn}"
+      TemplateSelectionExpression: \$default
+      RequestTemplates: 
+        "$default" : 
+          Fn::Sub: >
+            #set($ttl = $context.requestTimeEpoch + 86400)
+            { 
+                "TableName": "${SessionsTable}",
+                "Item": {
+              "connectionid": {
+                        "S": "$context.connectionId"
+                        },
+              "headers": {
+                        "S": "$input.params().get('header')"
+                        },
+              "querystring": {
+                        "S": "$input.params().get('querystring')"
+                        },
+              "ttl": {
+                        "N": "$ttl"
+                        }
+                }
+            }
+
+  ConnectRouteResponse: 
+    Type: AWS::ApiGatewayV2::RouteResponse
+    Properties:
+      RouteId: !Ref ConnectRoute
+      ApiId: !Ref WebSocketApi
+      RouteResponseKey: $default
+
+  ConnectRouteIntegrationResponse:
+    Type: AWS::ApiGatewayV2::IntegrationResponse
+    Properties: 
+      ApiId: !Ref WebSocketApi
+      IntegrationId: !Ref ConnectRouteIntegration
+      IntegrationResponseKey: /200/
+      TemplateSelectionExpression: \$default
+
+#######################################################
+#   Disconnect route implementation
+#######################################################
+  DisconnectRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref WebSocketApi
+      RouteKey: $disconnect
+      AuthorizationType: NONE
+      OperationName: DisconnectRoute
+      Target: !Join 
+        - /
+        - - integrations
+          - !Ref DisconnectRouteIntegration
+
+  DisconnectRouteIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref WebSocketApi
+      IntegrationType: AWS
+      IntegrationMethod: POST
+      IntegrationUri: !Sub "arn:aws:apigateway:${AWS::Region}:dynamodb:action/DeleteItem"
+      CredentialsArn: !Sub "${SessionsTableAccessRole.Arn}"
+      TemplateSelectionExpression: \$default
+      RequestTemplates: 
+        "$default" : 
+          Fn::Sub: >
+            { 
+                "TableName": "${SessionsTable}",
+                "Key": {
+              "connectionid": {
+                        "S": "$context.connectionId"
+                        }
+                }
+            }
+
+  DisconnectRouteResponse: 
+    Type: AWS::ApiGatewayV2::RouteResponse
+    Properties:
+      RouteId: !Ref DisconnectRoute
+      ApiId: !Ref WebSocketApi
+      RouteResponseKey: $default
+
+  DisconnectRouteIntegrationResponse:
+    Type: AWS::ApiGatewayV2::IntegrationResponse
+    Properties: 
+      ApiId: !Ref WebSocketApi
+      IntegrationId: !Ref DisconnectRouteIntegration
+      IntegrationResponseKey: /200/
+      TemplateSelectionExpression: \$default
+
+#######################################################
+#   Data storage for connection tracking
+#######################################################
+  SessionsTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub  ${AWS::StackName}-Sessions
+      AttributeDefinitions:
+        - AttributeName: connectionid
+          AttributeType: S
+      KeySchema:
+        - AttributeName: connectionid
+          KeyType: HASH
+      TimeToLiveSpecification:
+          AttributeName: ttl
+          Enabled: true
+      BillingMode: PAY_PER_REQUEST
+
+  SessionsTableAccessRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Action:
+              - "sts:AssumeRole"
+            Effect: Allow
+            Principal:
+              Service:
+                - apigateway.amazonaws.com
+      Path: /
+      Policies:
+        - PolicyName: DynamoDBAccess
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "dynamodb:DeleteItem"
+                  - "dynamodb:PutItem"
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${SessionsTable}"
+
+# List all common outputs for usage
+Outputs:
+  APIEndpoint:
+    Description: "API Gateway WebSocket endpoint URL"
+    Value: !Sub "wss://${WebSocketApi}.execute-api.${AWS::Region}.amazonaws.com/${ApiStageName}"
+
+  SessionsTable:
+    Description: "DynamoDB sessions table for WebSocket API connection ID tracking"
+    Value: !Ref SessionsTable


### PR DESCRIPTION
… Service integration type and Amazon DynamoDB

*Issue #, if available:*

*Description of changes:*
Adding pattern that uses Amazon API Gateway WebSocket API and AWS Service integration type with Amazon DynamoDB for the connection tracking. This approach simplifies architecture by eliminating the need to use additional compute components such as AWS Lambda.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
