### PR TITLE
Fix: Remove hash symbol from InvokeMode value in AWS SAM template

### DIFF
--- a/lambda-streaming-large-sam/template.yaml
+++ b/lambda-streaming-large-sam/template.yaml
@@ -18,7 +18,7 @@ Resources:
     Properties:
       TargetFunctionArn: !Ref LargePayloadFunction
       AuthType: AWS_IAM
-      InvokeMode: RESPONSE_STREAM#
+      InvokeMode: RESPONSE_STREAM
 Outputs:
   StreamingFunction:
     Description: "Large Payload Lambda Function ARN"


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Remove hash symbol from InvokeMode value in AWS SAM template `lambda-streaming-large-sam`
- Correct the InvokeMode property value by removing the hash symbol (#) from "RESPONSE_STREAM#"
- This fix ensures the proper configuration of Lambda response streaming

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.