### PR TITLE
New serverless pattern -  SNS to EventBridge Pipes triggering a Step Function via EventBus in CDK

### DIFF
--- a/cdk-sns-sqs-eventbridge-pipes-stepfunctions/Makefile
+++ b/cdk-sns-sqs-eventbridge-pipes-stepfunctions/Makefile
@@ -1,4 +1,4 @@
 deploy-local: 
 	cdk synth
-	cdk deploy  `npx ts-node bin/app.ts` --profile=personal
+	cdk deploy  `npx ts-node bin/app.ts`
 

--- a/cdk-sns-sqs-eventbridge-pipes-stepfunctions/Makefile
+++ b/cdk-sns-sqs-eventbridge-pipes-stepfunctions/Makefile
@@ -1,0 +1,4 @@
+deploy-local: 
+	cdk synth
+	cdk deploy  `npx ts-node bin/app.ts` --profile=personal
+

--- a/cdk-sns-sqs-eventbridge-pipes-stepfunctions/README.md
+++ b/cdk-sns-sqs-eventbridge-pipes-stepfunctions/README.md
@@ -1,37 +1,56 @@
-## README
+# AWS SNS to Step Functions via EventBridge Pipes and Bus
 
-CDK Pattern highlighting an architectual pattern that connects an SNS Message Producer to a Step Function by using EventBridge and SQS
+This pattern demonstrates how to trigger a Step Function from an Event that is publisehded into
+SNS and is handled by EventBridge Pipes where it is filtered and transformed before sending to an
+EventBus
 
