### PR TITLE
Gourangharhare New serverless pattern - Stream CloudWatch logs to Splunk near real-time

### DIFF
--- a/cloudwatch-logs-to-splunk-using-lambda-kinesis/README.md
+++ b/cloudwatch-logs-to-splunk-using-lambda-kinesis/README.md
@@ -1,0 +1,117 @@
+# Lambda, Kinesis Data Stream, Splunk cloud/Enterprise
+
+This pattern will setup serverless stack with AWS Lambda and Kinesis data stream (KDS) to process continuously streaming CloudWatch logs from different accounts and regions. Lambda receives stream records with CloudWatch log events which it decompress and decode to prepare events to be pushed to Splunk. A log destination ARN need to be configured across all account’s CloudWatch log groups. 
+
+Learn more about this pattern at Serverless Land Patterns: https://github.com/aws-samples/serverless-patterns/issues/1204
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS CDK Toolkit Installed]  https://docs.aws.amazon.com/cdk/v2/guide/cli.html
+* You have bootstrapped your account with CDK - https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping.html
+* Since this pattern will require logs to be ingested in Splunk cloud/enterprise platform. You need to have valid license for the same. For POC purpose you can opt for 14 days trial provided by Splunk with limited functionality. Once you hav valid splunk platform access follow the steps given in below article to create HTTP event collector (HEC) URL and associated token for authentication. Note: Do not opt for indexer acknowledgement while creating HEC.
+Set up and use HTTP Event Collector in Splunk Web https://docs.splunk.com/Documentation/Splunk/9.0.4/Data/UsetheHTTPEventCollector
+
+
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ```
+    cd cloudwatch-logs-to-splunk-using-lambda-kinesis
+    ```
+1. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
+    ```
+    cdk deploy
+    ```
+1. During the prompts:
+    * Process will show changes and take confirmation for deployment with something like "Do you wish to deploy these changes y/n?"
+
+
+    Once your cloudformation stack with name "KinesisDataStreamLogProcessorStack" is successfully deployed. Navigate to cloudformation console > go to stacks > check for status to confirm
+
+1. Manual steps required after stack deployment
+    The stack will create IAM role required for Log Destination but actual log destination currently not supported or working with CDK. Details on creation you can find in this article(https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CreateDestination.html). Note: Role would have already created by stack only log destination creation will be pending.
+    So you need to perform below small step throuw AWS CLI:
+    1. copy data stream ARN from cloudformation stack > Resources > Data stream with name like 'clw-log-processor-stream'
+        ARN will look like : arn:aws:kinesis:<<Region>>:<<AccountNumber>>:stream/<<data-stream-name>>
+    2. copy log destination IAM role ARN from cloudformation stack> resource with name like 'LogDestinationRole*'
+    3. Enter above ARN details in below command placeholders and run this command in AWS CLI (Refer this link for configuring up AWS CLI https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
+    ```
+    Run below command in AWS CLI
+    aws logs put-destination
+        –destination-name “<<LogDestination name you wish to give>>”
+        –target-arn “<<Enter kinesis data stream arn created by stack here which is created by stack as part of cdk deploy>>”
+        –role-arn “<<Enter log destination role ARN which is created by stack as part of cdk deploy>>”
+    ```
+    Output should look like below:
+
+    ```
+    {
+        “destination”: {
+        “destinationName”: “LogDestination”,
+        “targetArn”: “arn:aws:kinesis:<<Region>>:<<AccountNumber>>:stream/clw-log-processor-stream”,
+        “roleArn”: “arn:aws:iam::<<AccountNumber>>:role/LogDestinationRole”,
+        “arn”: “arn:aws:logs:<<Region>>:<<AccountNumber>>:destination:LogDestination”,
+        “creationTime”: 1680470148411
+        }
+    }
+    ```
+    4. Please note down ARN of log destination which you can use to configure subscription filter across cloudwatch log groups in same or cross account. 
+    5. You can also get log destination details using below command if you miss noting down. You can also use this step as verification.
+        ```
+        aws logs describe-destinations
+        ```
+    6. you need to configure Splunk HEC URL and Token in Lambda environment variable.
+
+    For more information refer below articles
+    Trouble shooting common CDK issues : https://docs.aws.amazon.com/cdk/v2/guide/troubleshooting.html#troubleshooting_app_required
+    About HTTP Event Collector Indexer Acknowledgment https://docs.splunk.com/Documentation/Splunk/9.0.4/Data/AboutHECIDXAck
+
+
+## How it works
+
+1. It will create kinesis data stream which will receive streaming logs from cloudwatch log groups. For this cloud watch log groups need to have subscription filter created to log destination.
+2. Kinesis data stream will be trigger or event source for Lambda function. So lambda will receive log streams ingested by various applications via cloudwatch log groups.
+3. Lambda will decompress log streams and decode Base64 strings. It will then send log events to splunk using web api URL provided by splunk platform. 
+4. Log streams will appear near real time in splunk dashboard (search & reporting)
+
+
+## Testing
+
+1. Create simple test lambda function which will perform some operations and write some logs.
+2. The lambda function logs will be visible initially in "/aws/lambda/<function-name>" log group.
+3. Go to cloudwatch console > log groups > click on particular log group > go to subscriptions > create subscription with 'Kinesis Stream' as destination. Use Log destination ARN which you have noted during creating subscription.
+4. You can create API gateway in front of test lambda function or call your function from another test function. Do not use test function capability on lambda console as it doesn't generate logs in required format and certain sections are not populated. This will not be the case if you use lambda behind api gateway or invoke it using other lambda or other invoking mechanism except on console testing.
+5. You can monitor function for success rate. Once your test function and actual log processor function has sucessful invocations. You can go to splunk platform and use 'search and reporting' module to search your logs. Try to log unique strings from your test function so you can find it in splunk almost near real time.
+
+Congratulations ! You have successfully tested end to end flow after this.
+
+## Cleanup
+ 
+1. Delete the stack
+    ```
+    cdk destroy
+    ```
+    OR
+    ```
+    bash
+    aws cloudformation delete-stack --stack-name STACK_NAME
+
+    ```
+1. Confirm the stack has been deleted
+    ```bash
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus"
+    ```
+----
+Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/cloudwatch-logs-to-splunk-using-lambda-kinesis/bin/kinesis-data-stream-log-processor.ts
+++ b/cloudwatch-logs-to-splunk-using-lambda-kinesis/bin/kinesis-data-stream-log-processor.ts
@@ -1,108 +1,115 @@
 #!/usr/bin/env node
+
+/*
+Date : 17-Mar-2023
+Author - Gourang Harhare
+Role - Sr. Solutions Architect @AWS India
+Description: This stack will deploy readymade architecture to receive cloudwatch and custom logs from different accounts and push to splunk cloud or splunk enterprise platform.
+
+*/
+
+
+
 import { Duration, Stack, StackProps, CfnParameter, App } from 'aws-cdk-lib';
 //import { KinesisDataStreamLogProcessorStack } from '../lib/kinesis-data-stream-log-processor-stack';
-import { Function, Runtime, AssetCode, Architecture,  StartingPosition } from 'aws-cdk-lib/aws-lambda';
-import {KinesisEventSource} from 'aws-cdk-lib/aws-lambda-event-sources';
+import { Function, Runtime, AssetCode, Architecture, StartingPosition } from 'aws-cdk-lib/aws-lambda';
+import { KinesisEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
 import * as logDestination from 'aws-cdk-lib/aws-logs-destinations';
 import * as kds from 'aws-cdk-lib/aws-kinesis';
-import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
 import { StreamMode } from 'aws-cdk-lib/aws-kinesis';
 import { Effect } from 'aws-cdk-lib/aws-iam';
 
 export class KinesisDataStreamLogProcessorStack extends Stack {
-    constructor(scope: Construct, id: string, props?: StackProps) {
-      super(scope, id, props);
-  
-  
-      const current_account = process.env.CDK_DEFAULT_ACCOUNT;
-      const current_region = process.env.CDK_DEFAULT_REGION;
-  
-/*       const var_splunk_hec_url = new CfnParameter(this, "SPLUNK_HEC_URL", {  type: "String", description: "Please provide URL of splunk host or splunk cloud endpoint"});
-  
-        const var_splunk_hec_token = new CfnParameter(this, "SPLUNK_HEC_TOKEN", {
-          type: "String",
-          description: "Please provide HEC token provided by Splunk for HTTP event collector"}); */
-  
-      //const s3Bucket = new s3.Bucket(this, "backupBucket",{bucketName:"clw-log-backup" });
-  
-      const lambda_role = new iam.Role(this, "Role",{assumedBy:new iam.ServicePrincipal("lambda.amazonaws.com"), description: "A role for lambda function to assume" });
-  
-      const datastream = new kds.Stream(this, "my-first-stream",{streamMode: StreamMode.ON_DEMAND, streamName: 'clw-log-processor-stream', retentionPeriod:Duration.hours(48)});
-  
-      datastream.grantReadWrite(lambda_role);
-  
-      //s3Bucket.grantReadWrite(lambda_role);
-     // s3Bucket.grantPut(lambda_role);
-
-      const iam_principal = new iam.ServicePrincipal("logs.amazonaws.com");
-
-      const policyWithConditions = new iam.PolicyStatement({
-        actions:['sts:AssumeRole'],
-        effect: Effect.ALLOW,
-        resources: ['*'],
-        conditions: {
-            'StringLike': {
-                'aws:SourceArn': [
-                    "arn:aws:logs:"+ current_region?.toString() +":"+ current_account?.toString() + ":*"
-                    ]
-                }
-            }
-        });
-
-        const log_dest_role = new iam.Role(this, "logDestinationRole",{roleName:"LogDestinationRole",assumedBy: iam_principal });
-
-        log_dest_role.addToPrincipalPolicy(policyWithConditions);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
 
+    const current_account = process.env.CDK_DEFAULT_ACCOUNT;
+    const current_region = process.env.CDK_DEFAULT_REGION;
 
-        const policyWithConditions2 = new iam.PolicyStatement({
-            actions:['kinesis:PutRecord','kinesis:PutRecords'],
-            effect: Effect.ALLOW,
-            resources: [datastream.streamArn]
-            });
-  
-         log_dest_role.addToPolicy(policyWithConditions2);
+    //Creates new lambda execution role to assume by log processor function
+    const lambda_role = new iam.Role(this, "Role", { assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"), description: "A role for lambda function to assume" });
 
-      
-  
-      const logDest = new logDestination.KinesisDestination(datastream,{role: log_dest_role});
+    //Creates new Kinesis data stream(KDS) with stream mode as on-demand and 2 days of retention period
+    const datastream = new kds.Stream(this, "my-first-stream", { streamMode: StreamMode.ON_DEMAND, streamName: 'clw-log-processor-stream', retentionPeriod: Duration.hours(48) });
 
-      console.log (logDest);
-  
-      const evtSrc = new KinesisEventSource(datastream,{retryAttempts:3, startingPosition: StartingPosition.LATEST});
-  
-  
-      const fnLogProcessor = new Function(this, "LogProcessorFunction", { 
-        functionName: "fnLogProcessor", 
-        handler: "index.handler", 
-        runtime: Runtime.NODEJS_14_X, 
-        code: new AssetCode(`./src`), 
-        memorySize: 512, 
-        timeout: Duration.seconds(300), 
-        environment: { 
-            BUCKET: "",//s3Bucket.bucketName, 
-            SPLUNK_HEC_URL: "", //var_splunk_hec_url.valueAsString,
-            SPLUNK_HEC_TOKEN: "" //var_splunk_hec_token.valueAsString
-        },
-        role: lambda_role, 
-        architecture: Architecture.X86_64
+    //this will grant read-write access on KDS to lambda function. this will be useful for setting KDS as trigger for the lambda function
+    datastream.grantReadWrite(lambda_role);
+
+    //create IAM principal record to be added to Log destination role to allow service
+    const iam_principal = new iam.ServicePrincipal("logs.amazonaws.com");
+
+    //create inline policy statement to allow any source arn in current account to be able to push logs to log destination
+    const policyWithConditions = new iam.PolicyStatement({
+      actions: ['sts:AssumeRole'],
+      effect: Effect.ALLOW,
+      resources: ['*'],
+      conditions: {
+        'StringLike': {
+          'aws:SourceArn': [
+            "arn:aws:logs:" + current_region?.toString() + ":" + current_account?.toString() + ":*"
+          ]
+        }
+      }
     });
-  
-      fnLogProcessor.addEventSource(evtSrc);
-  
-  
-  
-  
-      
-      
-  
-  
-  
-    }
-  }
 
-  const app = new App();
-  new KinesisDataStreamLogProcessorStack(app, 'KinesisDataStreamLogProcessorStack');
-  
+    //finally create role to be associated with log destination (manual step)
+    const log_dest_role = new iam.Role(this, "logDestinationRole", { roleName: "LogDestinationRole", assumedBy: iam_principal });
+
+    //add created inline policy to above created iam role
+    log_dest_role.addToPrincipalPolicy(policyWithConditions);
+
+
+    // additional policy statement for allowing log destination to put records in stream
+    const policyWithConditions2 = new iam.PolicyStatement({
+      actions: ['kinesis:PutRecord', 'kinesis:PutRecords'],
+      effect: Effect.ALLOW,
+      resources: [datastream.streamArn]
+    });
+    // associate policy statement with role created in above steps
+    log_dest_role.addToPolicy(policyWithConditions2);
+
+
+    //create log destination (this doesn't work through CDK and in readme manual step is given)
+    const logDest = new logDestination.KinesisDestination(datastream, { role: log_dest_role });
+
+ 
+    //create event source object to associate KDS as trigger for lambda function in next steps
+    const evtSrc = new KinesisEventSource(datastream, { retryAttempts: 3, startingPosition: StartingPosition.LATEST });
+
+    // creates fnLogProcessor function which received log events which is then process and send it to splunk cloud
+    const fnLogProcessor = new Function(this, "LogProcessorFunction", {
+      functionName: "fnLogProcessor",
+      handler: "index.handler",
+      runtime: Runtime.NODEJS_14_X,
+      code: new AssetCode(`./src`),
+      memorySize: 512,
+      timeout: Duration.seconds(300),
+      environment: {
+        BUCKET: "",//s3Bucket.bucketName, 
+        SPLUNK_HEC_URL: "", //var_splunk_hec_url.valueAsString,
+        SPLUNK_HEC_TOKEN: "" //var_splunk_hec_token.valueAsString
+      },
+      role: lambda_role,
+      architecture: Architecture.X86_64
+    });
+
+    //associates event source with lambda function
+    fnLogProcessor.addEventSource(evtSrc);
+
+
+
+
+
+
+
+
+
+  }
+}
+
+//initialize cdk app which will in turn deploy cfn template and above stack.
+const app = new App();
+new KinesisDataStreamLogProcessorStack(app, 'KinesisDataStreamLogProcessorStack');

--- a/cloudwatch-logs-to-splunk-using-lambda-kinesis/bin/kinesis-data-stream-log-processor.ts
+++ b/cloudwatch-logs-to-splunk-using-lambda-kinesis/bin/kinesis-data-stream-log-processor.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+import { Duration, Stack, StackProps, CfnParameter, App } from 'aws-cdk-lib';
+//import { KinesisDataStreamLogProcessorStack } from '../lib/kinesis-data-stream-log-processor-stack';
+import { Function, Runtime, AssetCode, Architecture,  StartingPosition } from 'aws-cdk-lib/aws-lambda';
+import {KinesisEventSource} from 'aws-cdk-lib/aws-lambda-event-sources';
+import * as logDestination from 'aws-cdk-lib/aws-logs-destinations';
+import * as kds from 'aws-cdk-lib/aws-kinesis';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { Construct } from 'constructs';
+import { StreamMode } from 'aws-cdk-lib/aws-kinesis';
+import { Effect } from 'aws-cdk-lib/aws-iam';
+
+export class KinesisDataStreamLogProcessorStack extends Stack {
+    constructor(scope: Construct, id: string, props?: StackProps) {
+      super(scope, id, props);
+  
+  
+      const current_account = process.env.CDK_DEFAULT_ACCOUNT;
+      const current_region = process.env.CDK_DEFAULT_REGION;
+  
+/*       const var_splunk_hec_url = new CfnParameter(this, "SPLUNK_HEC_URL", {  type: "String", description: "Please provide URL of splunk host or splunk cloud endpoint"});
+  
+        const var_splunk_hec_token = new CfnParameter(this, "SPLUNK_HEC_TOKEN", {
+          type: "String",
+          description: "Please provide HEC token provided by Splunk for HTTP event collector"}); */
+  
+      //const s3Bucket = new s3.Bucket(this, "backupBucket",{bucketName:"clw-log-backup" });
+  
+      const lambda_role = new iam.Role(this, "Role",{assumedBy:new iam.ServicePrincipal("lambda.amazonaws.com"), description: "A role for lambda function to assume" });
+  
+      const datastream = new kds.Stream(this, "my-first-stream",{streamMode: StreamMode.ON_DEMAND, streamName: 'clw-log-processor-stream', retentionPeriod:Duration.hours(48)});
+  
+      datastream.grantReadWrite(lambda_role);
+  
+      //s3Bucket.grantReadWrite(lambda_role);
+     // s3Bucket.grantPut(lambda_role);
+
+      const iam_principal = new iam.ServicePrincipal("logs.amazonaws.com");
+
+      const policyWithConditions = new iam.PolicyStatement({
+        actions:['sts:AssumeRole'],
+        effect: Effect.ALLOW,
+        resources: ['*'],
+        conditions: {
+            'StringLike': {
+                'aws:SourceArn': [
+                    "arn:aws:logs:"+ current_region?.toString() +":"+ current_account?.toString() + ":*"
+                    ]
+                }
+            }
+        });
+
+        const log_dest_role = new iam.Role(this, "logDestinationRole",{roleName:"LogDestinationRole",assumedBy: iam_principal });
+
+        log_dest_role.addToPrincipalPolicy(policyWithConditions);
+
+
+
+        const policyWithConditions2 = new iam.PolicyStatement({
+            actions:['kinesis:PutRecord','kinesis:PutRecords'],
+            effect: Effect.ALLOW,
+            resources: [datastream.streamArn]
+            });
+  
+         log_dest_role.addToPolicy(policyWithConditions2);
+
+      
+  
+      const logDest = new logDestination.KinesisDestination(datastream,{role: log_dest_role});
+
+      console.log (logDest);
+  
+      const evtSrc = new KinesisEventSource(datastream,{retryAttempts:3, startingPosition: StartingPosition.LATEST});
+  
+  
+      const fnLogProcessor = new Function(this, "LogProcessorFunction", { 
+        functionName: "fnLogProcessor", 
+        handler: "index.handler", 
+        runtime: Runtime.NODEJS_14_X, 
+        code: new AssetCode(`./src`), 
+        memorySize: 512, 
+        timeout: Duration.seconds(300), 
+        environment: { 
+            BUCKET: "",//s3Bucket.bucketName, 
+            SPLUNK_HEC_URL: "", //var_splunk_hec_url.valueAsString,
+            SPLUNK_HEC_TOKEN: "" //var_splunk_hec_token.valueAsString
+        },
+        role: lambda_role, 
+        architecture: Architecture.X86_64
+    });
+  
+      fnLogProcessor.addEventSource(evtSrc);
+  
+  
+  
+  
+      
+      
+  
+  
+  
+    }
+  }
+
+  const app = new App();
+  new KinesisDataStreamLogProcessorStack(app, 'KinesisDataStreamLogProcessorStack');
+  

--- a/cloudwatch-logs-to-splunk-using-lambda-kinesis/cdk.json
+++ b/cloudwatch-logs-to-splunk-using-lambda-kinesis/cdk.json
@@ -1,0 +1,37 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/kinesis-data-stream-log-processor.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
+    "@aws-cdk/core:stackRelativeExports": true,
+    "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
+    "@aws-cdk/aws-lambda:recognizeVersionProps": true,
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
+  }
+}

--- a/cloudwatch-logs-to-splunk-using-lambda-kinesis/example-pattern.json
+++ b/cloudwatch-logs-to-splunk-using-lambda-kinesis/example-pattern.json
@@ -1,0 +1,66 @@
+{
+  "title": "Stream CloudWatch logs to Splunk near real-time",
+  "description": "This pattern will setup serverless stack with AWS Lambda and Kinesis data stream (KDS) to process continuously streaming CloudWatch logs from different accounts and regions. Lambda receives stream records with CloudWatch log events which it decompress and decode to prepare events to be pushed to Splunk. A log destination ARN need to be configured across all account’s CloudWatch log groups.",
+  "language": "Python",
+  "level": "200",
+  "framework": "CDK",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "This pattern will setup serverless stack with AWS Lambda and Kinesis data stream (KDS) to process continuously streaming CloudWatch logs from different accounts and regions.",
+      "Lambda receives stream records with CloudWatch log events which it decompress and decode to prepare events to be pushed to Splunk.",
+      "A log destination ARN need to be configured across all accounts CloudWatch log groups as subscription filter for cloutwatch to start streaming logs"
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/cloudwatch-logs-to-splunk-using-lambda-kinesis",
+      "templateURL": "serverless-patterns/cloudwatch-logs-to-splunk-using-lambda-kinesis",
+      "projectFolder": "cloudwatch-logs-to-splunk-using-lambda-kinesis",
+      "templateFile": "cloudwatch-logs-to-splunk-using-lambda-kinesis/bin/kinesis-data-stream-log-processor.ts"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "Trouble shooting common CDK issues",
+        "link": "https://docs.aws.amazon.com/cdk/v2/guide/troubleshooting.html#troubleshooting_app_required"
+      },
+      {
+        "text": "Splunk - About HTTP Event Collector Indexer Acknowledgment. Use this link to configure http event collector at splunk side",
+        "link": "https://docs.splunk.com/Documentation/Splunk/9.0.4/Data/AboutHECIDXAck"
+      },
+      {
+        "text": " How to create LogDestination using command line",
+        "link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CreateDestination.html"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "git clone https://github.com/aws-samples/serverless-patterns",
+      "cd cloudwatch-logs-to-splunk-using-lambda-kinesis",
+      "cdk deploy",
+      "Note: Please refer manual steps/instructions after cdk has successfully deployed in Readme.md file"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the Github repo for detailed testing instructions in Readme.md file."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>cdk delete</code>."
+    ]
+  },
+  "authors": [
+    {
+      "name": "Gourang Harhare",
+      "image": "None",
+      "bio": "https://www.linkedin.com/in/gourang-harhare-022964a/",
+      "linkedin": "https://www.linkedin.com/in/gourang-harhare-022964a/",
+      "twitter": "None"
+    }
+  ]
+}

