### PR TITLE
New serverless pattern - waf-appsync-cdk.

### DIFF
--- a/waf-appsync-cdk/.gitignore
+++ b/waf-appsync-cdk/.gitignore
@@ -6,6 +6,3 @@ node_modules
 # CDK asset staging directory
 .cdk.staging
 cdk.out
-
-
-

--- a/waf-appsync-cdk/.gitignore
+++ b/waf-appsync-cdk/.gitignore
@@ -1,0 +1,11 @@
+*.js
+!jest.config.js
+*.d.ts
+node_modules
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out
+
+
+

--- a/waf-appsync-cdk/.npmignore
+++ b/waf-appsync-cdk/.npmignore
@@ -1,0 +1,6 @@
+*.ts
+!*.d.ts
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/waf-appsync-cdk/README.md
+++ b/waf-appsync-cdk/README.md
@@ -11,7 +11,7 @@ Important: this application uses various AWS services and there are costs associ
 - [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
 - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
 - [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-- [AWS Cloud Development Kit]() (AWS CDK) installed
+- [AWS Cloud Development Kit](https://aws.amazon.com/cdk/) (AWS CDK) installed
 
 ## Deployment Instructions
 

--- a/waf-appsync-cdk/README.md
+++ b/waf-appsync-cdk/README.md
@@ -1,0 +1,71 @@
+# AWS WAF to Appsync
+
+This pattern creates an AppSync graphql API with dynamodb resolvers and protects the api with associating AWS WAF WebACL including managed rules for IP reputation lists and custom rule for blocking graphql schema introspections.
+
+Learn more about this pattern at Serverless Land Patterns: [Serverless Land Pattern](https://serverlessland/patterns)
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+- [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+- [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+- [AWS Cloud Development Kit]() (AWS CDK) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+   ```
+   git clone https://github.com/aws-samples/serverless-patterns
+   ```
+1. Change directory to the pattern directory:
+   ```
+   cd waf-appsync-cdk
+   ```
+1. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
+   ```
+   cdk deploy --all
+   ```
+
+## How it works
+
+This CDK application creates an AppSync graphql API, a demo DynamoDB table, a WAF WebACL with two rules, and associates the WebACL with the API.
+
+## Testing
+
+1. Deploy the stack and use a graphql client to query demos. 
+
+```
+query MyQuery {
+  getDemos {
+    id
+    version
+  }
+}
+```
+
+2. Try to run an introspection query to see WAF WebACL rule in action.
+
+```
+query MyQuery {
+  __schema {
+    types {
+      name
+    }
+  }
+}
+```
+
+## Cleanup
+
+1. Delete the stack
+   ```bash
+   cdk destroy
+   ```
+
+---
+
+Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/waf-appsync-cdk/cdk-stack.ts
+++ b/waf-appsync-cdk/cdk-stack.ts
@@ -1,0 +1,112 @@
+import * as cdk from "aws-cdk-lib";
+import { Construct } from "constructs";
+
+import * as appsync from "@aws-cdk/aws-appsync-alpha";
+import * as waf from "aws-cdk-lib/aws-wafv2";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+
+export class CdkStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    // AppSync graphql API with dynamodb resolvers using L2 alpha construct
+    const api = new appsync.GraphqlApi(this, "DemoApi", {
+      name: "demo",
+      schema: appsync.Schema.fromAsset("schema.graphql"),
+      authorizationConfig: {
+        defaultAuthorization: {
+          authorizationType: appsync.AuthorizationType.API_KEY,
+          apiKeyConfig: {
+            expires: cdk.Expiration.after(cdk.Duration.days(30)),
+            name: "API Key",
+          },
+        },
+      },
+    });
+
+    const demoTable = new dynamodb.Table(this, "DemoTable", {
+      partitionKey: {
+        name: "id",
+        type: dynamodb.AttributeType.STRING,
+      },
+    });
+
+    const demoDS = api.addDynamoDbDataSource("DemoDataSource", demoTable);
+
+    // Resolver for the Query "getDemos" that scans the DynamoDb table and returns the entire list.
+    demoDS.createResolver({
+      typeName: "Query",
+      fieldName: "getDemos",
+      requestMappingTemplate: appsync.MappingTemplate.dynamoDbScanTable(),
+      responseMappingTemplate: appsync.MappingTemplate.dynamoDbResultList(),
+    });
+
+    // Resolver for the Mutation "addDemo" that puts the item into the DynamoDb table.
+    demoDS.createResolver({
+      typeName: "Mutation",
+      fieldName: "addDemo",
+      requestMappingTemplate: appsync.MappingTemplate.dynamoDbPutItem(
+        appsync.PrimaryKey.partition("id").auto(),
+        appsync.Values.projecting("input")
+      ),
+      responseMappingTemplate: appsync.MappingTemplate.dynamoDbResultItem(),
+    });
+
+    // WAF2 WebACL with managed rule set for IP reputation list and a custom rule to block graphql schema introspection queries
+    const webAcl = new waf.CfnWebACL(this, "DemoWebACL", {
+      defaultAction: { allow: {} },
+      visibilityConfig: {
+        cloudWatchMetricsEnabled: true,
+        metricName: "demo-waf",
+        sampledRequestsEnabled: false,
+      },
+      scope: "REGIONAL",
+      rules: [
+        {
+          name: "AWS-AWSManagedRulesAmazonIpReputationList",
+          priority: 10,
+          statement: {
+            managedRuleGroupStatement: {
+              vendorName: "AWS",
+              name: "AWSManagedRulesAmazonIpReputationList",
+            },
+          },
+          overrideAction: {
+            none: {},
+          },
+          visibilityConfig: {
+            sampledRequestsEnabled: true,
+            cloudWatchMetricsEnabled: true,
+            metricName: "AWSManagedRulesAmazonIpReputationList",
+          },
+        },
+        {
+          name: "GraphQLIntrospection",
+          priority: 2,
+          action: {
+            block: {},
+          },
+          visibilityConfig: {
+            sampledRequestsEnabled: true,
+            cloudWatchMetricsEnabled: true,
+            metricName: "BodyGraphQLIntrospectionRule",
+          },
+          statement: {
+            byteMatchStatement: {
+              fieldToMatch: { body: { oversizeHandling: "CONTINUE" } },
+              searchString: "__schema",
+              positionalConstraint: "CONTAINS",
+              textTransformations: [{ priority: 0, type: "LOWERCASE" }],
+            },
+          },
+        },
+      ],
+    });
+
+    // WebACL association with AppSync GraphQL API.
+    new waf.CfnWebACLAssociation(this, "DemoWebACLAssociation", {
+      webAclArn: webAcl.attrArn,
+      resourceArn: api.arn,
+    });
+  }
+}

--- a/waf-appsync-cdk/cdk.json
+++ b/waf-appsync-cdk/cdk.json
@@ -1,0 +1,36 @@
+{
+  "app": "npx ts-node --prefer-ts-exts cdk.ts",
+  "watch": {
+    "include": ["**"],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/core:target-partitions": ["aws", "aws-cn"],
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+    "@aws-cdk/core:enablePartitionLiterals": true,
+    "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
+    "@aws-cdk/aws-iam:standardizedServicePrincipals": false,
+
+    "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true
+  }
+}

--- a/waf-appsync-cdk/cdk.json
+++ b/waf-appsync-cdk/cdk.json
@@ -30,7 +30,6 @@
     "@aws-cdk/core:enablePartitionLiterals": true,
     "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
     "@aws-cdk/aws-iam:standardizedServicePrincipals": false,
-
     "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true
   }
 }

--- a/waf-appsync-cdk/cdk.ts
+++ b/waf-appsync-cdk/cdk.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import "source-map-support/register";
+import * as cdk from "aws-cdk-lib";
+import { CdkStack } from "./cdk-stack";
+
+const app = new cdk.App();
+new CdkStack(app, "Waf2AppSyncStack", {});

--- a/waf-appsync-cdk/package.json
+++ b/waf-appsync-cdk/package.json
@@ -7,16 +7,12 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "jest",
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@types/jest": "^27.5.2",
     "@types/node": "10.17.27",
     "@types/prettier": "2.6.0",
     "aws-cdk": "2.52.0",
-    "jest": "^27.5.1",
-    "ts-jest": "^27.1.4",
     "ts-node": "^10.9.1",
     "typescript": "~3.9.7"
   },

--- a/waf-appsync-cdk/package.json
+++ b/waf-appsync-cdk/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "cdk",
+  "version": "0.1.0",
+  "bin": {
+    "cdk": "cdk.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "test": "jest",
+    "cdk": "cdk"
+  },
+  "devDependencies": {
+    "@types/jest": "^27.5.2",
+    "@types/node": "10.17.27",
+    "@types/prettier": "2.6.0",
+    "aws-cdk": "2.52.0",
+    "jest": "^27.5.1",
+    "ts-jest": "^27.1.4",
+    "ts-node": "^10.9.1",
+    "typescript": "~3.9.7"
+  },
+  "dependencies": {
+    "@aws-cdk/aws-appsync-alpha": "^2.52.0-alpha.0",
+    "aws-cdk-lib": "2.52.0",
+    "constructs": "^10.0.0",
+    "source-map-support": "^0.5.21"
+  }
+}

