### PR TITLE
New serverless pattern - dynamodb-streams-lambda-eventbridge-sam-rust

### DIFF
--- a/dynamodb-streams-lambda-eventbridge-sam-rust/Cargo.toml
+++ b/dynamodb-streams-lambda-eventbridge-sam-rust/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "dynamodb-streams-lambda-eventbridge-sam-rust"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[[bin]]
+name = "handler"
+path = "src/bin/handler.rs"
+
+[dependencies]
+aws_lambda_events = { version = "0.7", default-features = false, features = ["dynamodb"] }
+aws-types = "0.54"
+aws-config = "0.54"
+aws-sdk-eventbridge = "0.24"
+lambda_runtime = "0.7"
+serde_json = "1"
+serde = {version = "1.0", features = ["derive"] }
+tokio = { version = "1", features = ["macros"] }
+tracing-subscriber = { version = "0.3", features = ["fmt", "json"] }
+typed-builder = "0.12"

--- a/dynamodb-streams-lambda-eventbridge-sam-rust/Makefile
+++ b/dynamodb-streams-lambda-eventbridge-sam-rust/Makefile
@@ -1,0 +1,33 @@
+FUNCTIONS := handler
+ARCH := aarch64-unknown-linux-gnu
+ARCH_SPLIT = $(subst -, ,$(ARCH))
+
+build-MainFunction:
+		cp -v "./build/handler/"* "$(ARTIFACTS_DIR)"
+
+build:
+ifeq ("$(shell zig targets | jq -r .native.cpu.arch)-$(shell zig targets | jq -r .native.os)-$(shell zig targets | jq -r .native.abi)", "$(word 1,$(ARCH_SPLIT))-$(word 3,$(ARCH_SPLIT))-$(word 4,$(ARCH_SPLIT))")
+	@echo "Same host and target. Using native build"
+	cargo build --release --target $(ARCH)
+else
+	@echo "Different host and target. Using zigbuild"
+	cargo zigbuild --release --target $(ARCH)
+endif
+
+	rm -rf ./build
+	mkdir -p ./build
+	${MAKE} ${MAKEOPTS} $(foreach function,${FUNCTIONS}, build-${function})
+
+build-%:
+	mkdir -p ./build/$*
+	cp -v ./target/$(ARCH)/release/$* ./build/$*/bootstrap
+
+deploy:
+	if [ -f samconfig.toml ]; \
+		then sam deploy; \
+		else sam deploy -g --profile test; \
+	fi
+
+
+delete:
+	sam delete

