### PR TITLE
New serverless pattern - dynamodb-streams-lambda-eventbridge-sam-node

### DIFF
--- a/dynamodb-streams-lambda-eventbridge-sam-node/README.md
+++ b/dynamodb-streams-lambda-eventbridge-sam-node/README.md
@@ -1,0 +1,89 @@
+# Amazon Dynamodb Streams to AWS Lambda to Amazon EventBridge
+
+The AWS SAM template deploys a Lambda function, a DynamoDB table and an Amazon EventBridge bus, and the minimum IAM resources required to run the application.
+
+When items are written in the DynamoDB table, the changes are sent to a stream. This pattern configures a Lambda function to poll this stream. The function is invoked with a payload containing the contents of the table item that changed.
+
+Learn more about this pattern at Serverless Land Patterns: https://serverlessland.com/patterns/dynamodb-lambda.
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+2. Change directory to the pattern directory:
+    ```
+    cd dynamodb-streams-lambda-eventbridge-sam-node
+    ```
+3. From the command line, initialize terraform to  to downloads and installs the providers defined in the configuration:
+    ```
+    sam build
+    ```
+4. From the command line, apply the configuration in the main.tf file:
+    ```
+    sam deploy
+    ```
+5. During the prompts:
+    * Enter a stack name
+    * Enter the desired AWS Region
+    * Allow SAM CLI to create IAM roles with the required permissions.
+
+    Once you have run `sam deploy -guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+
+6. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## How it works
+
+The changes are sent to a stream when items are written in a DynamoDB table. This pattern configures a Lambda function to poll this stream. The function is invoked with a payload containing the table item that has been inserted. The Lambda will then emit an event to Amazon EventBridge.
+
+## Testing
+
+After deployment, add an item to the DynamoDB table. Next, go to the CloudWatch Logs for the deployed Lambda function. Finally, the event is logged out, containing the item data and response from the Amazon EventBridge operation.
+
+```
+{
+  '$metadata': {
+    httpStatusCode: 200,
+    requestId: 'fd3f37c3-6175-4e99-8200-649b968d55cc',
+    extendedRequestId: undefined,
+    cfId: undefined,
+    attempts: 1,
+    totalRetryDelay: 0
+  },
+  Entries: [
+    {
+      ErrorCode: undefined,
+      ErrorMessage: undefined,
+      EventId: 'fea4a179-554f-f1bb-9166-fd533865f649'
+    }
+  ],
+  FailedEntryCount: 0
+}
+```
+
+Alternatively, you can use the events.json payload in Lambda to simulate over 100 inserted records.
+
+## Cleanup
+ 
+1. Delete the stack
+    ```bash
+    sam delete
+    ```
+2. Confirm the stack has been deleted
+    ```bash
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus"
+    ```
+----
+Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/dynamodb-streams-lambda-eventbridge-sam-node/events.json
+++ b/dynamodb-streams-lambda-eventbridge-sam-node/events.json
@@ -1,0 +1,14537 @@
+{
+  "Records": [
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e69f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "userIdentity": {
+        "type": "Service",
+        "principalId": "dynamodb.amazonaws.com"
+      },
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    },
+    {
+      "eventID": "f07f8ca4b0b26cb9c4e5e77e42f274ee",
+      "eventName": "INSERT",
+      "eventVersion": "1.1",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "ApproximateCreationDateTime": 1480642020,
+        "Keys": {
+          "val": {
+            "S": "data"
+          },
+          "key": {
+            "S": "binary"
+          }
+        },
+        "NewImage": {
+          "val": {
+            "S": "data"
+          },
+          "asdf1": {
+            "B": "AAEqQQ=="
+          },
+          "b2": {
+            "B": "test"
+          },
+          "asdf2": {
+            "BS": [
+              "AAEqQQ==",
+              "QSoBAA==",
+              "AAEqQQ=="
+            ]
+          },
+          "key": {
+            "S": "binary"
+          },
+          "Binary": {
+            "B": "AAEqQQ=="
+          },
+          "Boolean": {
+            "BOOL": true
+          },
+          "BinarySet": {
+            "BS": [
+              "AAEqQQ==",
+              "AAEqQQ=="
+            ]
+          },
+          "List": {
+            "L": [
+              {
+                "S": "Cookies"
+              },
+              {
+                "S": "Coffee"
+              },
+              {
+                "N": "3.14159"
+              }
+            ]
+          },
+          "Map": {
+            "M": {
+              "Name": {
+                "S": "Joe"
+              },
+              "Age": {
+                "N": "35"
+              }
+            }
+          },
+          "FloatNumber": {
+            "N": "123.45"
+          },
+          "IntegerNumber": {
+            "N": "123"
+          },
+          "NumberSet": {
+            "NS": [
+              "1234",
+              "567.8"
+            ]
+          },
+          "Null": {
+            "NULL": true
+          },
+          "String": {
+            "S": "Hello"
+          },
+          "StringSet": {
+            "SS": [
+              "Giraffe",
+              "Zebra"
+            ]
+          },
+          "EmptyStringSet": {
+            "SS": []
+          }
+        },
+        "SequenceNumber": "1405400000000002063282832",
+        "SizeBytes": 54,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000"
+    }
+  ]
+}

--- a/dynamodb-streams-lambda-eventbridge-sam-node/example-pattern.json
+++ b/dynamodb-streams-lambda-eventbridge-sam-node/example-pattern.json
@@ -1,0 +1,62 @@
+{
+  "title": "Amazon Dynamodb Streams to AWS Lambda to Amazon EventBridge",
+  "description": "TThe AWS SAM template deploys a Lambda function, a DynamoDB table and an Amazon EventBridge bus, and the minimum IAM resources required to run the application.",
+  "language": "TypeScript",
+  "level": "300",
+  "framework": "SAM",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "The changes are sent to a stream when items are written in a DynamoDB table. This pattern configures a Lambda function to poll this stream. The function is invoked with a payload containing the table item that has been inserted. The Lambda will then emit an event to Amazon EventBridge."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/dynamodb-streams-lambda-eventbridge-sam-node",
+      "templateURL": "serverless-patterns/dynamodb-streams-lambda-eventbridge-sam-node",
+      "projectFolder": "dynamodb-streams-lambda-eventbridge-sam-node",
+      "templateFile": "dynamodb-streams-lambda-eventbridge-sam-node/template.yml"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "Amazon DynamoDB Streams",
+        "link": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/streamsmain.html"
+      },
+      {
+        "text": "AWS Lambda",
+        "link": "https://docs.aws.amazon.com/lambda/latest/dg/welcome.html"
+      },
+      {
+        "text": "Amazon EventBridge",
+        "link": "https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-what-is.html"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "sam deploy"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the Github repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>sam delete</code>."
+    ]
+  },
+  "authors": [
+    {
+      "headline": "Presented by Daniele Frasca",
+      "name": "Daniele Frasca",
+      "image": "https://serverlessland.com/assets/images/resources/contributors/ext-daniele-frasca.jpg",
+      "bio": "I am Daniele Frasca serverless enthusiast. I build and architect serverless applications at scale.",
+      "linkedin": "daniele-frasca",
+      "twitter": "dfrasca80"
+    }
+  ]
+}

--- a/dynamodb-streams-lambda-eventbridge-sam-node/package.json
+++ b/dynamodb-streams-lambda-eventbridge-sam-node/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "dynamodb-streams-lambda-eventbridge-sam-node",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "build": "tsc"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@aws-sdk/client-eventbridge": "^3.266.1",
+    "@aws-sdk/util-dynamodb": "^3.266.1",
+    "@types/aws-lambda": "^8.10.110",
+    "@types/node": "^18.13.0",
+    "aws-lambda": "^1.0.7",
+    "typescript": "^4.9.5"
+  }
+}

--- a/dynamodb-streams-lambda-eventbridge-sam-node/src/handler.ts
+++ b/dynamodb-streams-lambda-eventbridge-sam-node/src/handler.ts
@@ -1,0 +1,55 @@
+
+import { DynamoDBStreamEvent, DynamoDBRecord } from "aws-lambda";
+import { unmarshall } from "@aws-sdk/util-dynamodb";
+import { EventBridgeClient, PutEventsCommand, PutEventsRequestEntry, PutEventsRequest } from '@aws-sdk/client-eventbridge';
+
+const eventBridgeClient = new EventBridgeClient({});
+
+export const handler = async (event: DynamoDBStreamEvent): Promise<void> => {
+  let messages = [];
+  await Promise.all(event.Records.map(async (record: DynamoDBRecord) => {
+    let payload = unmarshall(record.dynamodb.NewImage);
+    messages.push(payload);
+  }));
+
+  await eventBridge(messages);
+};
+
+async function eventBridge(messages: any[]) {
+  const chunkedArray: any[][] = chunkArray(messages, 10);
+
+  const batchPromises = [];
+  for (const items of chunkedArray) {
+    const entries: PutEventsRequestEntry[] = [];
+    for (const item of items) {
+      entries.push({
+        Detail: JSON.stringify(item),
+        DetailType: 'INSERTED',
+        EventBusName: process.env.BUS_NAME,
+        Source: 'demo.event',
+      });
+    }
+
+    batchPromises.push(eventBridgeClient.send(new PutEventsCommand({
+      Entries: entries
+    })));
+  }
+
+  const response = await Promise.allSettled(batchPromises);
+  response.forEach(promise => {
+    if (promise.status === "rejected")
+      console.log(promise.reason);
+    else
+      console.log(promise.value);
+  });
+}
+
+function chunkArray(messages: any[], size: number): any[][] {
+  const chunkedArr: any[][] = [];
+  let index = 0;
+  while (index < messages.length) {
+    chunkedArr.push(messages.slice(index, size + index));
+    index += size;
+  }
+  return chunkedArr;
+}

--- a/dynamodb-streams-lambda-eventbridge-sam-node/template.yml
+++ b/dynamodb-streams-lambda-eventbridge-sam-node/template.yml
@@ -1,0 +1,92 @@
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+##########################################################################
+#   DynamoDB                                                             #
+##########################################################################
+  MyTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: id
+          KeyType: HASH
+      BillingMode: PAY_PER_REQUEST
+      StreamSpecification:
+        StreamViewType: NEW_AND_OLD_IMAGES
+
+###########################################################
+# BUS                                                      #
+###########################################################
+  MyBus:
+    Type: AWS::Events::EventBus
+    Properties:
+      Name: !Sub ${AWS::StackName}-bus
+
+##########################################################################
+#   Lambda Function                                                      #
+##########################################################################
+  MyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Description: !Sub
+        - Stack ${AWS::StackName} Function ${ResourceName}
+        - ResourceName: StreamFunction
+      Handler: handler.handler
+      Runtime: nodejs18.x
+      Architectures: ["arm64"]
+      Timeout: 60
+      MemorySize: 1024
+      Policies:
+        - EventBridgePutEventsPolicy:
+            EventBusName: !Ref MyBus
+      Events:
+        DynamoStream:
+          Type: DynamoDB
+          Properties:
+            BatchSize: 100
+            ParallelizationFactor: 10
+            StartingPosition: LATEST
+            MaximumRetryAttempts: 2
+            BisectBatchOnFunctionError: true
+            MaximumRecordAgeInSeconds: 120
+            FilterCriteria:
+              Filters:
+                - Pattern: '{"eventName": ["INSERT"]}'
+            Stream: !GetAtt MyTable.StreamArn
+      Environment:
+        Variables:
+          BUS_NAME: !Ref MyBus
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        External: 
+          - '@aws-sdk/client-eventbridge'
+          - '@aws-sdk/util-dynamodb'
+        Minify: true
+        Target: "es2022"
+        Sourcemap: false
+        EntryPoints: 
+          - src/handler.ts
+
+  MyFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 1
+      LogGroupName: !Sub /aws/lambda/${MyFunction}
+
+##########################################################################
+#   OUTPUTS                                                              #
+##########################################################################
+Outputs:
+  MyTableStream:
+    Value: !GetAtt MyTable.StreamArn
+    Export: 
+      Name: !Sub ${AWS::StackName}-MyTableStream
+
+  MyFunctionArn:
+    Value: !GetAtt MyFunction.Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-MyFunctionArn

--- a/dynamodb-streams-lambda-eventbridge-sam-node/tsconfig.json
+++ b/dynamodb-streams-lambda-eventbridge-sam-node/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compileOnSave": true,
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "removeComments": true,
+    "target": "ES2022",
+    "inlineSourceMap": true,
+    "esModuleInterop": true,
+    "baseUrl": "./src",
+    "noImplicitOverride": false,
+    "experimentalDecorators": true
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
Description of changes:
The AWS SAM template deploys a Lambda function, a DynamoDB table and an Amazon EventBridge bus, and the minimum IAM resources required to run the application.

When items are written in the DynamoDB table, the changes are sent to a stream. This pattern configures a Lambda function to poll this stream. The function is invoked with a payload containing the contents of the table item that changed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.