--- a/cloudwatch-logs-to-splunk-using-lambda-kinesis/package.json
+++ b/cloudwatch-logs-to-splunk-using-lambda-kinesis/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "kinesis-data-stream-log-processor",
+  "version": "0.1.0",
+  "bin": {
+    "kinesis-data-stream-log-processor": "bin/kinesis-data-stream-log-processor.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "test": "jest",
+    "cdk": "cdk"
+  },
+  "devDependencies": {
+    "aws-cdk": "2.30.0",
+    "@types/jest": "^27.5.2",
+    "@types/node": "10.17.27",
+    "@types/prettier": "2.6.0",
+    "jest": "^27.5.1",
+    "ts-jest": "^27.1.4",
+    "ts-node": "^10.8.1",
+    "typescript": "~3.9.7"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "2.30.0",
+    "constructs": "^10.0.0"
+  }
+}

--- a/cloudwatch-logs-to-splunk-using-lambda-kinesis/src/index.js
+++ b/cloudwatch-logs-to-splunk-using-lambda-kinesis/src/index.js
@@ -1,0 +1,81 @@
+/**
+ * Stream events from AWS CloudWatch Logs to Splunk
+ *
+ * This function streams AWS CloudWatch Logs to Splunk using
+ * Splunk's HTTP event collector API.
+ *
+ * Define the following Environment Variables in the console below to configure
+ * this function to stream logs to your Splunk host:
+ *
+ * 1. SPLUNK_HEC_URL: URL address for your Splunk HTTP event collector endpoint.
+ * Default port for event collector is 8088. Example: https://host.com:8088/services/collector
+ *
+ * 2. SPLUNK_HEC_TOKEN: Token for your Splunk HTTP event collector.
+ * To create a new token for this Lambda function, refer to Splunk Docs:
+ * http://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector#Create_an_Event_Collector_token
+ */
+const loggerConfig = {
+    url: process.env.SPLUNK_HEC_URL,
+    token: process.env.SPLUNK_HEC_TOKEN,
+};
+
+const SplunkLogger = require('./lib/mysplunklogger');
+const zlib = require('zlib');
+
+const logger = new SplunkLogger(loggerConfig);
+
+exports.handler = (event, context, callback) => {
+    console.log('Received event:', JSON.stringify(event, null, 2));
+    
+    const records = event.Records;
+    records.forEach((rec, idx) => {
+   
+        // CloudWatch Logs data is base64 encoded so decode here
+        //const payload = Buffer.from(event.awslogs.data, 'base64');
+
+        //console.log("receied data:" + rec.kinesis.data);
+        const payload = Buffer.from(rec.kinesis.data, 'base64');
+        //console.log("receied payload:" + payload);
+        // CloudWatch Logs are gzip compressed so expand here
+        zlib.gunzip(payload, (err, result) => {
+            if (err) {
+                callback(err);
+            } else {
+                const parsed = JSON.parse(result.toString('ascii'));
+                //console.log('Decoded payload:', JSON.stringify(parsed, null, 2));
+                let count = 0;
+                if (parsed.logEvents) {
+                    parsed.logEvents.forEach((item) => {
+                        /* Log event to Splunk with explicit event timestamp.
+                        - Use optional 'context' argument to send Lambda metadata e.g. awsRequestId, functionName.
+                        - Change "item.timestamp" below if time is specified in another field in the event.
+                        - Change to "logger.log(item.message, context)" if no time field is present in event. */
+                        logger.logWithTime(item.timestamp, item.message, context);
+                        /* Alternatively, UNCOMMENT logger call below if you want to override Splunk input settings */
+                        /* Log event to Splunk with any combination of explicit timestamp, index, source, sourcetype, and host.
+                        - Complete list of input settings available at http://docs.splunk.com/Documentation/Splunk/latest/RESTREF/RESTinput#services.2Fcollector */
+                        // logger.logEvent({
+                        //     time: new Date(item.timestamp).getTime() / 1000,
+                        //     host: 'serverless',
+                        //     source: `lambda:${context.functionName}`,
+                        //     sourcetype: 'httpevent',
+                        //     index: 'main',
+                        //     event: item.message,
+                        // });
+                        count += 1;
+                    });
+                }
+                // Send all the events in a single batch to Splunk
+                logger.flushAsync((error, response) => {
+                    if (error) {
+                        callback(error);
+                    } else {
+                        console.log(`Response from Splunk:\n${response}`);
+                        console.log(`Successfully processed ${count} log event(s).`);
+                        callback(null, count); // Return number of log events
+                    }
+                });
+            }
+        });
+    });
+};

