### PR TITLE
New serverless pattern - API Gateway REST API to EventBridge with event payload composition and SQS as target

### DIFF
--- a/apigw-rest-api-eventbridge-sqs-sam/README.md
+++ b/apigw-rest-api-eventbridge-sqs-sam/README.md
@@ -1,6 +1,6 @@
 # API Gateway REST API to EventBridge with event payload composition and SQS as target
 
-The APIGW payload is sent to EventBridge as a custom event payload. In the integration request, a custom payload is created and passed to EventBridge that target an SQS.
+The APIGW payload is sent to Amazon EventBridge as a custom event payload. A custom payload is created in the integration request and passed to EventBridge with the "DetailType":"POSTED". A rule matches these events and sends the event to SQS. A Lambda function polls the SQS queue and writes the payload to CloudWatch Logs.
 
 Learn more about this pattern at Serverless Land Patterns: [https://serverlessland.com/patterns?services=apigw%2Ceventbridge](https://serverlessland.com/patterns?services=apigw%2Ceventbridge
 
@@ -66,12 +66,15 @@ curl --location --request POST '[YOUT_API_URL]' \
 } 
 ```
 
-3. This means your event was published successfully in the SQS.
+3. This means your event was published successfully to EventBridge.
 
-4. Go to the console and check the Lambda logs:
+4. To view the message sent to SQS, either navigate to the Lambda console and check the logs, or use `sam logs` to retrieve the logs within your terminal. Replace (stack-name) with the name you gave your your AWS SAM stack.
+
+```bash
+sam logs --stack-name (stack-name)
+```
 
 Below are snippets from the logs
-
 ```
 2022-12-17T08:05:42.754Z  5c0616f6-523d-54cb-8b83-4ae128b6822b  INFO  {
   data: { IsHelloWorldExample: 'Hello' },

--- a/apigw-rest-api-eventbridge-sqs-sam/README.md
+++ b/apigw-rest-api-eventbridge-sqs-sam/README.md
@@ -1,0 +1,82 @@
+# API Gateway REST API to EventBridge with event payload composition and SQS as target
+
+This pattern deploys an API Gateway HTTP API with a custom domain configuration and permissions to publish HTTP requests as events to EventBridge.
+
+Learn more about this pattern at Serverless Land Patterns: [https://serverlessland.com/patterns/apigateway-http-eventbridge-custom](https://serverlessland.com/patterns/apigateway-http-eventbridge-custom)
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ```
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ```
+    cd apigw-eventbridge
+    ```
+1. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
+    ```
+    sam deploy --guided --capabilities CAPABILITY_NAMED_IAM
+    ```
+1. During the prompts:
+    * Enter a stack name
+    * Enter the desired AWS Region
+    * Allow SAM CLI to create IAM roles with the required permissions.
+
+    Once you have run `sam deploy --guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+
+1. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## Testing
+
+Use your preferred terminal to send a http request.
+
+```bash
+curl --location --request POST 'https://[YOUT_API_URL]' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "Detail":{ 
+      "IsHelloWorldExample": "Hello" 
+    },
+    "DetailType":"POSTED",
+    "Source":"demo.event"
+}'
+```
+
+
+
+The response would be like:
+
+```bash
+{
+  "Entries":[
+    {
+      "EventId":"f0021bf7-e696-508a-823e-424aa2f48dfa"
+    }
+  ],
+  "FailedEntryCount":0
+} 
+```
+
+This means your event was published successfuly and you should see it in the SQS.
+
+## Cleanup
+
+1. Delete the stack
+    ```bash
+    sam delete
+    ```
+----
+
+Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/apigw-rest-api-eventbridge-sqs-sam/README.md
+++ b/apigw-rest-api-eventbridge-sqs-sam/README.md
@@ -1,6 +1,6 @@
 # API Gateway REST API to EventBridge with event payload composition and SQS as target
 
-The APIGW payload is sent to EventBridge as a custom event payload. In the integration request, a custom payload is created and passed to EventBridge to target an SQS.
+The APIGW payload is sent to EventBridge as a custom event payload. In the integration request, a custom payload is created and passed to EventBridge that target an SQS.
 
 Learn more about this pattern at Serverless Land Patterns: [https://serverlessland.com/patterns?services=apigw%2Ceventbridge](https://serverlessland.com/patterns?services=apigw%2Ceventbridge
 
@@ -19,29 +19,30 @@ Important: this application uses various AWS services and there are costs associ
     ```
     git clone https://github.com/aws-samples/serverless-patterns
     ```
-1. Change directory to the pattern directory:
+2. Change the directory to the pattern directory:
     ```
-    cd apigw-eventbridge
+    cd apigw-rest-api-eventbridge-sqs-sam
     ```
-1. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
+3. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
     ```
+    sam build
     sam deploy --guided --capabilities CAPABILITY_NAMED_IAM
     ```
-1. During the prompts:
+4. During the prompts:
     * Enter a stack name
     * Enter the desired AWS Region
     * Allow SAM CLI to create IAM roles with the required permissions.
 
     Once you have run `sam deploy --guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
 
-1. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+5. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
 
 ## Testing
 
-Use your preferred terminal to send a http request.
+1. Use your preferred terminal to send an http request.
 
 ```bash
-curl --location --request POST 'https://[YOUT_API_URL]' \
+curl --location --request POST '[YOUT_API_URL]' \
 --header 'Content-Type: application/json' \
 --data-raw '{
     "Detail":{ 
@@ -52,7 +53,7 @@ curl --location --request POST 'https://[YOUT_API_URL]' \
 }'
 ```
 
-The response would be like:
+2. The response would be like this:
 
 ```bash
 {
@@ -65,7 +66,22 @@ The response would be like:
 } 
 ```
 
-This means your event was published successfuly and you should see it in the SQS.
+3. This means your event was published successfully in the SQS.
+
+4. Go to the console and check the Lambda logs:
+
+Below are snippets from the logs
+
+```
+2022-12-17T08:05:42.754Z  5c0616f6-523d-54cb-8b83-4ae128b6822b  INFO  {
+  data: { IsHelloWorldExample: 'Hello' },
+  metadata: {
+    requestId: 'bcb9dd02-b9a4-40b8-ae9d-37a4fdb9d8cc',
+    requestTimeEpoch: '1671264101920'
+  }
+}
+
+```
 
 ## Cleanup
 

--- a/apigw-rest-api-eventbridge-sqs-sam/README.md
+++ b/apigw-rest-api-eventbridge-sqs-sam/README.md
@@ -1,8 +1,8 @@
 # API Gateway REST API to EventBridge with event payload composition and SQS as target
 
-This pattern deploys an API Gateway HTTP API with a custom domain configuration and permissions to publish HTTP requests as events to EventBridge.
+The APIGW payload is sent to EventBridge as a custom event payload. In the integration request, a custom payload is created and passed to EventBridge to target an SQS.
 
-Learn more about this pattern at Serverless Land Patterns: [https://serverlessland.com/patterns/apigateway-http-eventbridge-custom](https://serverlessland.com/patterns/apigateway-http-eventbridge-custom)
+Learn more about this pattern at Serverless Land Patterns: [https://serverlessland.com/patterns?services=apigw%2Ceventbridge](https://serverlessland.com/patterns?services=apigw%2Ceventbridge
 
 Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details.
 
@@ -51,8 +51,6 @@ curl --location --request POST 'https://[YOUT_API_URL]' \
     "Source":"demo.event"
 }'
 ```
-
-
 
 The response would be like:
 

--- a/apigw-rest-api-eventbridge-sqs-sam/example-pattern.json
+++ b/apigw-rest-api-eventbridge-sqs-sam/example-pattern.json
@@ -1,13 +1,13 @@
 {
   "title": "API Gateway REST API to EventBridge with event payload composition and SQS as target",
-  "description": "Create an API Gateway that sends events to EventBridge and enrich the event in the integration request.",
+  "description": "Create an API Gateway that sends events to EventBridge and enriches the event in the integration request.",
   "language": "",
   "level": "300",
   "framework": "SAM",
   "introBox": {
     "headline": "How it works",
     "text": [
-      "The APIGW payload is sent to EventBridge as part of a custom event payload. In the integration request a custom payload is created and passed to EventBridge that will target an SQS."
+      "The APIGW payload is sent to EventBridge as a custom event payload. In the integration request, a custom payload is created and passed to EventBridge to target an SQS."
     ]
   },
   "gitHub": {

--- a/apigw-rest-api-eventbridge-sqs-sam/example-pattern.json
+++ b/apigw-rest-api-eventbridge-sqs-sam/example-pattern.json
@@ -1,13 +1,13 @@
 {
   "title": "API Gateway REST API to EventBridge with event payload composition and SQS as target",
   "description": "Create an API Gateway that sends events to EventBridge and enriches the event in the integration request.",
-  "language": "",
+  "language": "Node.js, TypeScript",
   "level": "300",
   "framework": "SAM",
   "introBox": {
     "headline": "How it works",
     "text": [
-      "The APIGW payload is sent to EventBridge as a custom event payload. In the integration request, a custom payload is created and passed to EventBridge to target an SQS."
+      "The APIGW payload is sent to EventBridge as a custom event payload. In the integration request, a custom payload is created and passed to EventBridge that target an SQS."
     ]
   },
   "gitHub": {

--- a/apigw-rest-api-eventbridge-sqs-sam/example-pattern.json
+++ b/apigw-rest-api-eventbridge-sqs-sam/example-pattern.json
@@ -48,7 +48,6 @@
   },
   "authors": [
     {
-      "headline": "Presented by Daniele Frasca",
       "name": "Daniele Frasca",
       "image": "https://serverlessland.com/assets/images/resources/contributors/ext-daniele-frasca.jpg",
       "bio": "I am Daniele Frasca serverless enthusiast. I build and architect serverless applications at scale."

--- a/apigw-rest-api-eventbridge-sqs-sam/example-pattern.json
+++ b/apigw-rest-api-eventbridge-sqs-sam/example-pattern.json
@@ -1,0 +1,57 @@
+{
+  "title": "API Gateway REST API to EventBridge with event payload composition and SQS as target",
+  "description": "Create an API Gateway that sends events to EventBridge and enrich the event in the integration request.",
+  "language": "",
+  "level": "300",
+  "framework": "SAM",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "The APIGW payload is sent to EventBridge as part of a custom event payload. In the integration request a custom payload is created and passed to EventBridge that will target an SQS."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/apigw-rest-api-eventbridge-sqs-sam",
+      "templateURL": "serverless-patterns/apigw-rest-api-eventbridge-sqs-sam",
+      "projectFolder": "apigw-rest-api-eventbridge-sqs-sam",
+      "templateFile": "template.yaml"
+    }
+  },
+  "resources": {
+    "headline": "Additional resources",
+    "bullets": [
+      {
+        "text": "Integrating Amazon EventBridge into your serverless applications",
+        "link": "https://aws.amazon.com/blogs/compute/integrating-amazon-eventbridge-into-your-serverless-applications/"
+      },
+      {
+        "text": "Use Amazon EventBridge to Build Decoupled, Event-Driven Architectures",
+        "link": "https://serverlessland.com/learn/eventbridge"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "sam deploy"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the Github repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>sam delete</code>."
+    ]
+  },
+  "authors": [
+    {
+      "headline": "Presented by Daniele Frasca",
+      "name": "Daniele Frasca",
+      "image": "https://serverlessland.com/assets/images/resources/contributors/ext-daniele-frasca.jpg",
+      "bio": "I am Daniele Frasca serverless enthusiast. I build and architect serverless applications at scale."
+    }
+  ]
+}

--- a/apigw-rest-api-eventbridge-sqs-sam/example-pattern.json
+++ b/apigw-rest-api-eventbridge-sqs-sam/example-pattern.json
@@ -1,7 +1,7 @@
 {
   "title": "API Gateway REST API to EventBridge with event payload composition and SQS as target",
   "description": "Create an API Gateway that sends events to EventBridge and enriches the event in the integration request.",
-  "language": "Node.js, TypeScript",
+  "language": "Node.js",
   "level": "300",
   "framework": "SAM",
   "introBox": {
@@ -48,6 +48,7 @@
   },
   "authors": [
     {
+      "headline": "Presented by Daniele Frasca",
       "name": "Daniele Frasca",
       "image": "https://serverlessland.com/assets/images/resources/contributors/ext-daniele-frasca.jpg",
       "bio": "I am Daniele Frasca serverless enthusiast. I build and architect serverless applications at scale."

--- a/apigw-rest-api-eventbridge-sqs-sam/src/handler.ts
+++ b/apigw-rest-api-eventbridge-sqs-sam/src/handler.ts
@@ -1,0 +1,12 @@
+import { SQSEvent, SQSRecord } from "aws-lambda/trigger/sqs";
+
+export const handler: any = async (event: SQSEvent): Promise<any> => {
+  await Promise.all(event.Records.map(async (record: SQSRecord) => {
+    try {
+      let payload = JSON.parse(record.body);
+      console.log(payload.detail);
+    } catch (error) {
+      console.log(error);
+    }
+  }));
+};

--- a/apigw-rest-api-eventbridge-sqs-sam/src/package.json
+++ b/apigw-rest-api-eventbridge-sqs-sam/src/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "apigw-rest-api-eventbridge-sqs-sam",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "build": "tsc"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {},
+  "devDependencies": {
+    "aws-lambda": "^1.0.7",
+    "@types/aws-lambda": "^8.10.109",
+    "@types/node": "^18.11.11",
+    "typescript": "^4.9.4"
+  }
+}

--- a/apigw-rest-api-eventbridge-sqs-sam/src/tsconfig.json
+++ b/apigw-rest-api-eventbridge-sqs-sam/src/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compileOnSave": true,
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "removeComments": true,
+    "target": "ES2020",
+    "inlineSourceMap": true,
+    "esModuleInterop": true,
+    "baseUrl": "./src",
+    "noImplicitOverride": false,
+    "experimentalDecorators": true
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/apigw-rest-api-eventbridge-sqs-sam/template.yml
+++ b/apigw-rest-api-eventbridge-sqs-sam/template.yml
@@ -1,6 +1,15 @@
-AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: Serverless pattern API Gateway to EventBridge
+
+Globals:
+  Function:
+    Runtime: nodejs16.x
+    Architectures: ["arm64"]
+    Timeout: 29
+    MemorySize: 1024
+    Environment:
+      Variables:
+        AWS_NODEJS_CONNECTION_REUSE_ENABLED: 1
 
 Resources:
 # ##########################################################
@@ -175,6 +184,41 @@ Resources:
   Queue1:
     Type: AWS::SQS::Queue
 
+##########################################################################
+#   Lambda Function                                                      #
+##########################################################################
+  LambdaFuncton:
+    Type: AWS::Serverless::Function
+    Properties:
+      Description: !Sub
+        - Stack ${AWS::StackName} Function ${ResourceName}
+        - ResourceName: LambdaFuncton
+      CodeUri: src
+      Handler: handler.handler
+      Tracing: Active
+      Events:
+        Queue:
+          Type: SQS
+          Properties:
+            Queue: !GetAtt Queue.Arn
+            BatchSize: 10
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        External: 
+          - aws-sdk
+        Minify: true
+        Target: "es2020"
+        Sourcemap: false
+        EntryPoints: 
+          - handler.ts
+
+  LambdaFunctonLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 7
+      LogGroupName: !Sub /aws/lambda/${LambdaFuncton}
+
 
 ##########################################################################
 #   OUTPUTS                                                              #
@@ -183,3 +227,7 @@ Outputs:
   ApiURL:
     Description: API Endpoint
     Value: !Sub "https://${Api}.execute-api.${AWS::Region}.amazonaws.com/Prod"
+
+  LambdaFuncton:
+    Value: !Ref LambdaFuncton
+    Description: Lambda Function Name

--- a/apigw-rest-api-eventbridge-sqs-sam/template.yml
+++ b/apigw-rest-api-eventbridge-sqs-sam/template.yml
@@ -1,0 +1,185 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Serverless pattern API Gateway to EventBridge
+
+Resources:
+# ##########################################################
+# BUS                                                      #
+# ##########################################################
+  MyBus:
+    Type: AWS::Events::EventBus
+    Properties:
+      Name: !Sub ${AWS::StackName}-bus
+
+###########################################################################
+#   API GATEWAY ROLE WITH PERMISSIONS TO PUT EVENTS   #
+##########################################################################
+  ApiGatewayEventBridgeRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: !Join ["", ["/", !Ref "AWS::StackName", "/"]]
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowApiGatewayServiceToAssumeRole
+            Effect: Allow
+            Action:
+              - 'sts:AssumeRole'
+            Principal:
+              Service:
+                - apigateway.amazonaws.com
+      Policies:
+        - PolicyName: EBPutEvents
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'events:PutEvents'
+                Resource:
+                  - !GetAtt  MyBus.Arn
+
+##########################################################################
+#   REST API GATEWAY                                                     #
+##########################################################################
+  CloudWatchRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      RoleName: !Sub ${AWS::StackName}
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - apigateway.amazonaws.com
+            Action: 'sts:AssumeRole'
+      Path: /
+      ManagedPolicyArns:
+        - >-
+          arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
+
+  ApiGwAccount:
+    Type: 'AWS::ApiGateway::Account'
+    Properties:
+      CloudWatchRoleArn: !GetAtt CloudWatchRole.Arn
+
+  ApiLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 7
+
+  Api:
+    Type: AWS::Serverless::Api
+    Properties:
+      Name: !Sub
+        - ${ResourceName} From Stack ${AWS::StackName}
+        - ResourceName: Api
+      StageName: Prod
+      DefinitionBody:
+        openapi: '3.0'
+        info: {}
+        paths:
+          /:
+            post:
+              responses:
+                "200":
+                  description: "200 response"
+                  content:
+                    application/json:
+                      schema:
+                        $ref: "#/components/schemas/Empty"
+              x-amazon-apigateway-integration:
+                type: "aws"
+                uri:
+                  Fn::Sub: "arn:aws:apigateway:${AWS::Region}:events:action/PutEvents"
+                credentials: !GetAtt  ApiGatewayEventBridgeRole.Arn
+                httpMethod: "POST"
+                responses:
+                  default:
+                    statusCode: "200"
+                requestTemplates:
+                  application/json: !Sub 
+                    - |- 
+                      #set($context.requestOverride.header.X-Amz-Target = "AWSEvents.PutEvents")
+                      #set($context.requestOverride.header.Content-Type = "application/x-amz-json-1.1")
+                      #set($inputRoot = $input.path('$'))
+                      {
+                          "Entries": [
+                              {
+                                  "Detail": "{ \"data\": {\"IsHelloWorldExample\": \"$inputRoot.Detail.IsHelloWorldExample\"},\"metadata\": {\"requestId\": \"$context.requestId\",\"requestTimeEpoch\": \"$context.requestTimeEpoch\"}}",
+                                  "DetailType": "$inputRoot.DetailType",
+                                  "EventBusName": "${EventBusName}",
+                                  "Source": "$inputRoot.Source"
+                              }
+                          ]
+                      }
+                    - { EventBusName: !Ref MyBus }
+                passthroughBehavior: "when_no_templates"
+        components:
+          schemas:
+            Empty:
+              title: "Empty Schema"
+              type: "object"
+      AccessLogSetting: # Enable access logging with Amazon CloudWatch
+        DestinationArn: !GetAtt ApiLogGroup.Arn
+        Format: >
+          {"requestId":"$context.requestId",
+          "integration-error":"$context.integration.error",
+          "integration-status":"$context.integration.status",
+          "integration-latency":"$context.integration.latency",
+          "integration-requestId":"$context.integration.requestId",
+          "integration-integrationStatus":"$context.integration.integrationStatus",
+          "response-latency":"$context.responseLatency",
+          "status":"$context.status"}
+      EndpointConfiguration: REGIONAL
+      TracingEnabled: true
+
+##########################################################################
+#   SQS                                                                  #
+##########################################################################
+  Queue:
+    Type: AWS::SQS::Queue
+
+  # Define the event rule to filter for events
+  QueueRule: 
+    Type: AWS::Events::Rule
+    Properties: 
+      Description: "SQSEventRule"
+      EventBusName: !Ref MyBus
+      EventPattern: 
+        account: 
+          - !Sub '${AWS::AccountId}'
+        source:
+          - "demo.event"
+        detail-type:
+          - POSTED
+      Targets: 
+        - Arn: !GetAtt Queue.Arn
+          Id: "Queue"
+
+  # Allow EventBridge to invoke SQS
+  EventBridgeToToQeuPolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: events.amazonaws.com
+          Action: SQS:SendMessage
+          Resource: !GetAtt Queue.Arn
+      Queues:
+        - !Ref Queue
+
+  Queue1:
+    Type: AWS::SQS::Queue
+
+
+##########################################################################
+#   OUTPUTS                                                              #
+##########################################################################
+Outputs:
+  ApiURL:
+    Description: API Endpoint
+    Value: !Sub "https://${Api}.execute-api.${AWS::Region}.amazonaws.com/Prod"


### PR DESCRIPTION
Description of changes:
API Gateway REST API to EventBridge with event payload composition and SQS as target

The APIGW payload is sent to EventBridge as a custom event payload. In the integration request, a custom payload is created and passed to EventBridge to target an SQS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