--- a/dynamodb-streams-lambda-eventbridge-sam-rust/README.md
+++ b/dynamodb-streams-lambda-eventbridge-sam-rust/README.md
@@ -1,0 +1,75 @@
+# Amazon Dynamodb Streams to AWS Lambda to Amazon EventBridge
+
+The AWS SAM template deploys a Lambda function, a DynamoDB table and an Amazon EventBridge bus, and the minimum IAM resources required to run the application.
+
+When items are written in the DynamoDB table, the changes are sent to a stream. This pattern configures a Lambda function to poll this stream. The function is invoked with a payload containing the contents of the table item that changed.
+
+Learn more about this pattern at Serverless Land Patterns: https://serverlessland.com/patterns/dynamodb-lambda.
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+* [Rust](https://www.rust-lang.org/) 1.67.0 or higher
+* [cargo-zigbuild](https://github.com/messense/cargo-zigbuild) and [Zig](https://ziglang.org/) for cross-compilation
+* [AWS AppConfig integration with Lambda extensions](https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+2. Change directory to the pattern directory:
+    ```
+    cd dynamodb-streams-lambda-eventbridge-sam-rust
+    ```
+3. From the command line, initialize terraform to  to downloads and installs the providers defined in the configuration:
+    ```
+    make build
+    ```
+4. From the command line, apply the configuration in the main.tf file:
+    ```
+    make deploy
+    ```
+5. During the prompts:
+    * Enter a stack name
+    * Enter the desired AWS Region
+    * Allow SAM CLI to create IAM roles with the required permissions.
+
+    Once you have run `sam deploy -guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+
+6. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## How it works
+
+The changes are sent to a stream when items are written in a DynamoDB table. This pattern configures a Lambda function to poll this stream. The function is invoked with a payload containing the table item that has been inserted. The Lambda will then emit an event to Amazon EventBridge.
+
+## Testing
+
+After deployment, add an item to the DynamoDB table. Next, go to the CloudWatch Logs for the deployed Lambda function. Finally, the event is logged out, containing the item data and response from the Amazon EventBridge operation.
+
+```
+PutEventsOutput { failed_entry_count: 0, entries: Some([PutEventsResultEntry { event_id: Some("cb189d14-8799-80b4-66d1-e512d637889a"), error_code: None, error_message: None }]) }
+```
+
+Alternatively, you can use the events.json payload in Lambda to simulate over 100 inserted records.
+
+## Cleanup
+ 
+1. Delete the stack
+    ```bash
+    make delete
+    ```
+2. Confirm the stack has been deleted
+    ```bash
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus"
+    ```
+----
+Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/dynamodb-streams-lambda-eventbridge-sam-rust/events.json
+++ b/dynamodb-streams-lambda-eventbridge-sam-rust/events.json
@@ -1,0 +1,14537 @@
+{
+  "Records": [
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e69f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "userIdentity": {
+        "type": "Service",
+        "principalId": "dynamodb.amazonaws.com"
+      },
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    }
+  ]
+}

--- a/dynamodb-streams-lambda-eventbridge-sam-rust/example-pattern.json
+++ b/dynamodb-streams-lambda-eventbridge-sam-rust/example-pattern.json
@@ -1,0 +1,62 @@
+{
+  "title": "Amazon Dynamodb Streams to AWS Lambda to Amazon EventBridge",
+  "description": "TThe AWS SAM template deploys a Lambda function, a DynamoDB table and an Amazon EventBridge bus, and the minimum IAM resources required to run the application.",
+  "language": "Rust",
+  "level": "300",
+  "framework": "SAM",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "The changes are sent to a stream when items are written in a DynamoDB table. This pattern configures a Lambda function to poll this stream. The function is invoked with a payload containing the table item that has been inserted. The Lambda will then emit an event to Amazon EventBridge."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/dynamodb-streams-lambda-eventbridge-sam-rust",
+      "templateURL": "serverless-patterns/dynamodb-streams-lambda-eventbridge-sam-rust",
+      "projectFolder": "dynamodb-streams-lambda-eventbridge-sam-rust",
+      "templateFile": "dynamodb-streams-lambda-eventbridge-sam-rust/template.yml"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "Amazon DynamoDB Streams",
+        "link": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/streamsmain.html"
+      },
+      {
+        "text": "AWS Lambda",
+        "link": "https://docs.aws.amazon.com/lambda/latest/dg/welcome.html"
+      },
+      {
+        "text": "Amazon EventBridge",
+        "link": "https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-what-is.html"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "sam deploy"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the Github repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>make delete</code>."
+    ]
+  },
+  "authors": [
+    {
+      "headline": "Presented by Daniele Frasca",
+      "name": "Daniele Frasca",
+      "image": "https://serverlessland.com/assets/images/resources/contributors/ext-daniele-frasca.jpg",
+      "bio": "I am Daniele Frasca serverless enthusiast. I build and architect serverless applications at scale.",
+      "linkedin": "daniele-frasca",
+      "twitter": "dfrasca80"
+    }
+  ]
+}

--- a/dynamodb-streams-lambda-eventbridge-sam-rust/src/bin/handler.rs
+++ b/dynamodb-streams-lambda-eventbridge-sam-rust/src/bin/handler.rs
@@ -1,0 +1,96 @@
+use aws_lambda_events::dynamodb::Event;
+use aws_sdk_eventbridge::model::PutEventsRequestEntry;
+use lambda_runtime::{run, service_fn, Error, LambdaEvent};
+use std::sync::Arc;
+use tokio::task::JoinSet;
+use typed_builder::TypedBuilder as Builder;
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_max_level(tracing_subscriber::filter::LevelFilter::INFO)
+        .init();
+
+    let config = aws_config::from_env().load().await;
+
+    let eb_client = aws_sdk_eventbridge::Client::new(&config);
+    let bus_name = std::env::var("BUS_NAME").expect("BUS_NAME must be set");
+
+    let app_client = AppClient::builder()
+        .bus_name(bus_name)
+        .eb_client(eb_client)
+        .build();
+
+    run(service_fn(|event: LambdaEvent<Event>| {
+        function_handler(&app_client, event)
+    }))
+    .await
+}
+
+pub async fn function_handler(
+    app_client: &AppClient,
+    event: LambdaEvent<Event>,
+) -> Result<(), Error> {
+    println!("{event:?}");
+    let entries: Vec<Vec<PutEventsRequestEntry>> = event
+        .payload
+        .records
+        .chunks(10)
+        .map(|chunk| {
+            chunk
+                .iter()
+                .map(|record| {
+                    let new_image =
+                        serde_json::to_string(&record.clone().change.new_image).unwrap();
+                    PutEventsRequestEntry::builder()
+                        .event_bus_name(&app_client.bus_name)
+                        .source("demo.event")
+                        .detail_type("INSERTED")
+                        .detail(new_image)
+                        .build()
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    let mut set = JoinSet::new();
+    let shared_client = Arc::from(app_client.clone());
+    for entry in entries.into_iter() {
+        let shared_client = shared_client.clone();
+        set.spawn(async move {
+            shared_client
+                .eb_client
+                .put_events()
+                .set_entries(Some(entry))
+                .send()
+                .await
+                .map_or_else(
+                    |e| {
+                        println!("{e:?}");
+                    },
+                    |result| {
+                        println!("{result:?}");
+                    },
+                );
+        });
+    }
+
+    while let Some(res) = set.join_next().await {
+        if let Err(e) = res {
+            println!("{e:?}");
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, Builder)]
+pub struct AppClient {
+    #[builder(setter(into))]
+    pub bus_name: String,
+
+    #[builder(setter(into))]
+    pub eb_client: aws_sdk_eventbridge::Client,
+}

--- a/dynamodb-streams-lambda-eventbridge-sam-rust/template.yml
+++ b/dynamodb-streams-lambda-eventbridge-sam-rust/template.yml
@@ -1,0 +1,84 @@
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+##########################################################################
+#   DynamoDB                                                             #
+##########################################################################
+  MyTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: id
+          KeyType: HASH
+      BillingMode: PAY_PER_REQUEST
+      StreamSpecification:
+        StreamViewType: NEW_AND_OLD_IMAGES
+
+###########################################################
+# BUS                                                      #
+###########################################################
+  MyBus:
+    Type: AWS::Events::EventBus
+    Properties:
+      Name: !Sub ${AWS::StackName}-bus
+
+##########################################################################
+#   Lambda Function                                                      #
+##########################################################################
+  MyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Description: !Sub
+        - Stack ${AWS::StackName} Function ${ResourceName}
+        - ResourceName: MyFunction
+      MemorySize: 512
+      Architectures: ["arm64"]
+      Handler: bootstrap
+      Runtime: provided.al2
+      Timeout: 6
+      CodeUri: ./build/handler
+      Policies:
+        - EventBridgePutEventsPolicy:
+            EventBusName: !Ref MyBus
+      Events:
+        DynamoStream:
+          Type: DynamoDB
+          Properties:
+            BatchSize: 100
+            ParallelizationFactor: 10
+            StartingPosition: LATEST
+            MaximumRetryAttempts: 2
+            BisectBatchOnFunctionError: true
+            MaximumRecordAgeInSeconds: 120
+            FilterCriteria:
+              Filters:
+                - Pattern: '{"eventName": ["INSERT"]}'
+            Stream: !GetAtt MyTable.StreamArn
+      Environment:
+        Variables:
+          BUS_NAME: !Ref MyBus
+          RUST_BACKTRACE: 1
+          RUST_LOG: info
+
+  MyFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 1
+      LogGroupName: !Sub /aws/lambda/${MyFunction}
+
+##########################################################################
+#   OUTPUTS                                                              #
+##########################################################################
+Outputs:
+  MyTableStream:
+    Value: !GetAtt MyTable.StreamArn
+    Export: 
+      Name: !Sub ${AWS::StackName}-MyTableStream
+
+  MyFunctionArn:
+    Value: !GetAtt MyFunction.Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-MyFunctionArn


### PR DESCRIPTION
*Description of changes:*
The AWS SAM template deploys a Lambda function, a DynamoDB table and an Amazon EventBridge bus, and the minimum IAM resources required to run the application.

When items are written in the DynamoDB table, the changes are sent to a stream. This pattern configures a Lambda function to poll this stream. The function is invoked with a payload containing the contents of the table item that changed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