--- a/cloudwatch-logs-to-splunk-using-lambda-kinesis/src/lib/mysplunklogger.js
+++ b/cloudwatch-logs-to-splunk-using-lambda-kinesis/src/lib/mysplunklogger.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const url = require('url');
+
+const Logger = function Logger(config) {
+    this.url = config.url;
+    this.token = config.token;
+
+    this.addMetadata = true;
+    this.setSource = true;
+
+    this.parsedUrl = url.parse(this.url);
+    // eslint-disable-next-line import/no-dynamic-require
+    this.requester = require(this.parsedUrl.protocol.substring(0, this.parsedUrl.protocol.length - 1));
+    // Initialize request options which can be overridden & extended by consumer as needed
+    this.requestOptions = {
+        hostname: this.parsedUrl.hostname,
+        path: this.parsedUrl.path,
+        port: this.parsedUrl.port,
+        method: 'POST',
+        headers: {
+            Authorization: `Splunk ${this.token}`,
+        },
+        rejectUnauthorized: false,
+    };
+
+    this.payloads = [];
+};
+
+// Simple logging API for Lambda functions
+Logger.prototype.log = function log(message, context) {
+    this.logWithTime(Date.now(), message, context);
+};
+
+Logger.prototype.logWithTime = function logWithTime(time, message, context) {
+    const payload = {};
+
+    if (Object.prototype.toString.call(message) === '[object Array]') {
+        throw new Error('message argument must be a string or a JSON object.');
+    }
+    payload.event = message;
+
+    // Add Lambda metadata
+    if (typeof context !== 'undefined') {
+        if (this.addMetadata) {
+            // Enrich event only if it is an object
+            if (message === Object(message)) {
+                payload.event = JSON.parse(JSON.stringify(message)); // deep copy
+                payload.event.awsRequestId = context.awsRequestId;
+            }
+        }
+        if (this.setSource) {
+            payload.source = `lambda:${context.functionName}`;
+        }
+    }
+
+    payload.time = new Date(time).getTime() / 1000;
+
+    this.logEvent(payload);
+};
+
+Logger.prototype.logEvent = function logEvent(payload) {
+    this.payloads.push(JSON.stringify(payload));
+};
+
+Logger.prototype.flushAsync = function flushAsync(callback) {
+    callback = callback || (() => {}); // eslint-disable-line no-param-reassign
+
+    console.log('Sending event(s)');
+    const req = this.requester.request(this.requestOptions, (res) => {
+        res.setEncoding('utf8');
+
+        console.log('Response received');
+        res.on('data', (data) => {
+            let error = null;
+            if (res.statusCode !== 200) {
+                error = new Error(`error: statusCode=${res.statusCode}\n\n${data}`);
+                console.error(error);
+            }
+            this.payloads.length = 0;
+            callback(error, data);
+        });
+    });
+
+    req.on('error', (error) => {
+        callback(error);
+    });
+
+    req.end(this.payloads.join(''), 'utf8');
+};
+
+module.exports = Logger;

--- a/cloudwatch-logs-to-splunk-using-lambda-kinesis/tsconfig.json
+++ b/cloudwatch-logs-to-splunk-using-lambda-kinesis/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "commonjs",
+    "lib": [
+      "es2018"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": [
+      "./node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "cdk.out"
+  ]
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Submitting a server-less pattern. This pattern will setup serverless stack with AWS Lambda and Kinesis data stream (KDS) to process continuously streaming CloudWatch logs from different accounts and regions. Lambda receives stream records with CloudWatch log events which it decompress and decode to prepare events to be pushed to Splunk. A log destination ARN need to be configured across all account’s CloudWatch log groups. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
