### PR TITLE
set removal policy on log group

### DIFF
--- a/eventbridge-pipes-splitter-pattern/cdk/lib/cdk-stack.ts
+++ b/eventbridge-pipes-splitter-pattern/cdk/lib/cdk-stack.ts
@@ -19,7 +19,8 @@ export class EventBridgePipesSplitterPattern extends cdk.Stack {
     // log group to see Splitter output
     const ticketLogGroup = new LogGroup(this, 'tickets-log', {
       logGroupName: '/aws/events/tickets',
-      retention: RetentionDays.ONE_DAY
+      retention: RetentionDays.ONE_DAY,
+      removalPolicy: RemovalPolicy.DESTROY
     });
 
     const ticketOrdersBus = new EventBus(this, 'ticket-orders', {


### PR DESCRIPTION
Log Group should be deleted on `cdk destroy` - set removal policy to make it so


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
