### PR TITLE
Update elemental-mediapackage-cloudfront-cdk-ts to add CDN authorization

### DIFF
--- a/elemental-medialive-mediapackage-cdk-ts/lib/media_package_cdn_auth.ts
+++ b/elemental-medialive-mediapackage-cdk-ts/lib/media_package_cdn_auth.ts
@@ -1,0 +1,194 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+ import { 
+  Aws, 
+  aws_mediapackage as mediapackage } from "aws-cdk-lib";
+import { Construct } from "constructs";
+import { loadMediaPackageConfig } from "../helpers/configuration";
+import { Secrets } from "./secrets";
+
+export class MediaPackageCdnAuth extends Construct {
+  public readonly myChannel: mediapackage.CfnChannel;
+  public readonly hlsEndpoint: string;
+  public readonly dashEndpoint: string;
+  public readonly cmafEndpoint: string;
+  public readonly mssEndpoint: string;
+  public readonly myChannelArn: string;
+  public readonly myChannelName: string;
+  
+
+  constructor(scope: Construct, 
+    id: string, 
+    roleEMP: string, 
+    props: Secrets){
+    super(scope, id);
+    const myMediaPackageChannelName=Aws.STACK_NAME + "_MediaPackageChannel"
+    const config = loadMediaPackageConfig();
+  
+    //👇 Creating EMP channel
+    this.myChannel = new mediapackage.CfnChannel(this, "MyCfnChannel", {
+      id: myMediaPackageChannelName,
+      description: "Channel for " + Aws.STACK_NAME,
+    });
+
+
+    //👇 HLS Packaging & endpoint with CDN authorization
+    const hlsPackage: mediapackage.CfnOriginEndpoint.HlsPackageProperty = { 
+      adMarkers: config.ad_markers,
+      adTriggers: ['BREAK',
+        'DISTRIBUTOR_ADVERTISEMENT',
+        'DISTRIBUTOR_OVERLAY_PLACEMENT_OPPORTUNITY',
+        'DISTRIBUTOR_PLACEMENT_OPPORTUNITY',
+        'PROVIDER_ADVERTISEMENT',
+        'PROVIDER_OVERLAY_PLACEMENT_OPPORTUNITY',
+        'PROVIDER_PLACEMENT_OPPORTUNITY',
+        'SPLICE_INSERT'],
+      segmentDurationSeconds: config.hls_segment_duration_seconds,
+      programDateTimeIntervalSeconds: config.hls_program_date_interval,
+      playlistWindowSeconds: config.hls_playlist_window_seconds,
+      useAudioRenditionGroup:true,
+      streamSelection: {
+        minVideoBitsPerSecond: config.hls_min_video_bits_per_second,
+        maxVideoBitsPerSecond: config.hls_max_video_bits_per_second,
+        streamOrder: config.hls_stream_order,
+      },
+    };
+    const hlsEndpoint = new mediapackage.CfnOriginEndpoint(
+      this,
+      "HlsEndpoint",
+      {
+        channelId: this.myChannel.id,
+        id: Aws.STACK_NAME + "-hls-" + this.myChannel.id,
+        hlsPackage,
+        // the properties below are optional
+        authorization: {
+          cdnIdentifierSecret: props.cdnSecret.secretArn,
+          secretsRoleArn: roleEMP,
+        },
+      }
+    );
+    this.hlsEndpoint = hlsEndpoint.attrUrl;
+    hlsEndpoint.node.addDependency(this.myChannel);
+
+
+    //👇 DASH Packaging & endpoint with CDN authorization
+    const dashPackage: mediapackage.CfnOriginEndpoint.DashPackageProperty = {
+      periodTriggers: [config.dash_period_triggers],
+      adTriggers: ['BREAK',
+      'DISTRIBUTOR_ADVERTISEMENT',
+      'DISTRIBUTOR_OVERLAY_PLACEMENT_OPPORTUNITY',
+      'DISTRIBUTOR_PLACEMENT_OPPORTUNITY',
+      'PROVIDER_ADVERTISEMENT',
+      'PROVIDER_OVERLAY_PLACEMENT_OPPORTUNITY',
+      'PROVIDER_PLACEMENT_OPPORTUNITY',
+      'SPLICE_INSERT'],
+      segmentDurationSeconds: config.dash_segment_duration_seconds,
+      segmentTemplateFormat: 'TIME_WITH_TIMELINE',
+      profile: 'NONE',
+      minBufferTimeSeconds: 10,
+      minUpdatePeriodSeconds: config.dash_segment_duration_seconds,
+      manifestWindowSeconds: config.dash_manifest_window_seconds,
+      streamSelection: {
+        minVideoBitsPerSecond: config.dash_min_video_bits_per_second,
+        maxVideoBitsPerSecond: config.dash_max_video_bits_per_second,
+        streamOrder: config.dash_stream_order,
+      },
+    };
+    const dashEndpoint = new mediapackage.CfnOriginEndpoint(
+      this,
+      "DashEndpoint",
+      {
+        channelId: this.myChannel.id,
+        id: Aws.STACK_NAME + "-dash-" + this.myChannel.id,
+        dashPackage,
+        // the properties below are optional
+        authorization: {
+          cdnIdentifierSecret: props.cdnSecret.secretArn,
+          secretsRoleArn: roleEMP,
+        },
+      }
+    );
+    this.dashEndpoint = dashEndpoint.attrUrl;
+    dashEndpoint.node.addDependency(this.myChannel);
+
+   //👇 CMAF Packaging & endpoint with CDN authorization
+   const cmafPackage: mediapackage.CfnOriginEndpoint.CmafPackageProperty = {
+      
+    hlsManifests: [{
+      id: Aws.STACK_NAME + "-cmaf-" + this.myChannel.id,
+      // the properties below are optional
+      adMarkers: config.ad_markers,
+      includeIframeOnlyStream: false,
+      playlistWindowSeconds: config.cmaf_manifest_window_seconds,
+      programDateTimeIntervalSeconds: config.cmaf_program_date_interval,
+      url: 'url',
+    }],
+    segmentDurationSeconds: config.cmaf_segment_duration_seconds,
+    segmentPrefix: 'segmentPrefix',
+    streamSelection: {
+      maxVideoBitsPerSecond: config.cmaf_max_video_bits_per_second,
+      minVideoBitsPerSecond: config.cmaf_min_video_bits_per_second,
+      streamOrder: config.cmaf_stream_order,
+    },
+  };
+
+  const cmafEndpoint = new mediapackage.CfnOriginEndpoint(
+    this,
+    "cmafEndpoint",
+    {
+      channelId: this.myChannel.id,
+      id: Aws.STACK_NAME + "-cmaf-" + this.myChannel.id,
+      cmafPackage,
+      // the properties below are optional
+      authorization: {
+        cdnIdentifierSecret: props.cdnSecret.secretArn,
+        secretsRoleArn: roleEMP,
+      },
+    }
+  );
+  this.cmafEndpoint = cmafEndpoint.attrUrl;
+  cmafEndpoint.node.addDependency(this.myChannel);
+
+
+    //👇 MSS Packaging & endpoint with CDN authorization
+    const mssPackage: mediapackage.CfnOriginEndpoint.MssPackageProperty = {
+      segmentDurationSeconds: config.mss_segment_duration_seconds,
+      manifestWindowSeconds: config.mss_manifest_window_seconds,
+      streamSelection: {
+        minVideoBitsPerSecond: config.mss_min_video_bits_per_second,
+        maxVideoBitsPerSecond: config.mss_max_video_bits_per_second,
+        streamOrder: config.mss_stream_order,
+      },
+    };
+    const mssEndpoint = new mediapackage.CfnOriginEndpoint(
+      this,
+      "MssEndpoint",
+      {
+        channelId: this.myChannel.id,
+        id: Aws.STACK_NAME + "-mss-" + this.myChannel.id,
+        mssPackage,
+        // the properties below are optional
+        authorization: {
+          cdnIdentifierSecret: props.cdnSecret.secretArn,
+          secretsRoleArn: roleEMP,
+        },
+      }
+    );
+    this.mssEndpoint = mssEndpoint.attrUrl;
+    mssEndpoint.node.addDependency(this.myChannel);
+
+    this.myChannelName=myMediaPackageChannelName;
+    this.myChannelArn=this.myChannel.attrArn;
+  }
+}

