### PR TITLE
Fix for issue 850

### DIFF
--- a/apigw-canary-deployment-cdk/README.md
+++ b/apigw-canary-deployment-cdk/README.md
@@ -67,7 +67,7 @@ The API Gateway Canary Deployment will route 50% of the traffic to the new funct
 From the command line, run the following command to send an HTTP `GET` request to APIs endpoint. Note that you must edit the {MyServerlessApplicationStack.ApigwId} and {Region} placeholder with the ID of the deployed API and Region that it is deployed in. This is provided in the MyServerlessApplicationStack deployment outputs.
 
 ```
-curl -H "Origin: https://www.example.com" "http://{MyServerlessApplicationStack.ApigwId}.execute-api.{Region}.amazonaws.com/prod"
+curl -H "Origin: https://www.example.com" "https://{MyServerlessApplicationStack.ApigwId}.execute-api.{Region}.amazonaws.com/prod"
 ```
 
 Since the canary deployment is set at 50% traffic, when you run the above command more than once you should see the old version's and new version's output at a rate of about 50/50.

--- a/apigw-canary-deployment-cdk/requirements.txt
+++ b/apigw-canary-deployment-cdk/requirements.txt
@@ -1,5 +1,3 @@
 aws-cdk-lib
 constructs
-aws-cdk.aws-apigateway
-aws-cdk.aws-lambda
-aws-cdk.aws-iam
+


### PR DESCRIPTION
*Issue #, if available:* 850

*Description of changes:*
Removed individual aws-cdk requirements - they weren't actually used and were causing a conflict
Fixed the APIGW URL in the testing instructions (should be https).  


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
