### PR TITLE
New serverless pattern - EventBridge Scheduler to SNS with CDK Java Framework

### DIFF
--- a/eventbridge-schedule-to-sns-publish-cdk-java/README.md
+++ b/eventbridge-schedule-to-sns-publish-cdk-java/README.md
@@ -1,0 +1,55 @@
+# EventBridge Scheduler to Amazon SNS
+
+This pattern will create an [EventBridge Scheduler](https://docs.aws.amazon.com/scheduler/latest/UserGuide/getting-started.html) to publish a message to an Amazon [SNS](https://docs.aws.amazon.com/sns/latest/dg/welcome.html) topic every 5 minutes. The pattern is deployed using the AWS Cloud Development Kit (AWS CDK) for Java. 
+
+Learn more about this pattern at Serverless Land Patterns: [https://serverlessland.com/patterns/eventbridge-schedule-to-sns-publish-cdk-java](https://serverlessland.com/patterns/eventbridge-schedule-to-sns-publish-cdk-java)
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one
+  and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS
+  resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS CDK Toolkit](https://docs.aws.amazon.com/cdk/latest/guide/cli.html) installed and configured
+* [Java 11+](https://docs.aws.amazon.com/corretto/latest/corretto-11-ug/downloads-list.html) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+2. Change directory to the pattern directory:
+    ```
+    cd eventbridge-schedule-to-sns-publish-cdk-java
+    ```
+3. From the command line, bootstrap the CDK if you haven't already done so. 
+    ```
+    cdk bootstrap 
+    ```
+4. Deploy the CDK stack to your default AWS account and region. Replace email address after "email=" if you wish to test the notification with your email address.
+    ```
+    cdk deploy -c email=sample@example.com
+    ```
+
+## How it works
+
+An EventBridge Schedule is created that publishes a message to an Amazon SNS topic every 5 minutes. Along with a schedule, the CDK stack creates a SNS topic and an IAM role and policy for EventBridge scheduler to assume and send messages.  During CDK deployment, the email address provided in the parameters will receive a subscription confirmation email. Confirm the subscription by clicking the link in the email if you would like to receive the testing notification.  Check the junk email if you do not receive subsciption confirmation email. 
+
+## Testing
+
+The provided email address should receive notification email every 5 minutes after confirming the subscription.
+
+## Cleanup
+ 
+1. Delete the stack
+    ```bash
+    cdk destroy
+    ```
+----
+Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/eventbridge-schedule-to-sns-publish-cdk-java/cdk.json
+++ b/eventbridge-schedule-to-sns-publish-cdk-java/cdk.json
@@ -1,0 +1,46 @@
+{
+  "app": "mvn -e -q compile exec:java",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "target",
+      "pom.xml",
+      "src/test"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ],
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+    "@aws-cdk/core:enablePartitionLiterals": true,
+    "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
+    "@aws-cdk/aws-iam:standardizedServicePrincipals": true,
+    "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
+    "@aws-cdk/aws-iam:importedRoleStackSafeDefaultPolicyName": true,
+    "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
+    "@aws-cdk/aws-route53-patters:useCertificate": true,
+    "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
+    "@aws-cdk/aws-rds:databaseProxyUniqueResourceName": true,
+    "@aws-cdk/aws-codedeploy:removeAlarmsFromDeploymentGroup": true,
+    "@aws-cdk/aws-apigateway:authorizerChangeDeploymentLogicalId": true,
+    "@aws-cdk/aws-ec2:launchTemplateDefaultUserData": true,
+    "@aws-cdk/aws-secretsmanager:useAttachedSecretResourcePolicyForSecretTargetAttachments": true,
+    "@aws-cdk/aws-redshift:columnId": true
+  }
+}

--- a/eventbridge-schedule-to-sns-publish-cdk-java/eventbridge-schedule-to-sns-publish-cdk-java.json
+++ b/eventbridge-schedule-to-sns-publish-cdk-java/eventbridge-schedule-to-sns-publish-cdk-java.json
@@ -1,0 +1,63 @@
+{
+  "title": "EventBridge Scheduler to publish messages to Amazon SNS",
+  "description": "Simple pattern that publishes a message to a SNS topic every 5 minutes. Email address subscribed to the SNS topic will receive notifcication every 5 minutes.",
+  "language": "Java",
+  "level": "200",
+  "framework": "CDK",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "This sample pattern demonstrates how to use EventBridge Scheduler to publish message to a Amazon SNS topic every 5 minutes and deployed using the AWS CDK for Java."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-schedule-to-sns-publish-cdk-java",
+      "templateURL": "serverless-patterns/eventbridge-schedule-to-sns-publish-cdk-java",
+      "projectFolder": "eventbridge-schedule-to-sns-publish-cdk-java",
+      "templateFile": "eventbridge-schedule-to-sns-publish-cdk-java/src/main/java/com/myorg/EventbridgeScheduleToSnsCdkJavaStack.java"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "Working with the AWS CDK in Java",
+        "link": "https://docs.aws.amazon.com/cdk/v2/guide/work-with-cdk-java.html"
+      },
+      {
+        "text": "AWS CLI start-execution",
+        "link": "https://docs.aws.amazon.com/cli/latest/reference/stepfunctions/start-execution.html#start-execution"
+      },
+      {
+        "text": "Getting Started with EventBridge Scheduler",
+        "link": "https://docs.aws.amazon.com/scheduler/latest/UserGuide/getting-started.html"
+      },
+      {
+        "text": "Getting started with Amazon SNS",
+        "link": "https://docs.aws.amazon.com/sns/latest/dg/sns-getting-started.html"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "<code>cdk deploy -c email=sample@example.com</code>"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the Github repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>cdk delete</code>."
+    ]
+  },
+  "authors": [
+    {
+      "name": "Hoi Wing Chan",
+      "bio": "Hoi Wing is a Technical Account Manager at Amazon Web Services with a background of software development and architecture.",
+      "linkedin": "https://www.linkedin.com/in/wing-chan-0943a344"
+    }
+  ]
+}