-![High Level Architecture](https://www.binaryheap.com/wp-content/uploads/2023/03/sns_pipes.png)
+Learn more about this pattern at Serverless Land Patterns: << Add the live URL here >>
 
-### Description of the Flow
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
 
--   A publisher submits a message to SNS
--   SNS will then trigger the message and post into an SQS. The subscription needs to be marked as `Raw Message Delivery`
--   An EventBridge Pipe listens to the SQS and then
-    -   Filters the message for types of events it's interested in
-    -   Tranforms the body from an SQS Message Body into something more usable for an EventBus
--   A Custom Event Bus has a `Rule` that handles the message and targets a Step Function
--   The State Machine is triggered and just does a Succeed tasks (more workflow could surely be added)
+## Requirements
 
-### Running the Solution
+-   [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+-   [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+-   [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+-   [Node and NPM](https://nodejs.org/en/download/) installed
+-   [AWS CDK](https://docs.aws.amazon.com/cdk/v2/guide/getting_started.html) (AWS CDK) installed
 
-#### Deploying
+## Deployment Instructions
 
-To Deploy, run
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ```
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+2. Change directory to the pattern directory:
+    ```
+    cd cdk-sns-sqs-eventbridge-pipes-stepfunctions
+    ```
+3. Install the project dependencies
+    ```
+     npm instaall
+    ```
+4. Deploy the stack to your default AWS account and region
+    ```
+    cdk deploy
+    ```
 
-```
-make local-deploy
-```
+## How it works
 
-This will execute
+Once the pattern is deployed to AWS, you will have the following resources created with the described capabilities
 
--   CDK synth
--   Deploy out to your AWS Environment configured in your ~/.aws/profile
+-   SNS Topic that is used for receiving the input message
+-   SQS Queue which is subscrited to the SNS Topic with `rawMessageDelivery` enabled
+-   EventBridge Pipe is reading from the SQS
+    -   A Filter step will be attached for limiting the events the pipe allows through
+    -   A Transformation step will be attached to the Pipe for modifying the incoming Message Body to a more suitable output for consumption
+-   An EventBridge Custom EventBus
+-   EventBridge Rule attached to the Custom Bus which Triggers the State Machine
+-   A very basic Step Function with a Succeed Task to simply demonstrate connectivity
 
-#### Triggering the workflow
+## Testing
 
-Post a message onto the SNS Topic with the following structure
+In the AWS Console, browse to the SNS Service and find the `sample-topic` that is created. Once the Topic is opened, choose to `Publish Message`. Enter the below in the Message Body
 
 ```javascript
 {
@@ -41,3 +60,23 @@ Post a message onto the SNS Topic with the following structure
     "field3": "Sample Field 3"
 }
 ```
+
+After publishing, browse to the Step Functions Service and inspect that the State Machine was triggered and that the input supplied matches the input defined in the EventBridge Pipe.
+
+## Cleanup
+
+1. Delete the stack
+    ```bash
+    cdk destroy
+    ```
+
+## Documentation
+
+-   [AWS EventBridge Pipes](https://aws.amazon.com/eventbridge/pipes/)
+-   [AWS EventBridge Pipes SQS Source](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-pipes-sqs.html)
+
+---
+
+Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/cdk-sns-sqs-eventbridge-pipes-stepfunctions/README.md
+++ b/cdk-sns-sqs-eventbridge-pipes-stepfunctions/README.md
@@ -37,6 +37,8 @@ Important: this application uses various AWS services and there are costs associ
 
 ## How it works
 
+This pattern is designed to help connect producers that are submitting messages into SNS with EventBridge as a way to deliver those same events in a more configuration driven and scalable way. It also helps reduce load and needless code downstream by leveraging AWS EventBridge Pipes to both filter and transform the data from the producer before attaching to an EventBus for further consumption.
+
 Once the pattern is deployed to AWS, you will have the following resources created with the described capabilities
 
 -   SNS Topic that is used for receiving the input message

--- a/cdk-sns-sqs-eventbridge-pipes-stepfunctions/README.md
+++ b/cdk-sns-sqs-eventbridge-pipes-stepfunctions/README.md
@@ -1,0 +1,43 @@
+## README
+
+CDK Pattern highlighting an architectual pattern that connects an SNS Message Producer to a Step Function by using EventBridge and SQS
+
+![High Level Architecture](https://www.binaryheap.com/wp-content/uploads/2023/03/sns_pipes.png)
+
+### Description of the Flow
+
+-   A publisher submits a message to SNS
+-   SNS will then trigger the message and post into an SQS. The subscription needs to be marked as `Raw Message Delivery`
+-   An EventBridge Pipe listens to the SQS and then
+    -   Filters the message for types of events it's interested in
+    -   Tranforms the body from an SQS Message Body into something more usable for an EventBus
+-   A Custom Event Bus has a `Rule` that handles the message and targets a Step Function
+-   The State Machine is triggered and just does a Succeed tasks (more workflow could surely be added)
+
+### Running the Solution
+
+#### Deploying
+
+To Deploy, run
+
+```
+make local-deploy
+```
+
+This will execute
+
+-   CDK synth
+-   Deploy out to your AWS Environment configured in your ~/.aws/profile
+
+#### Triggering the workflow
+
+Post a message onto the SNS Topic with the following structure
+
+```javascript
+{
+    "eventType": "SampleEvent",
+    "field1": "Sample Field 1",
+    "field2": "Sample Field 2",
+    "field3": "Sample Field 3"
+}
+```

--- a/cdk-sns-sqs-eventbridge-pipes-stepfunctions/bin/app.ts
+++ b/cdk-sns-sqs-eventbridge-pipes-stepfunctions/bin/app.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import "source-map-support/register";
+import * as cdk from "aws-cdk-lib";
+import { MainStack } from "../lib/main-stack";
+
+const app = new cdk.App();
+new MainStack(app, "MainStack");

--- a/cdk-sns-sqs-eventbridge-pipes-stepfunctions/cdk.context.json
+++ b/cdk-sns-sqs-eventbridge-pipes-stepfunctions/cdk.context.json
@@ -1,0 +1,5 @@
+{
+  "acknowledged-issue-numbers": [
+    21661
+  ]
+}

--- a/cdk-sns-sqs-eventbridge-pipes-stepfunctions/cdk.json
+++ b/cdk-sns-sqs-eventbridge-pipes-stepfunctions/cdk.json
@@ -1,0 +1,41 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/app.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
+    "@aws-cdk/core:stackRelativeExports": true,
+    "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
+    "@aws-cdk/aws-lambda:recognizeVersionProps": true,
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+    "@aws-cdk/core:newStyleStackSynthsis": true,
+    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
+  }
+}

--- a/cdk-sns-sqs-eventbridge-pipes-stepfunctions/environment.json
+++ b/cdk-sns-sqs-eventbridge-pipes-stepfunctions/environment.json
@@ -1,0 +1,6 @@
+{
+    "Parameters": {
+        "LOG_LEVEL": "debug",
+        "IS_LOCAL": "true"
+    }
+}

--- a/cdk-sns-sqs-eventbridge-pipes-stepfunctions/example-pattern.json
+++ b/cdk-sns-sqs-eventbridge-pipes-stepfunctions/example-pattern.json
@@ -1,0 +1,52 @@
+{
+    "title": "SNS to Step Functions with an EventBridge Pipe and Bus via CDK",
+    "description": "Creates a Step Function Wofklow that is triggered by a producer that is generating messages in SNS.  The messages are filtered via EventBridge Pipes and the Step Function is Triggered by a Custom EventBus and Rule",
+    "language": "TypeScript",
+    "level": "300",
+    "framework": "CDK",
+    "introBox": {
+        "headline": "How it works",
+        "text": [
+            "This pattern is designed to help connect producers that are submitting messages into SNS with EventBridge as a way to deliver those same events in a more configuration driven and scalable way. It also helps reduce load and needless code downstream by leveraging AWS EventBridge Pipes to both filter and transform the data from the producer before attaching to an EventBus for further consumption."
+        ]
+    },
+    "gitHub": {
+        "template": {
+            "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/cdk-sns-sqs-eventbridge-pipes-stepfunctions",
+            "templateURL": "serverless-patterns/cdk-sns-sqs-eventbridge-pipes-stepfunctions",
+            "projectFolder": "cdk-sns-sqs-eventbridge-pipes-stepfunctions",
+            "templateFile": "lib/main-stack.ts"
+        }
+    },
+    "resources": {
+        "bullets": [
+            {
+                "text": "AWS EventBridge Pipes",
+                "link": "https://aws.amazon.com/eventbridge/pipes/"
+            },
+            {
+                "text": "AWS EventBridge Pipes SQS Source",
+                "link": "https://docs.aws.amazon.com/eventbridge/latest/userguide/"
+            }
+        ]
+    },
+    "deploy": {
+        "text": ["cdk deploy"]
+    },
+    "testing": {
+        "text": ["See the Github repo for detailed testing instructions."]
+    },
+    "cleanup": {
+        "text": ["Delete the stack: <code>cdk destroy</code>."]
+    },
+    "authors": [
+        {
+            "headline": "Presented by Benjamen Pyle",
+            "name": "Benjamen Pyle",
+            "image": "https://www.binaryheap.com/wp-content/uploads/2023/02/cropped-Photo-on-1-26-23-at-8.57-AM-2.png",
+            "bio": "Benjamen Pyle is an AWS Community Builder who loves building scalable and useful applications with Serverless and Event Drive Architectures",
+            "linkedin": "benjamenpyle",
+            "twitter": "benjamenpyle"
+        }
+    ]
+}

--- a/cdk-sns-sqs-eventbridge-pipes-stepfunctions/jest.config.js
+++ b/cdk-sns-sqs-eventbridge-pipes-stepfunctions/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  testEnvironment: 'node',
+  roots: ['<rootDir>/test'],
+  testMatch: ['**/*.test.ts'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest'
+  }
+};

--- a/cdk-sns-sqs-eventbridge-pipes-stepfunctions/lib/event-bridge-pipe-construct.ts
+++ b/cdk-sns-sqs-eventbridge-pipes-stepfunctions/lib/event-bridge-pipe-construct.ts
@@ -1,0 +1,141 @@
+import * as pipes from "aws-cdk-lib/aws-pipes";
+import {
+    PolicyDocument,
+    PolicyStatement,
+    Effect,
+    Role,
+    ServicePrincipal,
+} from "aws-cdk-lib/aws-iam";
+import { IQueue } from "aws-cdk-lib/aws-sqs";
+import { Construct } from "constructs";
+import { IEventBus } from "aws-cdk-lib/aws-events";
+
+interface PipeProps {
+    bus: IEventBus;
+    queue: IQueue;
+}
+
+export class EventBridgePipeConstruct extends Construct {
+    constructor(scope: Construct, id: string, props: PipeProps) {
+        super(scope, id);
+
+        // Create the role
+        const pipeRole = this.pipeRole(
+            scope,
+            this.sourcePolicy(props.queue),
+            this.targetPolicy(props.bus)
+        );
+
+        const pipe = new pipes.CfnPipe(this, "Pipe", {
+            name: "SampleEvent-Pipe",
+            roleArn: pipeRole.roleArn,
+            source: props.queue.queueArn,
+            target: props.bus.eventBusArn,
+            sourceParameters: this.sourceParameters(),
+            targetParameters: this.targetParameters(),
+        });
+    }
+
+    /*
+        Builds the IAM Policy for putting events on the bus
+    */
+    targetPolicy = (bus: IEventBus): PolicyDocument => {
+        return new PolicyDocument({
+            statements: [
+                new PolicyStatement({
+                    resources: [bus.eventBusArn],
+                    actions: ["events:PutEvents"],
+                    effect: Effect.ALLOW,
+                }),
+            ],
+        });
+    };
+
+    /*
+        Builds the IAM Policy for reading events from SQS
+    */
+    sourcePolicy = (queue: IQueue): PolicyDocument => {
+        return new PolicyDocument({
+            statements: [
+                new PolicyStatement({
+                    resources: [queue.queueArn],
+                    actions: [
+                        "sqs:ReceiveMessage",
+                        "sqs:DeleteMessage",
+                        "sqs:GetQueueAttributes",
+                    ],
+                    effect: Effect.ALLOW,
+                }),
+            ],
+        });
+    };
+
+    /*
+        Builds the IAM Role that combines the source and target policy 
+        with the ServicePrincipal for AWS Pipes
+    */
+    pipeRole = (
+        scope: Construct,
+        sourcePolicy: PolicyDocument,
+        targetPolicy: PolicyDocument
+    ): Role => {
+        return new Role(scope, "PipeRole", {
+            assumedBy: new ServicePrincipal("pipes.amazonaws.com"),
+            inlinePolicies: {
+                sourcePolicy,
+                targetPolicy,
+            },
+        });
+    };
+
+    /*
+        Input parameters.  Leveraging the Message Body from the SQS receiveMessage
+        By using filter criteria the developer can keep downstream systems from 
+        receiving unecassary messages from upstream noise
+    */
+    sourceParameters = () => {
+        return {
+            sqsQueueParameters: {
+                batchSize: 1,
+            },
+            filterCriteria: {
+                filters: [
+                    {
+                        pattern: `
+                {
+                    "body": {
+                        "eventType": ["SampleEvent"]
+                    }
+                  }                            
+                `,
+                    },
+                ],
+            },
+        };
+    };
+
+    /*
+        Target parameters.  Transforms the input from the queue into something
+        that is suitable for the downstream event bus to read.  Transforms give
+        the developer the ability to manipulate the output before it is written out
+    */
+    targetParameters = () => {
+        return {
+            eventBridgeEventBusParameters: {
+                detailType: "SampleEventTriggered",
+                source: "com.binaryheap.sample-source",
+            },
+            inputTemplate: `
+            {
+                "metaBody": {
+                    "correlationId": <$.messageId>
+                },
+                "messageBody": {
+                    "field1": <$.body.field1>,
+                    "field2": <$.body.field2>,
+                    "field3": <$.body.field3>
+                }
+            }`,
+        };
+    };
+}

--- a/cdk-sns-sqs-eventbridge-pipes-stepfunctions/lib/event-bridge-rule-construct.ts
+++ b/cdk-sns-sqs-eventbridge-pipes-stepfunctions/lib/event-bridge-rule-construct.ts
@@ -1,0 +1,39 @@
+import { IEventBus, Rule, RuleTargetInput } from "aws-cdk-lib/aws-events";
+import { SfnStateMachine } from "aws-cdk-lib/aws-events-targets";
+import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+import { IStateMachine } from "aws-cdk-lib/aws-stepfunctions";
+import { Construct } from "constructs";
+
+export interface EventBridgeRuleProps {
+    bus: IEventBus;
+    stateMachine: IStateMachine;
+}
+
+export class EventBridgeRuleConstruct extends Construct {
+    constructor(scope: Construct, id: string, props: EventBridgeRuleProps) {
+        super(scope, id);
+
+        const rule = new Rule(this, "SampleEvent-Rule", {
+            eventPattern: {
+                detailType: ["SampleEventTriggered"],
+            },
+            ruleName: "sample-event-triggered-rule",
+            eventBus: props.bus,
+        });
+
+        const dlq = new Queue(this, "SameEventTriggered-DLQ");
+
+        const role = new Role(this, "SameEventTriggered-Role", {
+            assumedBy: new ServicePrincipal("events.amazonaws.com"),
+        });
+
+        rule.addTarget(
+            new SfnStateMachine(props.stateMachine, {
+                input: RuleTargetInput,
+                deadLetterQueue: dlq,
+                role: role,
+            })
+        );
+    }
+}

--- a/cdk-sns-sqs-eventbridge-pipes-stepfunctions/lib/event-bus-construct.ts
+++ b/cdk-sns-sqs-eventbridge-pipes-stepfunctions/lib/event-bus-construct.ts
@@ -1,0 +1,19 @@
+import { Construct } from "constructs";
+import * as events from "aws-cdk-lib/aws-events";
+import { IEventBus } from "aws-cdk-lib/aws-events";
+
+export class EventBusConstruct extends Construct {
+    private readonly _bus: IEventBus;
+
+    constructor(scope: Construct, id: string) {
+        super(scope, id);
+
+        this._bus = new events.EventBus(scope, "EventBus", {
+            eventBusName: `sample-event-bus`,
+        });
+    }
+
+    get eventBus(): IEventBus {
+        return this._bus;
+    }
+}

--- a/cdk-sns-sqs-eventbridge-pipes-stepfunctions/lib/main-stack.ts
+++ b/cdk-sns-sqs-eventbridge-pipes-stepfunctions/lib/main-stack.ts
@@ -1,0 +1,41 @@
+import { Construct } from "constructs";
+import * as cdk from "aws-cdk-lib";
+import { SnsSqsConstruct } from "./sns-sqs-construct";
+import { EventBusConstruct } from "./event-bus-construct";
+import { EventBridgePipeConstruct } from "./event-bridge-pipe-construct";
+import { StateMachineConstruct } from "./state-machine-construct";
+import { EventBridgeRuleConstruct } from "./event-bridge-rule-construct";
+
+export class MainStack extends cdk.Stack {
+    constructor(scope: Construct, id: string) {
+        super(scope, id);
+
+        // create the queue/topic
+        const comms = new SnsSqsConstruct(this, "SnsSqsConstruct");
+
+        // create the eventbus
+        const bus = new EventBusConstruct(this, "EventBusConstruct");
+
+        /* create the pipe
+         * listen to the sqs created above
+         * target the eventbus created above
+         */
+        const pipe = new EventBridgePipeConstruct(
+            this,
+            "EventBridgePipeConstruct",
+            {
+                bus: bus.eventBus,
+                queue: comms.queue,
+            }
+        );
+
+        // create the state machine
+        const sm = new StateMachineConstruct(this, "StateMachinConstruct");
+
+        // create the eventbridge rule to trigger the statemachine
+        new EventBridgeRuleConstruct(this, "EventBridgeRuleConstruct", {
+            bus: bus.eventBus,
+            stateMachine: sm.stateMachine,
+        });
+    }
+}

--- a/cdk-sns-sqs-eventbridge-pipes-stepfunctions/lib/sns-sqs-construct.ts
+++ b/cdk-sns-sqs-eventbridge-pipes-stepfunctions/lib/sns-sqs-construct.ts
@@ -1,0 +1,38 @@
+import { Construct } from "constructs";
+import * as events from "aws-cdk-lib/aws-events";
+// import * as targets from "aws-cdk-lib/aws-events-targets";
+import { IQueue, Queue } from "aws-cdk-lib/aws-sqs";
+import { ITopic, Topic } from "aws-cdk-lib/aws-sns";
+import { SqsSubscription } from "aws-cdk-lib/aws-sns-subscriptions";
+
+export class SnsSqsConstruct extends Construct {
+    private readonly _queue: IQueue;
+    private readonly _topic: ITopic;
+
+    constructor(scope: Construct, id: string) {
+        super(scope, id);
+
+        this._topic = new Topic(scope, "SampleTopic", {
+            topicName: "sample-topic",
+            displayName: "Sample Topic",
+        });
+
+        this._queue = new Queue(scope, "SampleQueue", {
+            queueName: `sample-queue`,
+        });
+
+        this._topic.addSubscription(
+            new SqsSubscription(this._queue, {
+                rawMessageDelivery: true,
+            })
+        );
+    }
+
+    get topic(): ITopic {
+        return this._topic;
+    }
+
+    get queue(): IQueue {
+        return this._queue;
+    }
+}

--- a/cdk-sns-sqs-eventbridge-pipes-stepfunctions/lib/state-machine-construct.ts
+++ b/cdk-sns-sqs-eventbridge-pipes-stepfunctions/lib/state-machine-construct.ts
@@ -1,0 +1,68 @@
+import { Duration } from "aws-cdk-lib";
+import { Construct } from "constructs";
+import * as sf from "aws-cdk-lib/aws-stepfunctions";
+import * as stepfunctions from "aws-cdk-lib/aws-stepfunctions";
+import {
+    IStateMachine,
+    LogLevel,
+    Succeed,
+} from "aws-cdk-lib/aws-stepfunctions";
+import * as logs from "aws-cdk-lib/aws-logs";
+import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+
+export class StateMachineConstruct extends Construct {
+    private _stateMachine: sf.StateMachine;
+
+    get stateMachine(): IStateMachine {
+        return this._stateMachine;
+    }
+
+    constructor(scope: Construct, id: string) {
+        super(scope, id);
+        this.finalizeStateMachine(scope);
+    }
+
+    /**
+     * Sets up the state machine. Brings in the roles, permissions and appropriate keys and whatnot
+     * to allow the state machine to do its thing
+     *
+     *  @param {Construct} scope - the context for the state machine
+     */
+    finalizeStateMachine = (scope: Construct) => {
+        const logGroup = new logs.LogGroup(this, "CloudwatchLogs", {
+            logGroupName: "/aws/vendedlogs/states/sample-state-machine",
+        });
+
+        const role = new Role(this, "StateMachineRole", {
+            assumedBy: new ServicePrincipal(`states.us-west-2.amazonaws.com`),
+        });
+
+        const flow = this.buildStateMachine(scope);
+
+        this._stateMachine = new stepfunctions.StateMachine(
+            this,
+            "StateMachine",
+            {
+                role: role,
+                stateMachineName: "SampleStateMachine",
+                definition: flow,
+                stateMachineType: stepfunctions.StateMachineType.EXPRESS,
+                timeout: Duration.seconds(30),
+                logs: {
+                    level: LogLevel.ALL,
+                    destination: logGroup,
+                    includeExecutionData: true,
+                },
+            }
+        );
+    };
+
+    /**
+     * Creates the workflow for the state machine.  Builds transitions and errors/catches/retries
+     *
+     *  @param {Construct} scope - the context for the state machine
+     */
+    buildStateMachine = (scope: Construct): stepfunctions.IChainable => {
+        return new Succeed(scope, "DefaultSucceed");
+    };
+}

--- a/cdk-sns-sqs-eventbridge-pipes-stepfunctions/package.json
+++ b/cdk-sns-sqs-eventbridge-pipes-stepfunctions/package.json
@@ -1,0 +1,33 @@
+{
+    "name": "cdk-sns-eventbridge-pattern",
+    "version": "0.1.0",
+    "bin": {
+        "health-lake-change-data-capture": "bin/app.ts"
+    },
+    "scripts": {
+        "build": "tsc",
+        "watch": "tsc -w",
+        "test": "jest",
+        "cdk": "cdk",
+        "lint": "eslint . --ext .ts"
+    },
+    "devDependencies": {
+        "@types/jest": "^27.5.2",
+        "@types/node": "10.17.27",
+        "@types/prettier": "2.6.0",
+        "@typescript-eslint/eslint-plugin": "^5.43.0",
+        "@typescript-eslint/parser": "^5.43.0",
+        "aws-cdk": "2.66.1",
+        "eslint": "^8.28.0",
+        "jest": "^27.5.1",
+        "ts-jest": "^27.1.4",
+        "ts-node": "^10.9.1",
+        "typescript": "~3.9.7"
+    },
+    "dependencies": {
+        "@aws-cdk/aws-lambda-go-alpha": "^2.66.1-alpha.0",
+        "aws-cdk-lib": "2.66.1",
+        "constructs": "^10.0.0",
+        "source-map-support": "^0.5.21"
+    }
+}

--- a/cdk-sns-sqs-eventbridge-pipes-stepfunctions/test/sample-message.json
+++ b/cdk-sns-sqs-eventbridge-pipes-stepfunctions/test/sample-message.json
@@ -1,0 +1,6 @@
+{
+    "eventType": "SampleEvent",
+    "field1": "Sample Field 1",
+    "field2": "Sample Field 2",
+    "field3": "Sample Field 3"
+}

--- a/cdk-sns-sqs-eventbridge-pipes-stepfunctions/tsconfig.json
+++ b/cdk-sns-sqs-eventbridge-pipes-stepfunctions/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "commonjs",
+    "lib": [
+      "es2018"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": [
+      "./node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "cdk.out"
+  ]
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This code demonstrates how to connect an SNS Topic to EventBridge Pipes by way of SQS in the middle.  The Pipe filters the messages, transforms the data and forwards it to an EventBridge Bus that has a Rule which triggers a Step Function.  In existing environments where SNS is heavily used, it gives the developer the ability to bring in EventBridge without rewriting publishers but provides new opportunities for consumers


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
