### PR TITLE
New serverless pattern - s3-upload-presignedurl-api-cdk-ts 

### DIFF
--- a/s3-upload-presignedurl-api-cdk-ts/.gitignore
+++ b/s3-upload-presignedurl-api-cdk-ts/.gitignore
@@ -1,0 +1,7 @@
+!jest.config.js
+*.d.ts
+node_modules
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/s3-upload-presignedurl-api-cdk-ts/.npmignore
+++ b/s3-upload-presignedurl-api-cdk-ts/.npmignore
@@ -1,0 +1,6 @@
+*.ts
+!*.d.ts
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/s3-upload-presignedurl-api-cdk-ts/README.md
+++ b/s3-upload-presignedurl-api-cdk-ts/README.md
@@ -1,0 +1,70 @@
+# S3 upload pre-signed URL
+
+In web and mobile applications, it's common to provide the ability to upload data (documents, images, ...). It can be challenging to upload files to a web server and AWS generally recommends to upload files directly to Amazon S3. If you want to give your users this ability, but you don't want them to have AWS security credentials or permissions, you can use [pre-signed URLs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/PresignedUrlUploadObject.html).
+
+This pattern provides the CDK code to deploy a REST API that will expose a Lambda function in charge of generating the pre-signed URL.
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS CDK] (https://docs.aws.amazon.com/cdk/api/latest/)
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ```
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ```
+    cd s3-upload-presignedurl-api-cdk-ts
+    ```
+1. From the command line, use CDK to deploy the AWS resources for the pattern as specified in eventbridge-scheduled-lambda-cdk.ts file:
+    ```
+    cdk deploy
+    ```
+1. During the prompts:
+    * Do you wish to deploy these changes (y/n)?
+    answer: y <enter>
+
+## How it works
+
+This pattern leverage a high level CDK Construct [`cdk-s3-upload-presignedurl-api`](https://constructs.dev/packages/cdk-s3-upload-presignedurl-api) that will generate the following components:
+
+![architecture](https://raw.githubusercontent.com/jeromevdl/cdk-s3-upload-presignedurl-api/HEAD/images/architecture.png)
+
+1. The client makes a call to the API, specifying the "contentType" of the file to upload in request parameters (eg. `?contentType=image/png` in the URL)
+2. API Gateway handles the request and execute the Lambda function.
+3. The Lambda function makes a call to the [`getSignedUrl`](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html) api for a `putObject` operation.
+4. The Lambda function returns the generated URL and the key of the object in S3 to API Gateway.
+5. The API returns the generated URL and the key of the object in S3 to the client.
+6. The client can now use this URL to upload a file, directly to S3.
+
+## Testing
+- Create a user in Cognito User Pool (through the console).
+- Leverage the [frontend](https://github.com/jeromevdl/cdk-s3-upload-presignedurl-api/tree/main/frontend) example provided in the Construct repository
+  - Update the _src/aws-exports.js_ file with the correct values for the `userPoolId`, `userPoolWebClientId`, `region` and `endpoint` (these values are provided in output of the CDK stack).
+  - Run `npm install` to install the dependencies
+  - Run `npm run start` to start the frontend locally (generally http://localhost:3000)
+  - You will have to change your password on the first connection.
+  - You can then try to upload files in the UI (open the developer tools / network to observe the API calls).
+
+## Cleanup
+
+1. Delete the stack
+    ```bash
+    aws cloudformation delete-stack --stack-name STACK_NAME
+    ```
+1. Confirm the stack has been deleted
+    ```bash
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus"
+    ```
+1. or delete the stack using the AWS Cloudformation console
+----
+Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/s3-upload-presignedurl-api-cdk-ts/bin/s3-upload-presignedurl-api-cdk.ts
+++ b/s3-upload-presignedurl-api-cdk-ts/bin/s3-upload-presignedurl-api-cdk.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import 'source-map-support/register';
+import * as cdk from 'aws-cdk-lib';
+import { S3UploadPresignedURLAPIStack } from '../lib/s3-upload-presignedurl-api-cdk-stack';
+
+const app = new cdk.App();
+new S3UploadPresignedURLAPIStack(app, 'S3UploadPresignedURLAPIStack', {});

--- a/s3-upload-presignedurl-api-cdk-ts/cdk.json
+++ b/s3-upload-presignedurl-api-cdk-ts/cdk.json
@@ -1,0 +1,32 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/s3-upload-presignedurl-api-cdk.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
+    "@aws-cdk/core:stackRelativeExports": true,
+    "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
+    "@aws-cdk/aws-lambda:recognizeVersionProps": true,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
+  }
+}

--- a/s3-upload-presignedurl-api-cdk-ts/example-pattern.json
+++ b/s3-upload-presignedurl-api-cdk-ts/example-pattern.json
@@ -1,20 +1,22 @@
 {
-    "title": "API that expose a Lambda function to generate S3 pre-signed URLs",
-    "description": "Web and mobile applications often provide their users ability to upload files, documents or pictures. A good and now common practice is to upload them directly to Amazon S3, using [pre-signed URLs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/PresignedUrlUploadObject.html). To generate this pre-signed URL, you have to use the AWS SDK (generally in an AWS Lambda function), and expose the feature to the client through an API (with Amazon API Gateway).",
+    "title": "API Gateway and Lambda to generate S3 pre-signed URLS",
+    "description": "Secured REST API that expose a Lambda function to generate S3 pre-signed URLs",
     "language": "Typescript",
     "level": "300",
     "framework": "CDK",
     "introBox": {
       "headline": "How it works",
       "text": [
-            "The infrastructure deployed by this pattern contains an API Gateway REST API, exposing a Lambda function that will generate the S3 pre-signed URL and return it to the client. The API, the Lambda function and the S3 bucket handle CORS headers so that there is no error on the client side. The API is protected by a Cognito User Pool."
+        "Web and mobile applications often provide their users ability to upload files, documents or pictures. A good and now common practice is to upload them directly to Amazon S3, using pre-signed URLs. To generate this pre-signed URL, you have to use the AWS SDK (generally in an AWS Lambda function), and expose the feature to the client through an API (with Amazon API Gateway).",
+        "The infrastructure deployed by this pattern contains an API Gateway REST API, exposing a Lambda function that will generate the S3 pre-signed URL and return it to the client. The API, the Lambda function and the S3 bucket handle CORS headers so that there is no error on the client side. The API is protected by a Cognito User Pool."
       ]
     },
     "gitHub": {
       "template": {
         "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/s3-upload-presignedurl-api-cdk-ts",
         "templateURL": "serverless-patterns/s3-upload-presignedurl-api-cdk-ts",
-        "projectFolder": "s3-upload-presignedurl-api-cdk-ts"
+        "projectFolder": "bin",
+        "templateFile": "s3-upload-presignedurl-api-cdk.ts"
       }
     },
     "resources": {

--- a/s3-upload-presignedurl-api-cdk-ts/example-pattern.json
+++ b/s3-upload-presignedurl-api-cdk-ts/example-pattern.json
@@ -1,0 +1,56 @@
+{
+    "title": "API that expose a Lambda function to generate S3 pre-signed URLs",
+    "description": "Web and mobile applications often provide their users ability to upload files, documents or pictures. A good and now common practice is to upload them directly to Amazon S3, using [pre-signed URLs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/PresignedUrlUploadObject.html). To generate this pre-signed URL, you have to use the AWS SDK (generally in an AWS Lambda function), and expose the feature to the client through an API (with Amazon API Gateway).",
+    "language": "Typescript",
+    "level": "300",
+    "framework": "CDK",
+    "introBox": {
+      "headline": "How it works",
+      "text": [
+            "The infrastructure deployed by this pattern contains an API Gateway REST API, exposing a Lambda function that will generate the S3 pre-signed URL and return it to the client. The API, the Lambda function and the S3 bucket handle CORS headers so that there is no error on the client side. The API is protected by a Cognito User Pool."
+      ]
+    },
+    "gitHub": {
+      "template": {
+        "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/s3-upload-presignedurl-api-cdk-ts",
+        "templateURL": "serverless-patterns/s3-upload-presignedurl-api-cdk-ts",
+        "projectFolder": "s3-upload-presignedurl-api-cdk-ts"
+      }
+    },
+    "resources": {
+      "bullets": [
+        {
+          "text": "S3 Presigned URLs documentation",
+          "link": "https://docs.aws.amazon.com/AmazonS3/latest/userguide/PresignedUrlUploadObject.html"
+        },
+        {
+          "text": "Blog post on S3 pre-signed URLs",
+          "link": "https://aws.amazon.com/blogs/compute/uploading-to-amazon-s3-directly-from-a-web-or-mobile-application/ "
+        }
+      ]
+    },
+    "deploy": {
+      "text": [
+        "cdk deploy"
+      ]
+    },
+    "testing": {
+      "text": [
+        "See the Github repo for detailed testing instructions."
+      ]
+    },
+    "cleanup": {
+      "text": [
+        "Delete the stack: <code>cdk destroy</code>."
+      ]
+    },
+    "authors": [
+      {
+        "name": "Jerome Van Der Linden",
+        "image": "https://avatars.githubusercontent.com/u/117538?v=4",
+        "bio": "Jerome is a Solutions Architect Builder at AWS. Passionate about building stuff using the AWS services, and especially the serverless ones.",
+        "linkedin": "jeromevdl",
+        "twitter": "jeromevdl"
+      }
+    ]
+  }

--- a/s3-upload-presignedurl-api-cdk-ts/example-pattern.json
+++ b/s3-upload-presignedurl-api-cdk-ts/example-pattern.json
@@ -1,7 +1,7 @@
 {
     "title": "API Gateway and Lambda to generate S3 pre-signed URLS",
     "description": "Secured REST API that expose a Lambda function to generate S3 pre-signed URLs",
-    "language": "Typescript",
+    "language": "TypeScript",
     "level": "300",
     "framework": "CDK",
     "introBox": {

--- a/s3-upload-presignedurl-api-cdk-ts/jest.config.js
+++ b/s3-upload-presignedurl-api-cdk-ts/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  testEnvironment: 'node',
+  roots: ['<rootDir>/test'],
+  testMatch: ['**/*.test.ts'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest'
+  }
+};

--- a/s3-upload-presignedurl-api-cdk-ts/lib/s3-upload-presignedurl-api-cdk-stack.ts
+++ b/s3-upload-presignedurl-api-cdk-ts/lib/s3-upload-presignedurl-api-cdk-stack.ts
@@ -1,0 +1,11 @@
+import { Stack, StackProps } from 'aws-cdk-lib';
+import { S3UploadPresignedUrlApi } from 'cdk-s3-upload-presignedurl-api';
+import { Construct } from 'constructs';
+
+export class S3UploadPresignedURLAPIStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    const uploadS3API = new S3UploadPresignedUrlApi(this, 'API');
+  }
+}

--- a/s3-upload-presignedurl-api-cdk-ts/package.json
+++ b/s3-upload-presignedurl-api-cdk-ts/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "s3-upload-presignedurl-api-cdk-ts",
+  "version": "0.1.0",
+  "bin": {
+    "s3-upload-presignedurl-api-cdk-ts": "bin/s3-upload-presignedurl-api-cdk-ts.ts"
+  },
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "test": "jest",
+    "cdk": "cdk"
+  },
+  "devDependencies": {
+    "@types/jest": "^26.0.10",
+    "@types/node": "10.17.27",
+    "jest": "^26.4.2",
+    "ts-jest": "^26.2.0",
+    "aws-cdk": "^2.55.0",
+    "ts-node": "^9.0.0",
+    "typescript": "~3.9.7"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.55.0",
+    "constructs": "^10.0.0",
+    "source-map-support": "^0.5.16",
+    "cdk-s3-upload-presignedurl-api": "^0.0.6"
+  }
+}

--- a/s3-upload-presignedurl-api-cdk-ts/tsconfig.json
+++ b/s3-upload-presignedurl-api-cdk-ts/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": [
+      "ES2020", "DOM"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": [
+      "./node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "cdk.out"
+  ]
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
New pattern : Generation of S3 pre-signed URLs to upload files to S3 from a front 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
