### PR TITLE
Added "sam build" before "sam deploy -g"

### DIFF
--- a/s3-eventbridge-direct-java/README.md
+++ b/s3-eventbridge-direct-java/README.md
@@ -29,6 +29,7 @@ Important: this application uses various AWS services and there are costs associ
     ```
 1. From the command line, use AWS SAM to build and deploy the AWS resources for the pattern as specified in the template.yml file:
     ```
+    sam build
     sam deploy --guided
     ```
 1. During the prompts:


### PR DESCRIPTION
When I ran the project the first time just with "sam deploy -g" without "sam build", I had to see in cloudwatch that the build was not done because of the "ClassNotFoundException" error.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
