### PR TITLE
Documentation Fix: Removing references to AWS SAM from Terraform patterns

### DIFF
--- a/eventbridge-lambda-terraform/README.md
+++ b/eventbridge-lambda-terraform/README.md
@@ -56,7 +56,7 @@ Important: this application uses various AWS services and there are costs associ
 
 ## How it works
 
-The AWS SAM template deploys the resources and the IAM permissions required to run the application.
+The Terraform template deploys the resources and the IAM permissions required to run the application.
 
 The EventBridge rule specified in `main.tf` filters the events based upon the criteria in the `EventPattern` section. When matching events are sent to EventBridge that trigger the rule, they are delivered as a JSON event payload (see above) to the Lambda function.
 

--- a/lambda-eventbridge-terraform/README.md
+++ b/lambda-eventbridge-terraform/README.md
@@ -39,7 +39,7 @@ You are responsible for any AWS costs incurred. No warranty is implied in this e
 
 ## How it works
 
-The AWS Terraform template deploys the following resources:
+The Terraform template deploys the following resources:
 
 | Type | Logical ID |
 | --- | --- |

--- a/lambda-sqs-terraform/README.md
+++ b/lambda-sqs-terraform/README.md
@@ -53,14 +53,14 @@ Important: this application uses various AWS services and there are costs associ
 
 ### Testing
 
-Use the [AWS CLI](https://aws.amazon.com/cli/) to invoke the Lambda function. The function name is in the outputs of the AWS SAM deployment (the key is `QueuePublisherFunction`):
+Use the [AWS CLI](https://aws.amazon.com/cli/) to invoke the Lambda function. The function name is in the outputs of the Terraform deployment (the key is `QueuePublisherFunction`):
 
 1. Invoke the Lambda function to publish a message to the SQS queue:
 
 ```bash
 aws lambda invoke --function-name ENTER_YOUR_FUNCTION_NAME response.json
 ```
-2. Retrieve the message from the SQS queue, using the queue URL from the AWS SAM deployment outputs:
+2. Retrieve the message from the SQS queue, using the queue URL from the Terraform deployment outputs:
 ```bash
 aws sqs receive-message --queue-url ENTER_YOUR_QUEUE_URL
 ```

--- a/lambda-sqs-terraform/README.md
+++ b/lambda-sqs-terraform/README.md
@@ -53,14 +53,14 @@ Important: this application uses various AWS services and there are costs associ
 
 ### Testing
 
-Use the [AWS CLI](https://aws.amazon.com/cli/) to invoke the Lambda function. The function name is in the outputs of the AWS Terraform deployment (the key is `QueuePublisherFunction`):
+Use the [AWS CLI](https://aws.amazon.com/cli/) to invoke the Lambda function. The function name is in the outputs of the AWS SAM deployment (the key is `QueuePublisherFunction`):
 
 1. Invoke the Lambda function to publish a message to the SQS queue:
 
 ```bash
 aws lambda invoke --function-name ENTER_YOUR_FUNCTION_NAME response.json
 ```
-2. Retrieve the message from the SQS queue, using the queue URL from the AWS Terraform deployment outputs:
+2. Retrieve the message from the SQS queue, using the queue URL from the AWS SAM deployment outputs:
 ```bash
 aws sqs receive-message --queue-url ENTER_YOUR_QUEUE_URL
 ```

--- a/lambda-sqs-terraform/README.md
+++ b/lambda-sqs-terraform/README.md
@@ -53,14 +53,14 @@ Important: this application uses various AWS services and there are costs associ
 
 ### Testing
 
-Use the [AWS CLI](https://aws.amazon.com/cli/) to invoke the Lambda function. The function name is in the outputs of the AWS SAM deployment (the key is `QueuePublisherFunction`):
+Use the [AWS CLI](https://aws.amazon.com/cli/) to invoke the Lambda function. The function name is in the outputs of the AWS Terraform deployment (the key is `QueuePublisherFunction`):
 
 1. Invoke the Lambda function to publish a message to the SQS queue:
 
 ```bash
 aws lambda invoke --function-name ENTER_YOUR_FUNCTION_NAME response.json
 ```
-2. Retrieve the message from the SQS queue, using the queue URL from the AWS SAM deployment outputs:
+2. Retrieve the message from the SQS queue, using the queue URL from the AWS Terraform deployment outputs:
 ```bash
 aws sqs receive-message --queue-url ENTER_YOUR_QUEUE_URL
 ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Removing references to AWS SAM from Terraform patterns, and some references to AWS Terraform.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