--- a/waf-appsync-cdk/schema.graphql
+++ b/waf-appsync-cdk/schema.graphql
@@ -1,0 +1,13 @@
+type demo {
+  id: String!
+  version: String!
+}
+type Query {
+  getDemos: [demo!]
+}
+input DemoInput {
+  version: String!
+}
+type Mutation {
+  addDemo(input: DemoInput!): demo
+}

--- a/waf-appsync-cdk/tsconfig.json
+++ b/waf-appsync-cdk/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": [
+      "es2020"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": [
+      "./node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "cdk.out"
+  ]
+}

--- a/waf-appsync-cdk/waf-appsync-cdk-pattern.json
+++ b/waf-appsync-cdk/waf-appsync-cdk-pattern.json
@@ -1,0 +1,60 @@
+{
+  "title": "AWS WAF ACL attached to Amazon AppSync graphql API",
+  "description": "Create an AppSync graphql API protected with WAF rules. This WebACL limits the requests to certain countries and protects against common graphql attacks.",
+  "language": "typescript",
+  "level": "300",
+  "framework": "CDK",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "This sample project demonstrates how to protect an AppSync Graphql API against attacks using WAF (Web Application Firewall) rules.",
+      "This pattern deploys a graphql API with dynamodb resolvers, and a WAF web ACL with rules for protecting GraphQL APIs."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/waf-appsync-cdk",
+      "templateURL": "serverless-patterns/waf-appsync-cdk",
+      "projectFolder": "waf-appsync-cdk",
+      "templateFile": "waf_appsync_cdk/waf_appsync_cdk_stack.py"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "Using AWS WAF to protect your APIs",
+        "link": "https://docs.aws.amazon.com/appsync/latest/devguide/WAF-Integration.html"
+      },
+      {
+        "text": "AWS WAF",
+        "link": "https://aws.amazon.com/waf/"
+      },
+      {
+        "text": "Building WAF rules",
+        "link": "https://docs.aws.amazon.com/waf/latest/developerguide/waf-rules.html"
+      },
+      {
+        "text": "AWS AppSync",
+        "link": "https://docs.aws.amazon.com/appsync/latest/devguide/what-is-appsync.html"
+      }
+    ]
+  },
+  "deploy": {
+    "text": ["cdk deploy --all"]
+  },
+  "testing": {
+    "text": ["See the Github repo for detailed testing instructions."]
+  },
+  "cleanup": {
+    "text": ["Delete the stack: <code>cdk destroy</code>."]
+  },
+  "authors": [
+    {
+      "name": "Harun Hasdal",
+      "image": "https://avatars.githubusercontent.com/u/4698942",
+      "bio": "AWS Solution Architect. Serverless advocate.",
+      "linkedin": "harunhasdal",
+      "twitter": "@harunhasdal"
+    }
+  ]
+}

--- a/waf-appsync-cdk/waf-appsync-cdk-pattern.json
+++ b/waf-appsync-cdk/waf-appsync-cdk-pattern.json
@@ -8,7 +8,7 @@
     "headline": "How it works",
     "text": [
       "This sample project demonstrates how to protect an AppSync Graphql API against attacks using WAF (Web Application Firewall) rules.",
-      "This pattern deploys a graphql API with dynamodb resolvers, and a WAF web ACL with rules for protecting GraphQL APIs."
+      "This pattern deploys a graphql API with DynamoDB resolvers, and a WAF web ACL with rules for protecting GraphQL APIs."
     ]
   },
   "gitHub": {
@@ -16,7 +16,7 @@
       "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/waf-appsync-cdk",
       "templateURL": "serverless-patterns/waf-appsync-cdk",
       "projectFolder": "waf-appsync-cdk",
-      "templateFile": "waf_appsync_cdk/waf_appsync_cdk_stack.py"
+      "templateFile": "cdk.ts"
     }
   },
   "resources": {


### PR DESCRIPTION
*Description of changes:*

Adds a new pattern showing WAF2 WebACL association with AWS AppSync graphql API as documented in `Readme.md` with CDK. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