--- a/eventbridge-schedule-to-sns-publish-cdk-java/example-pattern.json
+++ b/eventbridge-schedule-to-sns-publish-cdk-java/example-pattern.json
@@ -1,0 +1,63 @@
+{
+  "title": "EventBridge Scheduler to publish messages to Amazon SNS",
+  "description": "Simple pattern that publishes a message to a SNS topic every 5 minutes. Email address subscribed to the SNS topic will receive notifcication every 5 minutes.",
+  "language": "Java",
+  "level": "200",
+  "framework": "CDK",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "This sample pattern demonstrates how to use EventBridge Scheduler to publish message to a Amazon SNS topic every 5 minutes and deployed using the AWS CDK for Java."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-schedule-to-sns-publish-cdk-java",
+      "templateURL": "serverless-patterns/eventbridge-schedule-to-sns-publish-cdk-java",
+      "projectFolder": "eventbridge-schedule-to-sns-publish-cdk-java",
+      "templateFile": "eventbridge-schedule-to-sns-publish-cdk-java/src/main/java/com/myorg/EventbridgeScheduleToSnsCdkJavaStack.java"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "Working with the AWS CDK in Java",
+        "link": "https://docs.aws.amazon.com/cdk/v2/guide/work-with-cdk-java.html"
+      },
+      {
+        "text": "AWS CLI start-execution",
+        "link": "https://docs.aws.amazon.com/cli/latest/reference/stepfunctions/start-execution.html#start-execution"
+      },
+      {
+        "text": "Getting Started with EventBridge Scheduler",
+        "link": "https://docs.aws.amazon.com/scheduler/latest/UserGuide/getting-started.html"
+      },
+      {
+        "text": "Getting started with Amazon SNS",
+        "link": "https://docs.aws.amazon.com/sns/latest/dg/sns-getting-started.html"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "<code>cdk deploy -c email=sample@example.com</code>"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the Github repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>cdk delete</code>."
+    ]
+  },
+  "authors": [
+    {
+      "name": "Hoi Wing Chan",
+      "bio": "Hoi Wing is a Technical Account Manager at Amazon Web Services with a background of software development and architecture.",
+      "linkedin": "https://www.linkedin.com/in/wing-chan-0943a344"
+    }
+  ]
+}

