### PR TITLE
New Pattern: EventBridge Scheduler schedule publishes to Amazon SNS

### DIFF
--- a/eventbridge-schedule-to-sns-cdk-python/.gitignore
+++ b/eventbridge-schedule-to-sns-cdk-python/.gitignore
@@ -1,0 +1,11 @@
+*.swp
+package-lock.json
+__pycache__
+.pytest_cache
+.env
+.venv
+*.egg-info
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/eventbridge-schedule-to-sns-cdk-python/README.md
+++ b/eventbridge-schedule-to-sns-cdk-python/README.md
@@ -1,0 +1,58 @@
+# EventBridge Scheduler to Amazon SNS
+
+This pattern will create an EventBridge schedule to send a message to an Amazon SNS topic every 5 minutes. The pattern is deployed using the AWS Cloud Development Kit (AWS CDK) for Python. 
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one
+  and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS
+  resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS CDK Toolkit](https://docs.aws.amazon.com/cdk/latest/guide/cli.html) installed and configured
+* [Python 3.9+](https://www.python.org/downloads/) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+2. Change directory to the pattern directory:
+    ```
+    cd eventbridge-schedule-to-sns-cdk-python
+    ```
+3. From the command line, bootstrap the CDK if you haven't already done so. 
+    ```
+    cdk bootstrap 
+    ```
+4. Install the Python required dependencies:
+    ```
+    pip install -r requirements.txt
+    ```
+5. Deploy the CDK stack to your default AWS account and region. 
+    ```
+    cdk deploy
+    ```
+
+## How it works
+
+An EventBridge Scheduler schedule is created that sends a message to an Amazon SNS topic every 5 minutes. Along with a schedule and topic, the CDK stack creates an IAM role and policy for EventBridge Scheduler to assume and send messages. 
+
+## Testing
+After the stack has been deployed, you can verify EventBridge is successfully publishing to the topic by viewing the topics "NumberOfMessagesPublished" metric in CloudWatch and verifying positive data points. 
+
+You can also add a subscription to the SNS topic such as an email address or phone number to verify messages are being published successfully.
+
+## Cleanup
+ 
+1. Delete the stack
+    ```bash
+    cdk destroy
+    ```
+----
+Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/eventbridge-schedule-to-sns-cdk-python/app.py
+++ b/eventbridge-schedule-to-sns-cdk-python/app.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+import aws_cdk as cdk
+
+from eventbridge_schedule_to_sns_cdk_python.eventbridge_schedule_to_sns_cdk_python_stack import EventbridgeScheduleToSnsCdkPythonStack
+
+
+app = cdk.App()
+EventbridgeScheduleToSnsCdkPythonStack(app, "EventbridgeScheduleToSnsCdkPythonStack")
+
+app.synth()

--- a/eventbridge-schedule-to-sns-cdk-python/cdk.json
+++ b/eventbridge-schedule-to-sns-cdk-python/cdk.json
@@ -1,0 +1,48 @@
+{
+    "app": "python3 app.py",
+    "watch": {
+      "include": [
+        "**"
+      ],
+      "exclude": [
+        "README.md",
+        "cdk*.json",
+        "requirements*.txt",
+        "source.bat",
+        "**/__init__.py",
+        "python/__pycache__",
+        "tests"
+      ]
+    },
+    "context": {
+      "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+      "@aws-cdk/core:checkSecretUsage": true,
+      "@aws-cdk/core:target-partitions": [
+        "aws",
+        "aws-cn"
+      ],
+      "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+      "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+      "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+      "@aws-cdk/aws-iam:minimizePolicies": true,
+      "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+      "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+      "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+      "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+      "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+      "@aws-cdk/core:enablePartitionLiterals": true,
+      "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
+      "@aws-cdk/aws-iam:standardizedServicePrincipals": true,
+      "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
+      "@aws-cdk/aws-iam:importedRoleStackSafeDefaultPolicyName": true,
+      "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
+      "@aws-cdk/aws-route53-patters:useCertificate": true,
+      "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
+      "@aws-cdk/aws-rds:databaseProxyUniqueResourceName": true,
+      "@aws-cdk/aws-codedeploy:removeAlarmsFromDeploymentGroup": true,
+      "@aws-cdk/aws-apigateway:authorizerChangeDeploymentLogicalId": true,
+      "@aws-cdk/aws-ec2:launchTemplateDefaultUserData": true,
+      "@aws-cdk/aws-secretsmanager:useAttachedSecretResourcePolicyForSecretTargetAttachments": true,
+      "@aws-cdk/aws-redshift:columnId": true
+    }
+  }

--- a/eventbridge-schedule-to-sns-cdk-python/eventbridge_schedule_to_sns_cdk_python/eventbridge_schedule_to_sns_cdk_python_stack.py
+++ b/eventbridge-schedule-to-sns-cdk-python/eventbridge_schedule_to_sns_cdk_python/eventbridge_schedule_to_sns_cdk_python_stack.py
@@ -1,0 +1,48 @@
+from aws_cdk import (
+    CfnOutput,
+    Stack,
+    aws_iam as iam,
+    aws_sns as _sns,
+    aws_scheduler as scheduler,
+)
+from constructs import Construct
+
+class EventbridgeScheduleToSnsCdkPythonStack(Stack):
+
+    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        ## Create SNS Topic
+        my_sns_topic = _sns.Topic(self, "my-sns-topic")
+
+        ## Create schedule role
+        scheduler_role = iam.Role(self, "scheduler-role",
+            assumed_by=iam.ServicePrincipal("scheduler.amazonaws.com")
+        )
+
+        ## Create IAM policy
+        scheduler_events_policy = iam.PolicyStatement(
+                actions=["sns:Publish"],
+                resources=[my_sns_topic.topic_arn],
+                effect=iam.Effect.ALLOW,
+        )
+
+        ## Add IAM policy to schedule role
+        scheduler_role.add_to_policy(scheduler_events_policy)
+
+        ## Create schedule to send a message to SNS every 5 minutes
+        my_schedule = scheduler.CfnSchedule(self, "my-schedule",
+                flexible_time_window=scheduler.CfnSchedule.FlexibleTimeWindowProperty(
+                    mode="OFF",
+                ),
+                schedule_expression="rate(5 minute)",
+                target=scheduler.CfnSchedule.TargetProperty(
+                    arn=my_sns_topic.topic_arn,
+                    role_arn=scheduler_role.role_arn,
+                    input="This message was sent using EventBridge Scheduler!"
+                )
+            )
+
+        ## CloudFormation Stack Outputs
+        CfnOutput(self, "SCHEDULE_NAME", value=my_schedule.ref)
+        CfnOutput(self, "SNS_TOPIC_NAME", value=my_sns_topic.topic_arn)

--- a/eventbridge-schedule-to-sns-cdk-python/example-pattern.json
+++ b/eventbridge-schedule-to-sns-cdk-python/example-pattern.json
@@ -1,0 +1,55 @@
+{
+    "title": "EventBridge Scheduler to send messages to Amazon SNS",
+    "description": "Simple pattern that publishes a message to an SNS topic every 5 minutes",
+    "language": "Python",
+    "level": "200",
+    "framework": "CDK",
+    "introBox": {
+      "headline": "How it works",
+      "text": [
+        "This sample pattern demonstrates how to send a message to an Amazon SNS topic every 5 minutes using EventBridge Scheduler and deployed using the AWS CDK for Python."
+      ]
+    },
+    "gitHub": {
+      "template": {
+        "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-schedule-to-sns-cdk-python",
+        "templateURL": "serverless-patterns/eventbridge-schedule-to-sns-cdk-python",
+        "projectFolder": "eventbridge-schedule-to-sns-cdk-python",
+        "templateFile": "eventbridge_schedule_to_sns_cdk_python/eventbridge_schedule_to_sns_cdk_python_stack.py"
+      }
+    },
+    "resources": {
+      "bullets": [
+        {
+          "text": "Getting Started with EventBridge Scheduler",
+          "link": "https://docs.aws.amazon.com/scheduler/latest/UserGuide/getting-started.html"
+        },
+        {
+          "text": "Getting started with Amazon SNS",
+          "link": "https://docs.aws.amazon.com/sns/latest/dg/sns-getting-started.html"
+        }
+      ]
+    },
+    "deploy": {
+      "text": [
+        "See the Github repo for detailed testing instructions."
+      ]
+    },
+    "testing": {
+      "text": [
+        "See the Github repo for detailed testing instructions."
+      ]
+    },
+    "cleanup": {
+      "text": [
+        "Delete the stack: <code>cdk destroy</code>."
+      ]
+    },
+    "authors": [
+      {
+        "name": "Tadhg O'Brien",
+        "bio": "Tadhg is a Technical Account Manager at Amazon Web Services supporting Public Sector customers and has a passion for Serverless",
+        "linkedin": "tadhgobrien"
+      }
+    ]
+  }

--- a/eventbridge-schedule-to-sns-cdk-python/example-pattern.json
+++ b/eventbridge-schedule-to-sns-cdk-python/example-pattern.json
@@ -32,7 +32,7 @@
     },
     "deploy": {
       "text": [
-        "See the Github repo for detailed testing instructions."
+        "See the Github repo for detailed deployment instructions."
       ]
     },
     "testing": {

--- a/eventbridge-schedule-to-sns-cdk-python/requirements.txt
+++ b/eventbridge-schedule-to-sns-cdk-python/requirements.txt
@@ -1,0 +1,2 @@
+aws-cdk-lib==2.70.0
+constructs>=10.0.0,<11.0.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This pattern creates an EventBridge Scheduler schedule that publishes messages to an Amazon SNS topic every 5 minutes. Resources are deployed using AWS CDK for Python. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
