### PR TITLE
Removed hard coded configuration for build EventBridgeClient

### DIFF
--- a/apigw-lambda-eventbridge-lambda-sam-java/src/main/java/com/example/publisher/TicketPublisher.java
+++ b/apigw-lambda-eventbridge-lambda-sam-java/src/main/java/com/example/publisher/TicketPublisher.java
@@ -48,10 +48,7 @@ public class TicketPublisher implements RequestHandler<APIGatewayProxyRequestEve
 
     private String publishEvent(TicketCreated ticketCreated) throws JsonProcessingException {
 
-        Region region = Region.EU_CENTRAL_1;
-        EventBridgeClient eventBrClient = EventBridgeClient.builder()
-                .region(region)
-                .build();
+        EventBridgeClient eventBrClient = EventBridgeClient.builder().build();
 
         String event = mapper.writeValueAsString(ticketCreated);
 


### PR DESCRIPTION
The first time I deployed the stack an error occurred because the region was different from the hard coded configuration. I just removed the region to build the EventBridgeClient and worked ok.