--- a/eventbridge-schedule-to-sns-publish-cdk-java/pom.xml
+++ b/eventbridge-schedule-to-sns-publish-cdk-java/pom.xml
@@ -1,0 +1,59 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>cdk-sample</groupId>
+    <artifactId>eventbridge-scheduler-to-sns</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+    <name>EventbridgeScheduleToSnsCdkJavaStack</name>
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <cdk.version>2.70.0</cdk.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <junit.version>5.7.1</junit.version>
+        <constructs.version>[10.0.0,11.0.0)</constructs.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>software.amazon.awscdk</groupId>
+            <artifactId>aws-cdk-lib</artifactId>
+            <version>${cdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.constructs</groupId>
+            <artifactId>constructs</artifactId>
+            <version>${constructs.version}</version>
+        </dependency>
+
+        <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter</artifactId>
+          <version>${junit.version}</version>
+          <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <mainClass>com.myorg.EventbridgeScheduleToSnsCdkJavaApp</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/eventbridge-schedule-to-sns-publish-cdk-java/src/main/java/com/myorg/EventbridgeScheduleToSnsCdkJavaApp.java
+++ b/eventbridge-schedule-to-sns-publish-cdk-java/src/main/java/com/myorg/EventbridgeScheduleToSnsCdkJavaApp.java
@@ -1,0 +1,13 @@
+package com.myorg;
+
+import software.amazon.awscdk.App;
+
+public final class EventbridgeScheduleToSnsCdkJavaApp {
+    public static void main(final String[] args) {
+        App app = new App();
+
+        new EventbridgeScheduleToSnsCdkJavaStack(app, "EventbridgeScheduleToSnsCdkJavaStack");
+
+        app.synth();
+    }
+}

--- a/eventbridge-schedule-to-sns-publish-cdk-java/src/main/java/com/myorg/EventbridgeScheduleToSnsCdkJavaStack.java
+++ b/eventbridge-schedule-to-sns-publish-cdk-java/src/main/java/com/myorg/EventbridgeScheduleToSnsCdkJavaStack.java
@@ -1,0 +1,65 @@
+package com.myorg;
+
+import software.amazon.awscdk.*;
+import software.amazon.awscdk.services.iam.*;
+import software.amazon.awscdk.services.sns.*;
+import software.amazon.awscdk.services.sns.subscriptions.EmailSubscription;
+import software.amazon.awscdk.services.scheduler.*;
+import software.constructs.Construct;
+
+import java.util.List;
+
+public class EventbridgeScheduleToSnsCdkJavaStack extends Stack {
+    public EventbridgeScheduleToSnsCdkJavaStack(final Construct scope, final String id) {
+        this(scope, id, null);
+    }
+
+    public EventbridgeScheduleToSnsCdkJavaStack(final Construct scope, final String id, final StackProps props) {
+        super(scope, id, props);
+
+        // get email address from parameters or use a fake email address
+        String email = (String)this.getNode().tryGetContext("email");
+        if (email == null || email.isEmpty())
+            email = "sample@example.com";
+
+        // create topic
+        Topic topic = Topic.Builder.create(this, "Scheduler Topic")
+         .displayName("Scheduler topic")
+         .build();
+
+        // subscribe to the created topic, the provided email address should receive subscription confirmation email
+        topic.addSubscription(new EmailSubscription(email));
+        
+        // create scheduler role
+        Role scheduler_role = Role.Builder.create(this, "scheduler-role")
+         .assumedBy(new ServicePrincipal("scheduler.amazonaws.com"))
+         .description("Scheduler role for Scheduler Topic")
+         .build();
+
+        // create IAM policy for scheduler
+        PolicyStatement scheduler_events_policy = PolicyStatement.Builder.create() 
+         .actions(List.of("sns:Publish"))
+         .resources(List.of(topic.getTopicArn()))
+         .effect(Effect.ALLOW)
+         .build();
+
+        // Add IAM policy to scheduler role
+        scheduler_role.addToPolicy(scheduler_events_policy);
+
+        // Create schedule to publish a message to SNS topic every 5 minutes, 
+        // the provided email should start receiving notification every 5 minutes if the above subscription is confirmed.
+        CfnSchedule scheduler = CfnSchedule.Builder.create(this, "demo-schedule")
+          .flexibleTimeWindow(CfnSchedule.FlexibleTimeWindowProperty.builder().mode("OFF").build())
+          .scheduleExpression("rate(5 minute)")
+          .target(CfnSchedule.TargetProperty.builder()
+                    .arn(topic.getTopicArn())
+                    .roleArn(scheduler_role.getRoleArn())
+                    .input("This message was sent using EventBridge Scheduler!").build())
+          .build();
+
+        // Output
+        CfnOutput.Builder.create(this,"Scheduler_ARN").value(scheduler.getAttrArn()).build();
+        CfnOutput.Builder.create(this,"SNS_Topic_ARN").value(topic.getTopicArn()).build();
+        
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
New EventBridge Scheduler pattern: Create EventBridge Scheduler to publish message to SNS topic every 5 minutes with CDK Java Framework.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
