### PR TITLE
Update: stepfn-lambda-vpc -> removed unused inbound secgroup rules

### DIFF
--- a/cdk-vpc-lambda-sfn/src/stacks/vpc_stack.ts
+++ b/cdk-vpc-lambda-sfn/src/stacks/vpc_stack.ts
@@ -54,9 +54,6 @@ export class vpcStack extends Stack {
             securityGroups: [vSecurityGroup]
         });
 
-        vSecurityGroup.addIngressRule(Peer.anyIpv4(), Port.tcp(80), 'allow HTTP traffic');
-        vSecurityGroup.addIngressRule(Peer.anyIpv4(), Port.tcp(443), 'allow HTTPS traffic');
-
         this.iVpc = vpc;
         this.publicSubNet = vpc.publicSubnets;
         this.privateSubNet = vpc.privateSubnets;


### PR DESCRIPTION
*Description of changes:*
There are two inbound rules in the security group, allowing HTTP & HTTPS from 0.0.0.0/0(anyIpv4) which are not unused.
This PR is for removing such rules