--- a/elemental-medialive-mediapackage-cdk-ts/lib/secrets.ts
+++ b/elemental-medialive-mediapackage-cdk-ts/lib/secrets.ts
@@ -1,0 +1,46 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import {
+  Aws,
+  CfnOutput,
+  aws_secretsmanager as secretsmanager,
+} from "aws-cdk-lib";
+import { Construct } from "constructs";
+
+export class Secrets extends Construct {
+  public readonly cdnSecret: secretsmanager.ISecret;
+ 
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const cdnSecret = new secretsmanager.Secret(this, "CdnSecret", {
+      secretName: "MediaPackage/"+Aws.STACK_NAME,
+      description: "Secret for Secure Resilient Live Streaming Delivery",
+      generateSecretString: {
+        secretStringTemplate: JSON.stringify({ MediaPackageCDNIdentifier: "" }),
+        generateStringKey: "MediaPackageCDNIdentifier", //MUST keep this StringKey to use with EMP
+      },
+    });
+
+    this.cdnSecret = cdnSecret;
+
+    new CfnOutput(this, "cdnSecret", {
+      value: cdnSecret.secretName,
+      exportName: Aws.STACK_NAME + "cdnSecret",
+      description: "The name of the cdnSecret",
+    });
+
+
+  }
+}

