### PR TITLE
[New Pattern] AWS IoT to DynamoDB

### DIFF
--- a/iot-dynamodb/README.md
+++ b/iot-dynamodb/README.md
@@ -1,0 +1,81 @@
+# AWS IoT to DynamoDB
+
+This pattern explains how to put data to AWS DynamoDB Table using AWS IoT Topic Rules.
+
+Learn more about this pattern at [Serverless Land Patterns](https://serverlessland.com/patterns/iot-dynamodb).
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ```
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ```
+    cd iot-dynamodb
+    ```
+1. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
+    ```
+    sam deploy --guided
+    ```
+1. During the prompts:
+    * Enter a stack name
+    * Enter the desired AWS Region
+    * Allow SAM CLI to create IAM roles with the required permissions.
+
+    Once you have run `sam deploy -guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+
+## Testing
+
+* IoT Rule -> DynamoDB Action
+
+  * Visit [AWS IoT Core Management Console Test Client](https://console.aws.amazon.com/iot/home#/test)
+  * Select 'Subscribe to a topic', enter Subscription topic as 'topics/ThingsGroupOne/TestThing' and select 'Subscribe'.
+  * Enter below example message payload JSON and select 'Publish'.
+  Note: IoT Rule in this case adds attributes 'thingId' (fetched from the topic entered in above step) and 'timestamp' putting event to DynamoDB Table. It puts full event payload JSON under 'device_data'.
+  ```
+  {
+    "temperature_F" : "86"
+  }
+  ```
+  * Visit [DynamoDB Management Console](https://console.aws.amazon.com/dynamodbv2/home#tables) and check the values in DynamoDB table 'IoTExampleTableOne'.
+
+* IoT Rule -> DynamoDBv2 Action
+
+  * Visit [AWS IoT Core Management Console Test Client](https://console.aws.amazon.com/iot/home#/test)
+  * Select 'Subscribe to a topic', enter subscription topic as 'topics/ThingsGroupTwo/TestThing' and select 'Subscribe'.
+  * Enter below example message payload JSON and select 'Publish'.
+  ```
+  {
+    "eventId" : "cf2b37c2-04c2-11ed-b293-aa665a182631",
+    "temperature_F" : "86"
+  }
+  ```
+  * Visit [DynamoDB Management Console](https://console.aws.amazon.com/dynamodbv2/home#tables) and check the values in DynamoDB table 'IoTExampleTableTwo'.
+
+## AWS Documentation
+- [AWS IoT SQL Reference](https://docs.aws.amazon.com/iot/latest/developerguide/iot-sql-reference.html?icmpid=docs_iot_console)
+- [AWS IoT SQL - FROM Clause](https://docs.aws.amazon.com/iot/latest/developerguide/iot-sql-from.html)
+- [AWS IoT Rule Actions](https://docs.aws.amazon.com/iot/latest/developerguide/iot-rule-actions.html)
+- [CloudFormation - AWS::IoT::TopicRule](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot-topicrule.html)
+- [CloudFormation - AWS::DynamoDB::Table](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html)
+- [AWS IoT Quotas](https://docs.aws.amazon.com/general/latest/gr/iot-core.html)
+
+## Cleanup
+
+1. Delete the stack
+    ```bash
+    sam delete
+    ```
+
+This pattern was contributed by Udit Parikh.
+

--- a/iot-dynamodb/example-pattern.json
+++ b/iot-dynamodb/example-pattern.json
@@ -1,0 +1,67 @@
+{
+  "title": "AWS IoT to DynamoDB",
+  "description": "Create IoT Topic Rules to put event data to DynamoDB table",
+  "level": "200",
+  "framework": "SAM",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "This sample project demonstrates how to use AWS IoT Topic rules to put incoming event data to DynamoDB. One example demonstrates how to use 'DynamoDB' Action and another example demonstrates how to use 'DynamoDBv2' Action with AWS IoT Topic Rules."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/iot-dynamodb",
+      "templateURL": "serverless-patterns/iot-dynamodb",
+      "projectFolder": "iot-dynamodb",
+      "templateFile": "iot-dynamodb/template.yaml"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "AWS IoT SQL Reference",
+        "link": "https://docs.aws.amazon.com/iot/latest/developerguide/iot-sql-reference.html?icmpid=docs_iot_console"
+      },
+      {
+        "text": "AWS IoT SQL - FROM Clause",
+        "link": "https://docs.aws.amazon.com/iot/latest/developerguide/iot-sql-from.html"
+      },
+      {
+        "text": "AWS IoT Rule Actions",
+        "link": "https://docs.aws.amazon.com/iot/latest/developerguide/iot-sql-from.html"
+      },
+      {
+        "text": "CloudFormation - AWS::IoT::TopicRule",
+        "link": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot-topicrule.html"
+      },
+      {
+        "text": "CloudFormation - AWS::DynamoDB::Table",
+        "link": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "sam deploy"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the Github repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>sam delete</code>."
+    ]
+  },
+  "authors": [
+    {
+      "name": "Udit Parikh",
+      "image": "https://1drv.ms/u/s!AufpCThJxKa2g50banMoavhl7i5EUg",
+      "bio": "Udit is a AWS 6x Certified Cloud Enthusiast who love building solutions.",
+      "linkedin": "https://www.linkedin.com/in/parikhudit"
+    }
+  ]
+}

--- a/iot-dynamodb/template.yaml
+++ b/iot-dynamodb/template.yaml
@@ -1,0 +1,95 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Transform: 'AWS::Serverless-2016-10-31'
+
+Description: Different methods to put the IoT events to a DynamoDB table using AWS IoT Topic rules.
+
+Resources:
+
+  # Define DynamoDB Table to save data for IoT Rule -> DynamoDB action
+  IoTExampleTableOne:
+    Type: 'AWS::DynamoDB::Table'
+    Properties:
+      TableName: IoTExampleTableOne
+      AttributeDefinitions:
+        - AttributeName: thingId
+          AttributeType: S
+        - AttributeName: timestamp
+          AttributeType: N
+      KeySchema:
+        - AttributeName: thingId
+          KeyType: HASH
+        - AttributeName: timestamp
+          KeyType: RANGE
+      ProvisionedThroughput:
+        ReadCapacityUnits: 5
+        WriteCapacityUnits: 5
+
+  # Define DynamoDB Table to save data for IoT Rule -> DynamoDv2 action
+  IoTExampleTableTwo:
+    Type: 'AWS::DynamoDB::Table'
+    Properties:
+      TableName: IoTExampleTableTwo
+      AttributeDefinitions:
+        - AttributeName: eventId
+          AttributeType: S
+      KeySchema:
+        - AttributeName: eventId
+          KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits: 5
+        WriteCapacityUnits: 5
+
+  # Define IAM Role to allow AWS IoT to put events to DynamoDB Tables
+  IoTTableAccessRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: iot.amazonaws.com
+          Action: sts:AssumeRole
+      Policies:
+      - PolicyName: IoTDynamoDBTablePutAccessPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action: dynamodb:PutItem
+            Resource: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${IoTExampleTableOne}
+          - Effect: Allow
+            Action: dynamodb:PutItem
+            Resource: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${IoTExampleTableTwo}
+
+  # Define AWS IoT Topic Rule to put event to DynamoDB Table using 'DynamoDB' Action.
+  IoTToDDBRule:
+    Type: AWS::IoT::TopicRule
+    Properties:
+      TopicRulePayload:
+        Actions:
+        - DynamoDB:
+            HashKeyField: thingId
+            HashKeyValue: ${topic(3)}
+            RangeKeyField: timestamp
+            RangeKeyValue: ${timestamp()}
+            RangeKeyType: NUMBER
+            PayloadField: device_data
+            TableName: !Ref IoTExampleTableOne
+            RoleArn: !GetAtt IoTTableAccessRole.Arn
+        RuleDisabled: false
+        Sql: SELECT * FROM 'topics/ThingsGroupOne/+'
+
+  # Define AWS IoT Topic Rule to put event to DynamoDB Table using 'DynamoDB2' Action.
+  IoTToDDBv2Rule:
+    Type: AWS::IoT::TopicRule
+    Properties:
+      TopicRulePayload:
+        Actions:
+        - DynamoDBv2:
+            PutItem:
+              TableName: !Ref IoTExampleTableTwo
+            RoleArn: !GetAtt IoTTableAccessRole.Arn
+        RuleDisabled: false
+        Sql: SELECT * FROM 'topics/ThingsGroupTwo/TestThing'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This sample project demonstrates how to use AWS IoT Topic rules to put incoming event data to DynamoDB. One example demonstrates how to use 'DynamoDB' Action and another example demonstrates how to use 'DynamoDBv2' Action with AWS IoT Topic Rules.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
