### PR TITLE
Fixing the github broken links

### DIFF
--- a/eventbridge-pipes-msk-iam-auth-to-lambda/example-pattern.json
+++ b/eventbridge-pipes-msk-iam-auth-to-lambda/example-pattern.json
@@ -10,7 +10,7 @@
     },
     "gitHub": {
       "template": {
-        "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/eventbridge-pipes-msk-iam-auth-to-lambda",
+        "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-pipes-msk-iam-auth-to-lambda",
         "templateURL": "serverless-patterns/eventbridge-pipes-msk-iam-auth-to-lambda",
         "projectFolder": "eventbridge-pipes-msk-iam-auth-to-lambda",
         "templateFile": "template.yaml"

--- a/eventbridge-pipes-msk-to-lambda/example-pattern.json
+++ b/eventbridge-pipes-msk-to-lambda/example-pattern.json
@@ -10,7 +10,7 @@
     },
     "gitHub": {
       "template": {
-        "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/eventbridge-pipes-msk-to-lambda",
+        "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-pipes-msk-to-lambda",
         "templateURL": "serverless-patterns/eventbridge-pipes-msk-to-lambda",
         "projectFolder": "eventbridge-pipes-msk-to-lambda",
         "templateFile": "template.yaml"


### PR DESCRIPTION
*Issue #, if available:*
#1270

*Description of changes:*
A couple of patterns for eventbridge-pipes-msk-to-lambda and eventbridge-pipes-msk-iam-auth-to-lambda have broken github links. Updated those links


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
