### PR TITLE
New serverless pattern - WAF to APIGW REST

### DIFF
--- a/waf-apigw-rest/README.md
+++ b/waf-apigw-rest/README.md
@@ -1,8 +1,8 @@
 # AWS Service 1 to AWS Service 2
 
-This pattern << explain usage >>
+This pattern creates an Amazon API Gateway with a WebACL attached to control access. This WebACL limits the requests to certain countries. 
 
-Learn more about this pattern at Serverless Land Patterns: << Add the live URL here >>
+Learn more about this pattern at Serverless Land Patterns: [https://serverlessland.com/patterns/waf-apigw-rest](https://serverlessland.com/patterns/waf-apigw-rest)
 
 Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
 
@@ -21,7 +21,7 @@ Important: this application uses various AWS services and there are costs associ
     ```
 1. Change directory to the pattern directory:
     ```
-    cd _patterns-model
+    cd waf-apigateway-rest
     ```
 1. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
     ```
@@ -38,17 +38,17 @@ Important: this application uses various AWS services and there are costs associ
 
 ## How it works
 
-Explain how the service interaction works.
+The application will only accept requests from countries that are in the country code array for the WAF rule.
 
 ## Testing
 
-Provide steps to trigger the integration and show what should be observed if successful.
+Deploy the app then go the the provided web address. If you are in the US you will get a 200 response from the backend Lambda funtion. If you are in any other country, you will get a 403 response from the WAF. Change the country codes in the array and redploy to see different results.
 
 ## Cleanup
  
 1. Delete the stack
     ```bash
-    aws cloudformation delete-stack --stack-name STACK_NAME
+    sam delete --stack-name STACK_NAME
     ```
 1. Confirm the stack has been deleted
     ```bash

--- a/waf-apigw-rest/README.md
+++ b/waf-apigw-rest/README.md
@@ -1,0 +1,60 @@
+# AWS Service 1 to AWS Service 2
+
+This pattern << explain usage >>
+
+Learn more about this pattern at Serverless Land Patterns: << Add the live URL here >>
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ```
+    cd _patterns-model
+    ```
+1. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
+    ```
+    sam deploy --guided
+    ```
+1. During the prompts:
+    * Enter a stack name
+    * Enter the desired AWS Region
+    * Allow SAM CLI to create IAM roles with the required permissions.
+
+    Once you have run `sam deploy --guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+
+1. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## How it works
+
+Explain how the service interaction works.
+
+## Testing
+
+Provide steps to trigger the integration and show what should be observed if successful.
+
+## Cleanup
+ 
+1. Delete the stack
+    ```bash
+    aws cloudformation delete-stack --stack-name STACK_NAME
+    ```
+1. Confirm the stack has been deleted
+    ```bash
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus"
+    ```
+----
+Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/waf-apigw-rest/example-pattern.json
+++ b/waf-apigw-rest/example-pattern.json
@@ -1,6 +1,6 @@
 {
   "title": "AWS WAF attached to Amazon API Gateway REST API",
-  "description": "Create an Amazon API Gateway with a WebACL attached to control access. This WebACL limits the requests to certain countries.",
+  "description": "Creates an Amazon API Gateway with a WebACL attached to control access. This WebACL limits the requests to certain countries.",
   "language": "Python",
   "level": "300",
   "framework": "SAM",

--- a/waf-apigw-rest/example-pattern.json
+++ b/waf-apigw-rest/example-pattern.json
@@ -1,0 +1,57 @@
+{
+  "title": "AWS WAF attached to Amazon API Gateway REST API",
+  "description": "Create an Amazon API Gateway with a WebACL attached to control access. This WebACL limits the requests to certain countries.",
+  "language": "Python",
+  "level": "300",
+  "framework": "SAM",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "This sample project demonstrates how to use AWS WAF to add extra security to an Amazon API Gateway REST API. In this example, only requests from the US will be accepted. All others will be rejected with a 403. To add another country add the country code to the 'CountryCode' array starting on line 32."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/waf-apigw-rest",
+      "templateURL": "serverless-patterns/waf-apigw-rest",
+      "projectFolder": "waf-apigw-rest",
+      "templateFile": "waf-apigw-rest/template.yaml"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "AWS WAF",
+        "link": "https://aws.amazon.com/waf/"
+      },
+      {
+        "text": "Building rules",
+        "link": "https://docs.aws.amazon.com/waf/latest/developerguide/waf-rules.html"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "sam deploy"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the Github repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>sam delete</code>."
+    ]
+  },
+  "authors": [
+    {
+      "name": "Eric Johnson",
+      "image": "https://serverlessland.com/assets/images/resources/ericdj.jpg",
+      "bio": "Eric Johnson is a Principal Developer Advocate for Serverless Applications at Amazon Web Services and is based in Northern Colorado. Eric is a fanatic about serverless and enjoys helping developers understand how serverless technologies introduces a major paradigm shift in how they approach building and running applications at massive scale with minimal administration overhead. Prior to this, Eric has worked as a developer, solutions architect and AWS Evangelist for an AWS partner company.",
+      "linkedin": "singledigit",
+      "twitter": "edjgeek"
+    }
+  ]
+}

