### PR TITLE
Fix LinkedIn URL in bio

### DIFF
--- a/cognito-restapi-vpclink-cdk/example-pattern.json
+++ b/cognito-restapi-vpclink-cdk/example-pattern.json
@@ -58,7 +58,7 @@
       "name": "Justin Plock",
       "image": "",
       "bio": "Principal Solutions Architect at AWS",
-      "linkedin": "https://www.linkedin.com/in/justinplock/",
+      "linkedin": "justinplock",
       "twitter": "@jplock"
     }
   ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The website is currently showing `https://www.linkedin.com/in/https://www.linkedin.com/in/justinplock//` as the LinkedIn URL. This should end up showing the proper URL of `https://www.linkedin.com/in/justinplock/`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
