### PR TITLE
Improve `apigw-lambda-sls` pattern

### DIFF
--- a/apigw-lambda-sls/README.md
+++ b/apigw-lambda-sls/README.md
@@ -2,7 +2,7 @@
 
 This pattern in Serverless Framework offers a boilerlate to generate an Amazon API Gateway REST API endpoint with a greedy proxy ("{proxy+}") and "ANY" method from the specified path, meaning it will accept by default any method and any path. The Lambda function, provided in TypeScript, only returns the path.
 
-Learn more about this pattern at Serverless Land Patterns: [https://serverlessland.com/patterns/apigw-lambda-cdk](https://serverlessland.com/patterns/apigw-lambda-cdk).
+Learn more about this pattern at Serverless Land Patterns: [https://serverlessland.com/patterns/apigw-lambda-sls](https://serverlessland.com/patterns/apigw-lambda-sls).
 
 Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
 

--- a/apigw-lambda-sls/serverless.yml
+++ b/apigw-lambda-sls/serverless.yml
@@ -12,7 +12,7 @@ provider:
   architecture: arm64 # use Graviton for running all Lambda functions
 
   # override the default stage (dev)
-  stage: ${opt:stage, "prod"}
+  stage: prod
 
   # optional, Lambda function's memory size in MB, default is 1024
   memorySize: 256

--- a/apigw-lambda-sls/serverless.yml
+++ b/apigw-lambda-sls/serverless.yml
@@ -11,9 +11,6 @@ provider:
   runtime: nodejs16.x
   architecture: arm64 # use Graviton for running all Lambda functions
 
-  # use --region option value or the default - us-east-1
-  region: ${opt:region, "us-east-1"}
-
   # override the default stage (dev)
   stage: ${opt:stage, "prod"}
 

--- a/apigw-lambda-sls/serverless.yml
+++ b/apigw-lambda-sls/serverless.yml
@@ -8,7 +8,7 @@ provider:
   name: aws
 
   # common configuration for all Lambda functions in this stack
-  runtime: nodejs14.x
+  runtime: nodejs16.x
   architecture: arm64 # use Graviton for running all Lambda functions
 
   # use --region option value or the default - us-east-1


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

When browsing examples on Serverless Patterns website, I've noticed that some of them could be slightly simplified or improved. This PR includes changes for `apigw-lambda-sls` pattern such as:

1. Fix incorrect link to Serverless Patterns website in the docs. It was pointing to another pattern.
2. Update runtime to `nodejs16.x`
3. Simplify the change of `stage`. The `provider.stage` is only a default stage and overriding it via `--stage <stage>` will be accepted anyway, so no need to write `stage: ${opt:stage, "prod"}`, as it doesn't really change the behavior in a meaningful way and might be more confusing to users
4. Removed setting `region`, because it doesn't differ from the default behavior in any way and only adds confusion for the user.

I've also noticed that the description of this pattern on the website: https://serverlessland.com/patterns/apigw-lambda-sls is wrong as it refers to HTTP API, not REST API, but I couldn't find the source for it. I believe it would be great to address it. 

Please let me know what do you think 🙇 I will totally understand if you're not interested in accepting the contribution.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