--- a/waf-apigw-rest/src/app.py
+++ b/waf-apigw-rest/src/app.py
@@ -1,0 +1,8 @@
+import json
+def lambda_handler(event, context):
+    return {
+        "statusCode": 200,
+        "body": json.dumps({
+            "message": "Request received by Lambda function",
+        }),
+    }

--- a/waf-apigw-rest/template.yaml
+++ b/waf-apigw-rest/template.yaml
@@ -1,0 +1,73 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Serverless patterns - AWS WAF to Amazon API Gateway REST
+
+Resources:
+  # AWS WAF Access Control List limits each IP to 100 requestes per second
+  MyWAFACL:
+    Type: AWS::WAFv2::WebACL
+    Properties:
+      CustomResponseBodies: # Define a response from WAF
+        CountryNotValid:
+          Content: Country not allowed
+          ContentType: TEXT_PLAIN
+      DefaultAction:
+        Block: 
+          CustomResponse: # Choose a defined template to respond when blocked
+            ResponseCode: "403"
+            CustomResponseBodyKey: CountryNotValid
+      Description: Application WAF
+      Scope: REGIONAL
+      VisibilityConfig:
+        CloudWatchMetricsEnabled: true
+        MetricName: AppRules
+        SampledRequestsEnabled: true
+      Rules:
+        - Action:
+            Allow: {} # Allow if conditions are met
+          Name: AllowCountryList
+          Priority: 0
+          Statement:
+            GeoMatchStatement:
+              CountryCodes: # Requests from following countries are allowed (Add your country code to test)
+                - US
+          VisibilityConfig:
+            CloudWatchMetricsEnabled: true
+            MetricName: AllowCountryList
+            SampledRequestsEnabled: true
+  
+  # Amazon API gateway REST API
+  MyApi: 
+    Type: AWS::Serverless::Api 
+    Properties: 
+      StageName: Prod
+      EndpointConfiguration: REGIONAL
+      TracingEnabled: true
+
+  # Associate the WebACL with the API gateway
+  MyWAFAssociation:
+    Type: AWS::WAFv2::WebACLAssociation
+    Properties: 
+      ResourceArn: !Sub arn:aws:apigateway:${AWS::Region}::/restapis/${MyApi}/stages/Prod
+      WebACLArn: !GetAtt MyWAFACL.Arn
+
+# Lambda function as an example micro-service behind the API Gateway REST endpoint
+  MyLambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: app.lambda_handler
+      Runtime: python3.9
+      Events:
+        RootGet:
+          Type: Api
+          Properties:
+            Path: /
+            Method: get
+            RestApiId: !Ref MyApi
+
+Outputs:
+  # API endpoint for testing
+  ApiEndpoint:
+    Description: "API endpoint URL"
+    Value: !Sub arn:aws:apigateway:${AWS::Region}::/restapis/${MyApi}/stages/Prod


### PR DESCRIPTION
Adds a pattern creating an AWS WAF WebACL that restricts access to an APIGW REST API based on the originating country of the request.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
