### PR TITLE
New pattern eventbridge-schedule-to-ssm-sam

### DIFF
--- a/eventbridge-schedule-to-ssm-sam/README.md
+++ b/eventbridge-schedule-to-ssm-sam/README.md
@@ -1,0 +1,94 @@
+# AWS EventBridge to AWS Systems Manager - State Manager Associations
+
+This SAM template deploys a custom scheduled EventBridge task that triggers a SSM association that runs a custom 'Hello World!' SSM document. The EventBridge rule uses a cron schedule to run the SSM association every 15 minutes. The EC2 instances are deployed as targets for the SSM association using tag based rules. 
+
+Learn more about this pattern at Serverless Land Patterns: https://docs.aws.amazon.com/scheduler/latest/UserGuide/what-is-scheduler.html
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ```
+    cd EventBridge-schedule-to-ssm-sam
+    ```
+1. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
+    ```
+    sam deploy --guided
+    ```
+1. During the prompts:
+    * Enter a stack name
+    * Enter the desired AWS Region
+    * Allow SAM CLI to create IAM roles with the required permissions.
+
+    Once you have run `sam deploy --guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+
+1. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## How it works
+
+This SAM template deploys the resources and the IAM permissions required to run the application, including: an EventBridge Scheduler Task, SSM Document, SSM Association, two EC2 instances (Windows and Linux), and a S3 bucket to store the SSM association output. IAM execution roles are also created for EC2, SSM and EventBridge Scheduler.
+
+The EventBridge Scheduler uses a cron expression to define how often the SSM association is executed. When run, the SSM association will run the custom 'Hello World!' SSM document, which executes simple echo commands on the Windows and Linux EC2 instances created by the SAM template. The SSM State Manager Association uses tag based rules to target the EC2 instance. Output of each Association execution is captured in the S3 bucket this template creates. The Cloud Formation output provides the names of the created resources.
+
+When building the EventBridge Scheduler Task, we are using a universal target since SSM Associations do not have a pre-defined template. With universal targets you can target hundreds of AWS services APIs, a full list can be found within the [EventBridge Scheduler User Guide](https://docs.aws.amazon.com/scheduler/latest/UserGuide/managing-targets-universal.html). Input for the universal target is well formatted JSON string containing the required keys and values for the API method being invoked.  Refer to the [AWS services' SDK documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/index.html) to understand which information 'Input' requires as each API method contains different parameters.
+
+## Testing
+
+1.  Within the AWS console, navigate the [CloudFormation Stack](https://console.aws.amazon.com/cloudformation/home) that this SAM template created and make note of the names of the resources it created in the 'Outputs' 
+
+2. Let's view the EventBridge Schedule, browse to EventBridge within the console
+
+3. Select 'Schedules' under 'Scheduler' in the navigation pane
+
+4. Select the schedule the SAM template created
+
+5. Review the 'Schedule' section to see how often the task will run and when the next execution is scheduled for. The next 10 trigger dates should be displayed below the cron expression.
+
+6. Next, click on the 'Target' section within the schedule to view the type of target we are invoking, the service, method (API) and the payload (Input)
+
+7. Wait until the next scheduled time passes to validate the SSM State Manager Association is successfully run
+
+8. Once the schedule task runs, you can verify it ran by browsing to [AWS Systems Manager](https://console.aws.amazon.com/systems-manager/home) within the console
+
+9. Then click on 'State Manager' under 'Node Management' within the navigation pane
+
+10. Select the association ID for the 'Cross-platform-Hello-World' association
+
+11. Select 'Execution history' and verify the document ran successfully
+
+12. Finally, navigate to the 'logs' folder within the S3 bucket. Each time the SSM Association runs it creates a new folder with the results of the execution. Select one of the runs, then select either of the instances it ran on, click on document task (awsrunPowerShellScript/awsrunShellScript) and name (runCommandsWindows/runCommandsLinux), then stdout file. 
+
+*__Note:__ If you don't see any folder/files within the logs directory yet, the cron schedule may have not executed yet since the deployment. Wait 15 mins and check again.*
+
+
+## Cleanup
+ 
+1. Delete all objects in the S3 log bucket
+     ```bash
+    aws s3 rm s3://<bucket-name> --recursive
+    ```
+
+2. Delete the stack and SAM artifacts
+    ```bash
+    sam delete
+    ```
+
+    Select 'Y' to delete the stack and folder containing the artifacts
+
+
+----
+Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/eventbridge-schedule-to-ssm-sam/example-pattern.json
+++ b/eventbridge-schedule-to-ssm-sam/example-pattern.json
@@ -7,7 +7,7 @@
   "introBox": {
     "headline": "How it works",
     "text": [
-      "This SAM template deploys a custom scheduled EventBridge task that triggers a SSM association that runs a custom 'Hello World!' SSM document. The EventBridge rule uses a cron schedule to run the SSM association every 15 minutes. The EC2 instances are deployed as targets for the SSM association using tag based rules. "
+      "EventBridge Scheduler Task to run a SSM Association every 15 minutes"
     ]
   },
   "gitHub": {
@@ -54,8 +54,7 @@
       "name": "Joe Losinski",
       "image": "https://avatars.githubusercontent.com/u/128616881?s=400&u=709f313db9eab1162d1874860c96bbd44164f1bf&v=4",
       "bio": "AWS Senior Solutions Architect and Serverless Enthusiast.",
-      "linkedin": "joelosinski",
-      "twitter": "n/a"
+      "linkedin": "joelosinski"
     }
   ]
 }

--- a/eventbridge-schedule-to-ssm-sam/example-pattern.json
+++ b/eventbridge-schedule-to-ssm-sam/example-pattern.json
@@ -1,0 +1,61 @@
+{
+  "title": "EventBridge to Systems Manager Associations",
+  "description": "Create an EventBridge Schedule to execute a SSM State Manager Association",
+  "language": "N/A",
+  "level": "200",
+  "framework": "SAM",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "This SAM template deploys a custom scheduled EventBridge task that triggers a SSM association that runs a custom 'Hello World!' SSM document. The EventBridge rule uses a cron schedule to run the SSM association every 15 minutes. The EC2 instances are deployed as targets for the SSM association using tag based rules. "
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-schedule-to-ssm-sam",
+      "templateURL": "serverless-patterns/eventbridge-schedule-to-ssm-sam",
+      "projectFolder": "eventbridge-schedule-to-ssm-sam",
+      "templateFile": "eventbridge-schedule-to-ssm-sam/template.yaml"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "EventBridge Scheduler User Guide",
+        "link": "https://docs.aws.amazon.com/scheduler/latest/UserGuide/what-is-scheduler.html"
+      },
+      {
+        "text": "CloudFormation AWS::Scheduler::Schedule",
+        "link": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-scheduler-schedule.html"
+      },
+      {
+        "text": "SSM Start_associations_Once SDK Reference",
+        "link": "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ssm/client/start_associations_once.html"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "sam deploy"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the Github repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>sam delete</code>."
+    ]
+  },
+  "authors": [
+    {
+      "name": "Joe Losinski",
+      "image": "https://avatars.githubusercontent.com/u/128616881?s=400&u=709f313db9eab1162d1874860c96bbd44164f1bf&v=4",
+      "bio": "AWS Senior Solutions Architect and Serverless Enthusiast.",
+      "linkedin": "joelosinski",
+      "twitter": "n/a"
+    }
+  ]
+}

--- a/eventbridge-schedule-to-ssm-sam/example-pattern.json
+++ b/eventbridge-schedule-to-ssm-sam/example-pattern.json
@@ -1,19 +1,20 @@
 {
   "title": "EventBridge to Systems Manager Associations",
   "description": "Create an EventBridge Schedule to execute a SSM State Manager Association",
-  "language": "N/A",
+  "language": "YAML",
   "level": "200",
   "framework": "SAM",
   "introBox": {
     "headline": "How it works",
     "text": [
-      "EventBridge Scheduler Task to run a SSM Association every 15 minutes"
+      "This sample pattern demonstrates how to use EventBridge Scheduler to run a SSM Association every 15 minutes and deployed using SAM."
     ]
   },
   "gitHub": {
     "template": {
       "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-schedule-to-ssm-sam",
       "templateURL": "serverless-patterns/eventbridge-schedule-to-ssm-sam",
+      "readmeURL":"https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-schedule-to-ssm-sam/README.md",
       "projectFolder": "eventbridge-schedule-to-ssm-sam",
       "templateFile": "eventbridge-schedule-to-ssm-sam/template.yaml"
     }
@@ -36,7 +37,8 @@
   },
   "deploy": {
     "text": [
-      "sam deploy"
+      "<code>sam build</code>",
+      "<code>sam deploy --guided</code>"
     ]
   },
   "testing": {
@@ -46,15 +48,14 @@
   },
   "cleanup": {
     "text": [
-      "Delete the stack: <code>sam delete</code>."
+      "See the Github repo for detailed clean-up instructions."
     ]
   },
   "authors": [
     {
       "name": "Joe Losinski",
       "image": "https://avatars.githubusercontent.com/u/128616881?s=400&u=709f313db9eab1162d1874860c96bbd44164f1bf&v=4",
-      "bio": "AWS Senior Solutions Architect and Serverless Enthusiast.",
-      "linkedin": "joelosinski"
+      "bio": "AWS Senior Solutions Architect and Serverless Enthusiast."
     }
   ]
 }

--- a/eventbridge-schedule-to-ssm-sam/template.yaml
+++ b/eventbridge-schedule-to-ssm-sam/template.yaml
@@ -1,0 +1,198 @@
+## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+## SPDX-License-Identifier: MIT-0
+
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Serverless patterns - How to schedule a SSM State Manager Association execution with Eventbridge
+
+Parameters:
+  #Pull the latest AMI IDs from Amazon's public SSM parameter store
+  LatestAmiIdLinux:
+    Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
+    Default: "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2"
+  LatestAmiIdWindows:
+    Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
+    Default: "/aws/service/ami-windows-latest/Windows_Server-2022-English-Core-Base"
+
+Resources:
+  #S3 Bucket used to store SSM State Manager Association Run Output
+  SSMAssocLogs:
+    Type: AWS::S3::Bucket
+
+  #IAM Role associated with SSM and EC2 instances
+  SSMInstanceRole: 
+    Type : AWS::IAM::Role
+    Properties:
+      Path: /
+      Policies:
+        - PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:PutObjectAcl
+                  - s3:ListBucket
+                Resource: 
+                  - !Sub 'arn:${AWS::Partition}:s3:::${SSMAssocLogs}/*'
+                  - !Sub 'arn:${AWS::Partition}:s3:::${SSMAssocLogs}'
+                Effect: Allow
+          PolicyName: s3-instance-bucket-policy
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore'
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy'
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+        - Effect: "Allow"
+          Principal:
+            Service:
+            - "ec2.amazonaws.com"
+            - "ssm.amazonaws.com"
+          Action: "sts:AssumeRole"
+
+  #EC2 Instance Role
+  SSMInstanceProfile:
+    Type: "AWS::IAM::InstanceProfile"
+    Properties:
+      Roles:
+      - !Ref SSMInstanceRole
+
+  #Deploy a standard EC2 t3.small AML2 and Windows Server 2022 instance as targets for our SSM document
+  EC2InstanceLinux:
+    Type: "AWS::EC2::Instance"
+    Properties:
+      ImageId: !Ref LatestAmiIdLinux
+      InstanceType: "t3.small"
+      IamInstanceProfile: !Ref SSMInstanceProfile
+      Tags:
+      - Key: 'HelloWorld'
+        Value: 'true'
+  EC2InstanceWindows:
+    Type: "AWS::EC2::Instance"
+    Properties:
+      ImageId: !Ref LatestAmiIdWindows
+      InstanceType: "t3.small"
+      IamInstanceProfile: !Ref SSMInstanceProfile
+      Tags:
+      - Key: 'HelloWorld'
+        Value: 'true'
+
+  #Create the SSM Document the State Manager Association will Run
+  HelloWorldDocument:
+    Type: AWS::SSM::Document
+    Properties:
+      DocumentFormat: YAML
+      DocumentType: Command
+      Content:
+        schemaVersion: '2.2'
+        description: 'HelloWorld! script that can run on Windows and Linux'
+        parameters:
+          Message:
+            type: String
+            description: 'Echo Parameter'
+            default: 'Hello World!'
+        mainSteps:
+          - action: aws:runPowerShellScript
+            name: runCommandsWindows
+            precondition:
+              StringEquals:
+              - platformType
+              - Windows
+            inputs:
+              timeoutSeconds: '60'
+              runCommand:
+              - 'Write-Output {{Message}}'
+          - action: aws:runShellScript
+            name: runCommandsLinux
+            precondition:
+              StringEquals:
+              - platformType
+              - Linux
+            inputs:
+              timeoutSeconds: '60'
+              runCommand:
+              - 'echo {{Message}}'
+
+
+  #Deploy a new SSM State Manager Association
+  EchoStateManagerAssociation:
+    Type: AWS::SSM::Association
+    DependsOn: 
+    - HelloWorldDocument
+    - EC2InstanceLinux
+    Properties:
+      AssociationName: 'Cross-platform-Hello-World'
+      Name: !Ref HelloWorldDocument
+      WaitForSuccessTimeoutSeconds: 300
+      Targets:
+        - Key: tag:HelloWorld
+          Values:
+          - 'true'
+      OutputLocation:
+        S3Location: 
+          OutputS3BucketName: !Ref SSMAssocLogs
+          OutputS3KeyPrefix: 'logs/'
+      
+  #Eventbridge Scheduler IAM Role used to start the State Manager Association
+  EchoScheduleRole: 
+    Type: AWS::IAM::Role
+    DependsOn: EchoStateManagerAssociation
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - scheduler.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: SSM-StateManager-AssociationExec
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'ssm:StartAssociationsOnce'
+                Resource:
+                  - '*'
+                  
+  #Eventbridge schedule that will run every 15 mins to execute a state manager association 
+  StateManagerAssociationSchedule:
+    Type: AWS::Scheduler::Schedule
+    DependsOn: EchoScheduleRole
+    Properties:
+      Description: Eventbridge schedule the runs a SSM association every day 
+      FlexibleTimeWindow:
+        Mode: 'OFF'
+      ScheduleExpression: 'cron(0,15,30,45 * * * ? *)' 
+      Target:
+        #Input is custom to the resource API we are invoking since this is a universal target. For SSM Associations, we need to specify the AssociationID in a string containing a well-formated JSON
+        #Ref https://docs.aws.amazon.com/scheduler/latest/UserGuide/managing-targets-universal.html for additional information on scheduling universal targets
+        Input: !Sub
+          - '{"AssociationIds": ["${assocID}"]}'
+          - assocID: !GetAtt EchoStateManagerAssociation.AssociationId
+        Arn: arn:aws:scheduler:::aws-sdk:ssm:startAssociationsOnce
+        RoleArn: !GetAtt EchoScheduleRole.Arn
+  
+
+#Resource Creation Outputs
+Outputs:
+  EC2Windows:
+    Description: 'EC2 Windows Server instance id'
+    Value: !Ref EC2InstanceWindows
+  EC2Linux:
+    Description: 'EC2 Linux instance id'
+    Value: !Ref EC2InstanceLinux
+  S3Bucket:
+    Description: 'S3 bucket were SSM association output is located'
+    Value: !Ref SSMAssocLogs
+  SSMAssocID:
+    Description: 'The SSM State Manager AssociationID'
+    Value: !GetAtt EchoStateManagerAssociation.AssociationId
+  EBSchedule:
+    Description: 'Eventbridge Scheduler ARN'
+    Value: !GetAtt StateManagerAssociationSchedule.Arn
+


### PR DESCRIPTION
Added new pattern eventbridge-schedule-to-ssm-sam. EventBridge scheduler task to run a SSM state manager association.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