--- a/elemental-medialive-mediapackage-cdk-ts/lib/streaming_stack.ts
+++ b/elemental-medialive-mediapackage-cdk-ts/lib/streaming_stack.ts
@@ -22,7 +22,6 @@ import { Construct, DependencyGroup } from 'constructs';
 import { MediaLive } from './media_live';
 import { MediaPackage } from './media_package';
 import { MediaPackageCdnAuth } from './media_package_cdn_auth';
-
 import { Secrets } from "./secrets";
 import { loadMediaPackageConfig } from "../helpers/configuration";
 

--- a/elemental-mediapackage-cloudfront-cdk-ts/README.md
+++ b/elemental-mediapackage-cloudfront-cdk-ts/README.md
@@ -11,9 +11,15 @@ Ingests the MediaLive Output and package the Live stream into:
 
 - HLS
 - DASH
-- CMAF
 
-Each format is delivered through a MediaPackage custom endpoint.
+
+Each format is delivered through a MediaPackage custom endpoint. There is a [CDN authorization](https://docs.aws.amazon.com/mediapackage/latest/ug/cdn-auth.html) implemented for each endpoint to reinforce the security through a secret store on [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/). This is the way to secure the access to each MediaPackage endpoints.
+The solution will create HLS, MPEG-DASH outputs with SCTE35 in Passthrough mode.
+
+## Amazon CloudFront
+
+A distribution is created to provide URL for HLS and MPEG-DASH. The default managed cache policy ELEMENTAL_MEDIA_PACKAGE is used for each behavior.
+The output will provide URL for HLS and MPEG-DASH to play only from CloudFront (MediaPackage endpoints are secured using CDN authorization).
 
 Learn more about this pattern at: https://serverlessland.com/patterns/elemental-mediapackage-cloudfront
 

--- a/elemental-mediapackage-cloudfront-cdk-ts/helpers/stream_config.ts
+++ b/elemental-mediapackage-cloudfront-cdk-ts/helpers/stream_config.ts
@@ -1,5 +1,8 @@
 export type IMediaPackageConfig = {
 
+ad_markers: string;
+  cdn_authorization: boolean;
+  hls_program_date_interval: number;
   ip_sg_input: string;
   stream_name: string;
   hls_segment_duration_seconds: number;
@@ -7,11 +10,23 @@ export type IMediaPackageConfig = {
   hls_max_video_bits_per_second: number;
   hls_min_video_bits_per_second: number;
   hls_stream_order: string;
+  hls_include_I_frame:boolean;
+  hls_audio_rendition_group:boolean;
+  dash_period_triggers: string;
   dash_segment_duration_seconds: number;
   dash_manifest_window_seconds: number;
   dash_max_video_bits_per_second: number;
   dash_min_video_bits_per_second: number;
   dash_stream_order: string;
+  cmaf_segment_duration_seconds: number;
+  cmaf_program_date_interval:number;
+  cmaf_manifest_window_seconds: number;
+  cmaf_max_video_bits_per_second: number;
+  cmaf_min_video_bits_per_second: number;
+  cmaf_stream_order: string;
+  cmaf_include_I_frame:boolean;
+  cmaf_audio_rendition_group:boolean;
+  cmaf_include_encoder_configuration_in_segments:boolean;
   mss_segment_duration_seconds: number;
   mss_manifest_window_seconds: number;
   mss_max_video_bits_per_second: number;

--- a/elemental-mediapackage-cloudfront-cdk-ts/lib/cloudfront.ts
+++ b/elemental-mediapackage-cloudfront-cdk-ts/lib/cloudfront.ts
@@ -1,66 +1,125 @@
-import { Aws, aws_mediapackage as mediapackage, CfnOutput,   aws_cloudfront as cloudfront, Fn } from "aws-cdk-lib";
-import { HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
 
+ import { 
+  Aws, 
+  aws_mediapackage as mediapackage, 
+  aws_cloudfront as cloudfront,
+  aws_cloudfront_origins as origins,
+  Fn} from "aws-cdk-lib";
 import { Construct } from "constructs";
-export class CloudFront extends Construct {
-  public readonly channel: mediapackage.CfnChannel;
+import { Secrets } from "./secrets";
 
-  constructor(scope: Construct, id: string, hlsEndpoint: string, dashEndpoint: string, mssEndpoint: string) {
+export class CloudFront extends Construct {
+  //👇 Defining public variables to export on CloudFormation 
+  public readonly channel: mediapackage.CfnChannel;
+  public readonly hlsPlayback: string;
+  public readonly dashPlayback: string;
+  public readonly myChannelArn: string;
+  public readonly myDistribId: string;
+  public readonly myDistribHostname: string;
+
+  //Defining private Variable
+  private readonly CDNHEADER="MediaPackageCDNIdentifier"
+
+  constructor(scope: Construct, 
+    id: string, 
+    hlsEndpoint: string, 
+    dashEndpoint: string,
+    props: Secrets){
     super(scope, id);
 
+    //👇 Defining Origin Hostname variables for EMP
     const mediaPackageHostname = Fn.select(2, Fn.split("/", hlsEndpoint));
 
+    //👇 Creating generic Viewer/Country/City Origin Request Policy with CloudFront Header
+    const myOriginRequestPolicy = new cloudfront.OriginRequestPolicy(this, 'OriginRequestPolicy',
+        {
+          originRequestPolicyName: Aws.STACK_NAME + "Viewer-Country-City",
+          comment: "Policy to FWD CloudFront headers",
+          headerBehavior: cloudfront.OriginRequestHeaderBehavior.allowList(
+            "CloudFront-Viewer-Address",
+            "CloudFront-Viewer-Country",
+            "CloudFront-Viewer-City",
+            "Referer",
+            "User-Agent",
+            "Access-Control-Request-Method",
+            "Access-Control-Request-Headers"
+          ),
+          queryStringBehavior: cloudfront.OriginRequestQueryStringBehavior.all(),
+        }
+      );
 
-    const origin = new HttpOrigin(mediaPackageHostname);
+    //👇 Creating EMP origin with green header
+    const mediaPackageOrigin = new origins.HttpOrigin(
+        mediaPackageHostname,
+        {
+          customHeaders: {
+          'X-MediaPackage-CDNIdentifier': props.cdnSecret.secretValueFromJson(this.CDNHEADER).unsafeUnwrap().toString(),
+          },
+          originSslProtocols: [cloudfront.OriginSslPolicy.SSL_V3],
+          protocolPolicy: cloudfront.OriginProtocolPolicy.HTTPS_ONLY,
+        }
+    );
 
-
+    //👇 Creating the CloudFront Distribution
     const distribution = new cloudfront.Distribution(this, "Distribution", {
-        comment: Aws.STACK_NAME + " - Demo website Secure Media Delivery",
-        defaultRootObject: "index.html",
+        comment: Aws.STACK_NAME + " - CDK deployment Secure Media Delivery",
+        defaultRootObject: "",
         minimumProtocolVersion: cloudfront.SecurityPolicyProtocol.TLS_V1_2016,
         defaultBehavior: {
-          origin: origin,
+          origin: mediaPackageOrigin,
           cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
           allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD,
           viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+          originRequestPolicy : myOriginRequestPolicy,
         },
         additionalBehaviors: {
           "*.m3u8": {
-            origin: origin,
-            viewerProtocolPolicy:
-              cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+            origin: mediaPackageOrigin,
+            viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+            allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
             cachePolicy: cloudfront.CachePolicy.ELEMENTAL_MEDIA_PACKAGE,
-
+            originRequestPolicy : myOriginRequestPolicy,
           },
           "*.ts": {
-            origin: origin,
-            viewerProtocolPolicy:
-              cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+            origin: mediaPackageOrigin,
+            viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
             cachePolicy: cloudfront.CachePolicy.ELEMENTAL_MEDIA_PACKAGE,
+            originRequestPolicy : myOriginRequestPolicy,
+
+          },
+          "*.mpd": {
+            origin: mediaPackageOrigin,
+            viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+            cachePolicy: cloudfront.CachePolicy.ELEMENTAL_MEDIA_PACKAGE,
+            originRequestPolicy : myOriginRequestPolicy,
+
           }
         },
-      });
+    });
+
+    //👇 Getting the path from EMP (/out/v1/<hashed-id-EMP>) & EMT (/v1/master/<hashed-id-EMT>/<config-EMT>) endpoints
+    const hlsPath = Fn.select(1, Fn.split("/out/", hlsEndpoint));
+    const dashPath = Fn.select(1, Fn.split("/out/", dashEndpoint));
 
 
-      const hlsPath = Fn.select(1, Fn.split("/out/", hlsEndpoint));
-      const dashPath = Fn.select(1, Fn.split("/out/", dashEndpoint));
-      const mssPath = Fn.select(1, Fn.split("/out/", mssEndpoint));
+    this.hlsPlayback="https://" + distribution.domainName + '/out/' + hlsPath
+    this.dashPlayback="https://" + distribution.domainName + '/out/' + dashPath
 
-      new CfnOutput(this, "HlsEndpoint", {
-        exportName: Aws.STACK_NAME + "-HLS-CF",
-        value: "https://" + distribution.domainName + '/out/' + hlsPath,
-      });
+    this.myDistribId=distribution.distributionId
+    this.myDistribHostname=distribution.distributionDomainName
 
-      new CfnOutput(this, "DashEndpoint", {
-        exportName: Aws.STACK_NAME + "-DASH-CF",
-        value: "https://" + distribution.domainName + '/out/' + dashPath,
-      });
-
-      new CfnOutput(this, "MssEndpoint", {
-        exportName: Aws.STACK_NAME + "-MSS-CF",
-        value: "https://" + distribution.domainName + '/out/' + mssPath,
-      });
-
-  }
+}
 
 }

--- a/elemental-mediapackage-cloudfront-cdk-ts/lib/media_package.ts
+++ b/elemental-mediapackage-cloudfront-cdk-ts/lib/media_package.ts
@@ -1,48 +1,103 @@
-import { Aws, aws_mediapackage as mediapackage, CfnOutput } from "aws-cdk-lib";
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
 
+ import { 
+  Aws, 
+  aws_mediapackage as mediapackage } from "aws-cdk-lib";
 import { Construct } from "constructs";
 import { loadMediaPackageConfig } from "../helpers/configuration";
-export class MediaPackage extends Construct {
+import { Secrets } from "./secrets";
+
+export class MediaPackageCdnAuth extends Construct {
+  public readonly myChannel: mediapackage.CfnChannel;
   public readonly hlsEndpoint: string;
   public readonly dashEndpoint: string;
+  public readonly cmafEndpoint: string;
   public readonly mssEndpoint: string;
+  public readonly myChannelArn: string;
+  public readonly myChannelName: string;
+  
 
-  constructor(scope: Construct, id: string) {
+  constructor(scope: Construct, 
+    id: string, 
+    roleEMP: string, 
+    props: Secrets){
     super(scope, id);
-
-    const myChannel = new mediapackage.CfnChannel(this, "MyCfnChannel", {
-      id: "myMediaPackageChannel",
+    const myMediaPackageChannelName=Aws.STACK_NAME + "_MediaPackageChannel"
+    const config = loadMediaPackageConfig();
+  
+    //👇 Creating EMP channel
+    this.myChannel = new mediapackage.CfnChannel(this, "MyCfnChannel", {
+      id: myMediaPackageChannelName,
       description: "Channel for " + Aws.STACK_NAME,
     });
 
-    const config = loadMediaPackageConfig();
 
-    const hlsPackage: mediapackage.CfnOriginEndpoint.HlsPackageProperty = {
+    //👇 HLS Packaging & endpoint with CDN authorization
+    const hlsPackage: mediapackage.CfnOriginEndpoint.HlsPackageProperty = { 
+      adMarkers: config.ad_markers,
+      adTriggers: ['BREAK',
+        'DISTRIBUTOR_ADVERTISEMENT',
+        'DISTRIBUTOR_OVERLAY_PLACEMENT_OPPORTUNITY',
+        'DISTRIBUTOR_PLACEMENT_OPPORTUNITY',
+        'PROVIDER_ADVERTISEMENT',
+        'PROVIDER_OVERLAY_PLACEMENT_OPPORTUNITY',
+        'PROVIDER_PLACEMENT_OPPORTUNITY',
+        'SPLICE_INSERT'],
       segmentDurationSeconds: config.hls_segment_duration_seconds,
+      programDateTimeIntervalSeconds: config.hls_program_date_interval,
       playlistWindowSeconds: config.hls_playlist_window_seconds,
+      useAudioRenditionGroup:true,
       streamSelection: {
         minVideoBitsPerSecond: config.hls_min_video_bits_per_second,
         maxVideoBitsPerSecond: config.hls_max_video_bits_per_second,
         streamOrder: config.hls_stream_order,
       },
     };
-
     const hlsEndpoint = new mediapackage.CfnOriginEndpoint(
       this,
       "HlsEndpoint",
       {
-        channelId: myChannel.id,
-        id: Aws.STACK_NAME + "-hls-" + myChannel.id,
+        channelId: this.myChannel.id,
+        id: Aws.STACK_NAME + "-hls-" + this.myChannel.id,
         hlsPackage,
+        // the properties below are optional
+        authorization: {
+          cdnIdentifierSecret: props.cdnSecret.secretArn,
+          secretsRoleArn: roleEMP,
+        },
       }
     );
-
     this.hlsEndpoint = hlsEndpoint.attrUrl;
+    hlsEndpoint.node.addDependency(this.myChannel);
 
-    hlsEndpoint.node.addDependency(myChannel);
 
+    //👇 DASH Packaging & endpoint with CDN authorization
     const dashPackage: mediapackage.CfnOriginEndpoint.DashPackageProperty = {
+      periodTriggers: [config.dash_period_triggers],
+      adTriggers: ['BREAK',
+      'DISTRIBUTOR_ADVERTISEMENT',
+      'DISTRIBUTOR_OVERLAY_PLACEMENT_OPPORTUNITY',
+      'DISTRIBUTOR_PLACEMENT_OPPORTUNITY',
+      'PROVIDER_ADVERTISEMENT',
+      'PROVIDER_OVERLAY_PLACEMENT_OPPORTUNITY',
+      'PROVIDER_PLACEMENT_OPPORTUNITY',
+      'SPLICE_INSERT'],
       segmentDurationSeconds: config.dash_segment_duration_seconds,
+      segmentTemplateFormat: 'TIME_WITH_TIMELINE',
+      profile: 'NONE',
+      minBufferTimeSeconds: 10,
+      minUpdatePeriodSeconds: config.dash_segment_duration_seconds,
       manifestWindowSeconds: config.dash_manifest_window_seconds,
       streamSelection: {
         minVideoBitsPerSecond: config.dash_min_video_bits_per_second,
@@ -50,21 +105,63 @@ export class MediaPackage extends Construct {
         streamOrder: config.dash_stream_order,
       },
     };
-
     const dashEndpoint = new mediapackage.CfnOriginEndpoint(
       this,
       "DashEndpoint",
       {
-        channelId: myChannel.id,
-        id: Aws.STACK_NAME + "-dash-" + myChannel.id,
+        channelId: this.myChannel.id,
+        id: Aws.STACK_NAME + "-dash-",
         dashPackage,
+        // the properties below are optional
+        authorization: {
+          cdnIdentifierSecret: props.cdnSecret.secretArn,
+          secretsRoleArn: roleEMP,
+        },
       }
     );
-
     this.dashEndpoint = dashEndpoint.attrUrl;
+    dashEndpoint.node.addDependency(this.myChannel);
 
-    dashEndpoint.node.addDependency(myChannel);
+   //👇 CMAF Packaging & endpoint with CDN authorization
+   const cmafPackage: mediapackage.CfnOriginEndpoint.CmafPackageProperty = {
+      
+    hlsManifests: [{
+      id: Aws.STACK_NAME + "-cmaf-",
+      // the properties below are optional
+      adMarkers: config.ad_markers,
+      includeIframeOnlyStream: false,
+      playlistWindowSeconds: config.cmaf_manifest_window_seconds,
+      programDateTimeIntervalSeconds: config.cmaf_program_date_interval,
+      url: 'url',
+    }],
+    segmentDurationSeconds: config.cmaf_segment_duration_seconds,
+    segmentPrefix: 'segmentPrefix',
+    streamSelection: {
+      maxVideoBitsPerSecond: config.cmaf_max_video_bits_per_second,
+      minVideoBitsPerSecond: config.cmaf_min_video_bits_per_second,
+      streamOrder: config.cmaf_stream_order,
+    },
+  };
 
+  const cmafEndpoint = new mediapackage.CfnOriginEndpoint(
+    this,
+    "cmafEndpoint",
+    {
+      channelId: this.myChannel.id,
+      id: Aws.STACK_NAME + "-cmaf-",
+      cmafPackage,
+      // the properties below are optional
+      authorization: {
+        cdnIdentifierSecret: props.cdnSecret.secretArn,
+        secretsRoleArn: roleEMP,
+      },
+    }
+  );
+  this.cmafEndpoint = cmafEndpoint.attrUrl;
+  cmafEndpoint.node.addDependency(this.myChannel);
+
+
+    //👇 MSS Packaging & endpoint with CDN authorization
     const mssPackage: mediapackage.CfnOriginEndpoint.MssPackageProperty = {
       segmentDurationSeconds: config.mss_segment_duration_seconds,
       manifestWindowSeconds: config.mss_manifest_window_seconds,
@@ -74,34 +171,24 @@ export class MediaPackage extends Construct {
         streamOrder: config.mss_stream_order,
       },
     };
-
     const mssEndpoint = new mediapackage.CfnOriginEndpoint(
       this,
       "MssEndpoint",
       {
-        channelId: myChannel.id,
-        id: Aws.STACK_NAME + "-mss-" + myChannel.id,
+        channelId: this.myChannel.id,
+        id: Aws.STACK_NAME + "-mss-",
         mssPackage,
+        // the properties below are optional
+        authorization: {
+          cdnIdentifierSecret: props.cdnSecret.secretArn,
+          secretsRoleArn: roleEMP,
+        },
       }
     );
-
     this.mssEndpoint = mssEndpoint.attrUrl;
+    mssEndpoint.node.addDependency(this.myChannel);
 
-    mssEndpoint.node.addDependency(myChannel);
-
-    new CfnOutput(this, "HlsUrlStream", {
-      exportName: Aws.STACK_NAME + "-HLS-URL",
-      value: hlsEndpoint.attrUrl,
-    });
-
-    new CfnOutput(this, "DashUrlStream", {
-      exportName: Aws.STACK_NAME + "-DASH-URL",
-      value: dashEndpoint.attrUrl,
-    });
-
-    new CfnOutput(this, "MssUrlStream", {
-      exportName: Aws.STACK_NAME + "-MSS-URL",
-      value: mssEndpoint.attrUrl,
-    });
+    this.myChannelName=myMediaPackageChannelName;
+    this.myChannelArn=this.myChannel.attrArn;
   }
 }

--- a/elemental-mediapackage-cloudfront-cdk-ts/lib/secrets.ts
+++ b/elemental-mediapackage-cloudfront-cdk-ts/lib/secrets.ts
@@ -1,0 +1,46 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import {
+  Aws,
+  CfnOutput,
+  aws_secretsmanager as secretsmanager,
+} from "aws-cdk-lib";
+import { Construct } from "constructs";
+
+export class Secrets extends Construct {
+  public readonly cdnSecret: secretsmanager.ISecret;
+ 
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const cdnSecret = new secretsmanager.Secret(this, "CdnSecret", {
+      secretName: "MediaPackage/"+Aws.STACK_NAME,
+      description: "Secret for Secure Resilient Live Streaming Delivery",
+      generateSecretString: {
+        secretStringTemplate: JSON.stringify({ MediaPackageCDNIdentifier: "" }),
+        generateStringKey: "MediaPackageCDNIdentifier", //MUST keep this StringKey to use with EMP
+      },
+    });
+
+    this.cdnSecret = cdnSecret;
+
+    new CfnOutput(this, "cdnSecret", {
+      value: cdnSecret.secretName,
+      exportName: Aws.STACK_NAME + "cdnSecret",
+      description: "The name of the cdnSecret",
+    });
+
+
+  }
+}

--- a/elemental-mediapackage-cloudfront-cdk-ts/lib/streaming_stack.ts
+++ b/elemental-mediapackage-cloudfront-cdk-ts/lib/streaming_stack.ts
@@ -8,6 +8,7 @@ export class StreamingStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
+    
     //1. Create MediaPackage Channel
     const mediaPackageChannel = new MediaPackage(
       this,

--- a/elemental-mediapackage-cloudfront-cdk-ts/lib/streaming_stack.ts
+++ b/elemental-mediapackage-cloudfront-cdk-ts/lib/streaming_stack.ts
@@ -1,22 +1,86 @@
-import { Stack, StackProps } from 'aws-cdk-lib';
+import {
+  Stack,
+  StackProps,
+  Duration,
+  CfnOutput,
+  aws_iam as iam,
+} from "aws-cdk-lib";
 import { Construct } from 'constructs';
+import { MediaPackageCdnAuth } from './media_package';
 import { CloudFront } from './cloudfront';
-import { MediaPackage } from './media_package';
-// import * as sqs from 'aws-cdk-lib/aws-sqs';
+
+import { Secrets } from "./secrets";
+
 
 export class StreamingStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
-    
-    //1. Create MediaPackage Channel
-    const mediaPackageChannel = new MediaPackage(
+    //1. Create Secrets, Policy and Role to be used by MediaPackage for CDN Authorization
+    const secrets = new Secrets(this, "Secrets");
+
+    const customPolicy = new iam.PolicyDocument({
+        statements: [
+          new iam.PolicyStatement({
+            resources: [
+              secrets.cdnSecret.secretArn,
+            ],
+            actions: [
+              "secretsmanager:GetSecretValue",
+              "secretsmanager:DescribeSecret",
+              "secretsmanager:ListSecrets",
+              "secretsmanager:ListSecretVersionIds",
+            ],
+          }),
+        ],
+    });
+
+    //Role to be used by MediaPackage for CDN Authorization
+    const role4mediapackage = new iam.Role(this, "MyMediaPackageRole", {
+        description: "A role to be assumed by MediaPackage",
+        assumedBy: new iam.ServicePrincipal('mediapackage.amazonaws.com'),
+        inlinePolicies: {
+          policy: customPolicy,
+        },
+        maxSessionDuration: Duration.hours(1),
+    });
+
+    //2. Create MediaPackage Channel using CDN Authorization
+    const mediaPackageChannel = new MediaPackageCdnAuth(
       this,
-      "MediaPackage"
+      "MyMediaPackageChannel",
+      role4mediapackage.roleArn,
+      secrets,
     );
 
-    //2. Create CloudFront distribution
-    const cloudfront = new CloudFront(this, "MyCloudFront", mediaPackageChannel.hlsEndpoint, mediaPackageChannel.dashEndpoint, mediaPackageChannel.mssEndpoint);
-  }
 
+   //3. Create CloudFront distribution
+   const cloudfront = new CloudFront(
+    this,
+    "MyCloudFrontDistribution", 
+    mediaPackageChannel.hlsEndpoint, 
+    mediaPackageChannel.dashEndpoint,
+    secrets
+  );
+  
+
+  //👇 Generating Cfn output
+  new CfnOutput(this, "MediaPackageChannelName", {
+    value: mediaPackageChannel.myChannelName,
+  });
+  new CfnOutput(this, "MediaPackageChannelArn", {
+    value: mediaPackageChannel.myChannelArn,
+  });
+
+
+  new CfnOutput(this, "CloudFrontDistributionId", {
+    value: cloudfront.myDistribId,
+  });
+  new CfnOutput(this, "CloudFrontDistribution-HLS", {
+    value: cloudfront.hlsPlayback,
+  });
+  new CfnOutput(this, "CloudFrontDistribution-DASH", {
+    value: cloudfront.dashPlayback,
+  });
+  }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Adding CDN Authorization to MediaPackage Endpoints
- On Amazon CloudFront distribution, providing a Header to forward to MediaPackage

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
