### PR TITLE
New pattern: APIGW, Route53 failover

### DIFF
--- a/apigw-route53-failover/README.md
+++ b/apigw-route53-failover/README.md
@@ -1,0 +1,66 @@
+# Amazon Route53 to Amazon API Gateway failover
+
+This pattern creates a simple application with failover records in Route53
+
+Learn more about this pattern at Serverless Land Patterns: [https://serverlessland.com/patterns/apigw-route53-failover](https://serverlessland.com/patterns/apigw-route53-failover)
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+Before deploying this application you will need the following:
+* A domain name and hosted zone
+* An ACM certificate for the domain name.
+
+### To deploy
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ```
+    cd waf-apigw-rest
+    ```
+1. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
+    ```
+    sam deploy --guided
+    ```
+    * Deploy to two seperate regions. One as the PRIMARY one as SECONDARY.
+1. During the prompts:
+    * Enter a stack name
+    * Enter the desired AWS Region
+    * Enter the **DomainName**, **ZoneId**, **CertArn**, and region **Priority** (PRIMARY | SECONDARY)
+    * Allow SAM CLI to create IAM roles with the required permissions.
+
+    Once you have run `sam deploy --guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+
+1. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## How it works
+
+The application exists in two seperate regions. One is a primary and the second is a secondary. Traffic will always be routed to the primary region unless there is an issue. If an issue with the primary region occurs, Route53 will route traffic to the secondary region. This example demonstrates the failover only and does not encompass authentication and data for the multiple regions.
+
+## Testing
+
+Deploy the application to bothe regions. Traffic will be routed to the primary only. Change the Lambda function to return a 500 and Route53 will then start routing to the secondary region. The function will return the ARN of the Lasmbda function invoked. The ARN contains the region.
+
+## Cleanup (Do this in both regions)
+ 
+1. Delete the stack
+    ```bash
+    sam delete --stack-name STACK_NAME
+    ```
+1. Confirm the stack has been deleted
+    ```bash
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus"
+    ```
+----
+Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/apigw-route53-failover/example-pattern.json
+++ b/apigw-route53-failover/example-pattern.json
@@ -1,0 +1,47 @@
+{
+  "title": "Amazon Route53 to Amazon API Gateway failover",
+  "description": "Creates a simple application with failover records in Route53",
+  "language": "Python",
+  "level": "300",
+  "framework": "SAM",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "The application exists in two seperate regions. One is a primary and the second is a secondary. Traffic will always be routed to the primary region unless there is an issue. If an issue with the primary region occurs, Route53 will route traffic to the secondary region. This example demonstrates the failover only and does not encompass authentication and data for the multiple regions."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/apigw-route53-failover",
+      "templateURL": "serverless-patterns/apigw-route53-failovert",
+      "projectFolder": "apigw-route53-failover"
+    }
+  },
+  "resources": {
+    "bullets": []
+  },
+  "deploy": {
+    "text": [
+      "sam deploy"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the Github repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>sam delete</code>."
+    ]
+  },
+  "authors": [
+    {
+      "name": "Eric Johnson",
+      "image": "https://serverlessland.com/assets/images/resources/ericdj.jpg",
+      "bio": "Eric Johnson is a Principal Developer Advocate for Serverless Applications at Amazon Web Services and is based in Northern Colorado. Eric is a fanatic about serverless and enjoys helping developers understand how serverless technologies introduces a major paradigm shift in how they approach building and running applications at massive scale with minimal administration overhead. Prior to this, Eric has worked as a developer, solutions architect and AWS Evangelist for an AWS partner company.",
+      "linkedin": "singledigit",
+      "twitter": "edjgeek"
+    }
+  ]
+}

--- a/apigw-route53-failover/src/app.py
+++ b/apigw-route53-failover/src/app.py
@@ -1,0 +1,10 @@
+import json
+
+def lambda_handler(event, context):
+    return {
+        "statusCode": 200,
+        "body": json.dumps({
+            "message": "Function hit",
+            "Function name": context.invoked_function_arn
+        }),
+    }

--- a/apigw-route53-failover/template.yaml
+++ b/apigw-route53-failover/template.yaml
@@ -1,0 +1,96 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Failover example
+Globals:
+  Function:
+    Timeout: 3
+    Tracing: Active
+    Runtime: python3.9
+    Handler: app.lambda_handler
+    Architectures:
+      - arm64
+  Api:
+    TracingEnabled: True
+
+Parameters:
+  DomainName:
+    Type: String
+    Description: Domian name for api
+    MinLength: 5
+  ZoneId:
+    Type: String
+    Description: Zone ID.
+    MinLength: 5
+  CertArn:
+    Type: String
+    Description: Certificate ARN
+    MinLength: 5
+  Priority:
+    Type: String
+    Description: PRIMARY or SECONDARY
+    AllowedValues: ["PRIMARY", "SECONDARY"]
+
+Resources:
+  CustomDomain: # Creates the domain name
+    Type: AWS::ApiGatewayV2::DomainName
+    Properties: 
+      DomainName: !Ref DomainName
+      DomainNameConfigurations: 
+        - EndpointType: REGIONAL
+          CertificateArn: !Ref CertArn
+
+  RestApiMapping: #Create a maooing to a REST API
+    Type: AWS::ApiGatewayV2::ApiMapping
+    Properties: 
+      ApiId: !Ref RestApiGateway
+      DomainName: !Ref DomainName
+      Stage: !Ref RestApiGatewayProdStage ## = {Logicalname} + {StageName} + Stage
+
+  RestApiGateway: # Creates a REST API endpoint
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: Prod
+      EndpointConfiguration:
+        Type: REGIONAL
+  
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Events:
+        Fetch:
+          Type: Api
+          Properties:
+            RestApiId: !Ref RestApiGateway
+            Path: /
+            Method: get
+
+  HealthCheck:
+    Type: AWS::Route53::HealthCheck
+    Properties: 
+      HealthCheckConfig:
+        EnableSNI: true
+        FullyQualifiedDomainName: !Sub ${RestApiGateway}.execute-api.${AWS::Region}.amazonaws.com
+        Type: HTTPS
+        FailureThreshold: 5 ## Default is 3
+        MeasureLatency: true ## Cannot be changed after creation
+        ResourcePath: /Prod
+
+  FailoverRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      Failover: !Ref Priority
+      Name: !Ref DomainName
+      HostedZoneId: !Ref ZoneId
+      SetIdentifier: !Sub ${AWS::Region}-failover
+      HealthCheckId: !Ref HealthCheck
+      TTL: 60
+      AliasTarget:
+        DNSName: !GetAtt CustomDomain.RegionalDomainName
+        HostedZoneId: !GetAtt CustomDomain.RegionalHostedZoneId
+      Type: A
+
+Outputs:
+  HelloWorldApi:
+    Description: "API Gateway endpoint URL for Prod stage for Hello World function"
+    Value: !Sub "https://${RestApiGateway}.execute-api.${AWS::Region}.amazonaws.com/Prod/"

--- a/apigw-route53-failover/template.yaml
+++ b/apigw-route53-failover/template.yaml
@@ -44,7 +44,7 @@ Resources:
     Properties: 
       ApiId: !Ref RestApiGateway
       DomainName: !Ref DomainName
-      Stage: !Ref RestApiGatewayProdStage ## = {Logicalname} + {StageName} + Stage
+      Stage: Prod
 
   RestApiGateway: # Creates a REST API endpoint
     Type: AWS::Serverless::Api


### PR DESCRIPTION
*Issue #, if available:*

Adds pattern for APIGW and Route53 failover from primary to secondary regions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
