### PR TITLE
New Pattern: EventBridge Scheduler to Amazon SNS using AWS CDK for Ty…

### DIFF
--- a/eventbridge-schedule-to-sns-cdk-typescript/.gitignore
+++ b/eventbridge-schedule-to-sns-cdk-typescript/.gitignore
@@ -1,0 +1,8 @@
+*.js
+!jest.config.js
+*.d.ts
+node_modules
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/eventbridge-schedule-to-sns-cdk-typescript/.npmignore
+++ b/eventbridge-schedule-to-sns-cdk-typescript/.npmignore
@@ -1,0 +1,6 @@
+*.ts
+!*.d.ts
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/eventbridge-schedule-to-sns-cdk-typescript/README.md
+++ b/eventbridge-schedule-to-sns-cdk-typescript/README.md
@@ -1,0 +1,58 @@
+# EventBridge Scheduler to Amazon SNS
+
+This pattern will create an EventBridge schedule to send a message to an Amazon SNS topic every 5 minutes. The pattern is deployed using the AWS Cloud Development Kit (AWS CDK) for TypeScript. 
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one
+  and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS
+  resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS CDK Toolkit](https://docs.aws.amazon.com/cdk/latest/guide/cli.html) installed and configured
+* [Node and NPM](https://nodejs.org/en/download/) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+2. Change directory to the pattern directory:
+    ```
+    cd eventbridge-schedule-to-sns-cdk-typescript
+    ```
+3. From the command line, bootstrap the CDK if you haven't already done so. 
+    ```
+    cdk bootstrap 
+    ```
+4. Install dependencies:
+    ```
+    npm install 
+    ```
+5. Deploy the CDK stack to your default AWS account and region. 
+    ```
+    cdk deploy
+    ```
+
+## How it works
+
+An EventBridge Schedule is created that sends a message to an Amazon SNS topic every 5 minutes. Along with a schedule and topic, the CDK stack creates an IAM role and policy for EventBridge scheduler to assume and send messages. 
+
+## Testing
+After the stack has been deployed, you can verify EventBridge is successfully publishing to the topic by viewing the topics "NumberOfMessagesPublished" metric and verifying positive data points. 
+
+You can also add a subscription to the SNS topic such as an email address or phone number to verify messages are being published to Amazon SNS from EventBridge. 
+
+## Cleanup
+ 
+1. Delete the stack
+    ```bash
+    cdk destroy
+    ```
+----
+Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/eventbridge-schedule-to-sns-cdk-typescript/bin/eventbridge-schedule-to-sns-cdk-typescript.ts
+++ b/eventbridge-schedule-to-sns-cdk-typescript/bin/eventbridge-schedule-to-sns-cdk-typescript.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import 'source-map-support/register';
+import * as cdk from 'aws-cdk-lib';
+import { EventbridgeScheduleToSnsCdkTypescriptStack } from '../lib/eventbridge-schedule-to-sns-cdk-typescript-stack';
+
+const app = new cdk.App();
+new EventbridgeScheduleToSnsCdkTypescriptStack(app, 'EventbridgeScheduleToSnsCdkTypescriptStack', {
+  /* If you don't specify 'env', this stack will be environment-agnostic.
+   * Account/Region-dependent features and context lookups will not work,
+   * but a single synthesized template can be deployed anywhere. */
+
+  /* Uncomment the next line to specialize this stack for the AWS Account
+   * and Region that are implied by the current CLI configuration. */
+  // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
+
+  /* Uncomment the next line if you know exactly what Account and Region you
+   * want to deploy the stack to. */
+  // env: { account: '123456789012', region: 'us-east-1' },
+
+  /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
+});

--- a/eventbridge-schedule-to-sns-cdk-typescript/cdk.json
+++ b/eventbridge-schedule-to-sns-cdk-typescript/cdk.json
@@ -1,0 +1,50 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/eventbridge-schedule-to-sns-cdk-typescript.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ],
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+    "@aws-cdk/core:enablePartitionLiterals": true,
+    "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
+    "@aws-cdk/aws-iam:standardizedServicePrincipals": true,
+    "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
+    "@aws-cdk/aws-iam:importedRoleStackSafeDefaultPolicyName": true,
+    "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
+    "@aws-cdk/aws-route53-patters:useCertificate": true,
+    "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
+    "@aws-cdk/aws-rds:databaseProxyUniqueResourceName": true,
+    "@aws-cdk/aws-codedeploy:removeAlarmsFromDeploymentGroup": true,
+    "@aws-cdk/aws-apigateway:authorizerChangeDeploymentLogicalId": true,
+    "@aws-cdk/aws-ec2:launchTemplateDefaultUserData": true,
+    "@aws-cdk/aws-secretsmanager:useAttachedSecretResourcePolicyForSecretTargetAttachments": true,
+    "@aws-cdk/aws-redshift:columnId": true
+  }
+}

--- a/eventbridge-schedule-to-sns-cdk-typescript/example-pattern.json
+++ b/eventbridge-schedule-to-sns-cdk-typescript/example-pattern.json
@@ -1,0 +1,55 @@
+{
+    "title": "EventBridge Scheduler to send messages to Amazon SNS",
+    "description": "Simple pattern that publishes a message to an SNS topic every 5 minutes",
+    "language": "TypeScript",
+    "level": "200",
+    "framework": "CDK",
+    "introBox": {
+      "headline": "How it works",
+      "text": [
+        "This sample pattern demonstrates how to send a message to an Amazon SNS topic every 5 minutes using EventBridge Scheduler and deployed using the AWS CDK for TypeScript."
+      ]
+    },
+    "gitHub": {
+      "template": {
+        "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-schedule-to-sns-cdk-typescript",
+        "templateURL": "serverless-patterns/eventbridge-schedule-to-sns-cdk-typescript",
+        "projectFolder": "eventbridge-schedule-to-sns-cdk-typescript",
+        "templateFile": "eventbridge-schedule-to-sns-cdk-typescript/lib/eventbridge-schedule-to-sns-cdk-typescript-stack.ts"
+      }
+    },
+    "resources": {
+      "bullets": [
+        {
+          "text": "Getting Started with EventBridge Scheduler",
+          "link": "https://docs.aws.amazon.com/scheduler/latest/UserGuide/getting-started.html"
+        },
+        {
+          "text": "Getting started with Amazon SNS",
+          "link": "https://docs.aws.amazon.com/sns/latest/dg/sns-getting-started.html"
+        }
+      ]
+    },
+    "deploy": {
+      "text": [
+        "See the Github repo for detailed deployment instructions."
+      ]
+    },
+    "testing": {
+      "text": [
+        "See the Github repo for detailed testing instructions."
+      ]
+    },
+    "cleanup": {
+      "text": [
+        "Delete the stack: <code>cdk destroy</code>."
+      ]
+    },
+    "authors": [
+      {
+        "name": "Tadhg O'Brien",
+        "bio": "Tadhg is a Technical Account Manager at Amazon Web Services supporting Public Sector customers and has a passion for Serverless",
+        "linkedin": "tadhgobrien"
+      }
+    ]
+  }

--- a/eventbridge-schedule-to-sns-cdk-typescript/jest.config.js
+++ b/eventbridge-schedule-to-sns-cdk-typescript/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  testEnvironment: 'node',
+  roots: ['<rootDir>/test'],
+  testMatch: ['**/*.test.ts'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest'
+  }
+};

--- a/eventbridge-schedule-to-sns-cdk-typescript/lib/eventbridge-schedule-to-sns-cdk-typescript-stack.ts
+++ b/eventbridge-schedule-to-sns-cdk-typescript/lib/eventbridge-schedule-to-sns-cdk-typescript-stack.ts
@@ -1,0 +1,45 @@
+import * as cdk from 'aws-cdk-lib';
+import { Topic } from 'aws-cdk-lib/aws-sns';
+import { CfnSchedule } from 'aws-cdk-lib/aws-scheduler';
+import { Effect, PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { Construct } from 'constructs';
+import { CfnOutput } from 'aws-cdk-lib';
+
+export class EventbridgeScheduleToSnsCdkTypescriptStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    // Create SNS Topic
+    const snsTopic = new Topic(this, 'my-sns-topic')
+
+    // Create IAM that can be assumed by EventBridge Scheduler
+    const schedulerRole = new Role(this, 'schedule-role', {
+      assumedBy: new ServicePrincipal('scheduler.amazonaws.com'),
+    });
+
+    // Create IAM policy to allow EventBridge Scheduler to send messages to SNS
+    schedulerRole.addToPolicy(new PolicyStatement({
+      effect: Effect.ALLOW,
+      actions: ['sns:Publish'],
+      resources: [snsTopic.topicArn]
+    }));
+
+    // Creates EventBridge Schedule
+    const mySchedule = new CfnSchedule(this, 'my-schedule', {
+      flexibleTimeWindow: {
+        mode: 'OFF'
+      },
+      scheduleExpression: 'rate(5 minute)',
+      description: 'Schedule to send message to Amazon SNS every 5 minutes',
+      target: {
+        arn: snsTopic.topicArn,
+        roleArn: schedulerRole.roleArn,
+        input: 'This message was sent using EventBridge Scheduler!'
+      }
+    });
+
+    // CloudFormation Stack Outputs
+    new CfnOutput(this, 'SCHEDULE_NAME', { value: mySchedule.ref });
+    new CfnOutput(this, 'SNS_TOPIC_NAME', { value: snsTopic.topicArn });
+  }
+}

--- a/eventbridge-schedule-to-sns-cdk-typescript/package.json
+++ b/eventbridge-schedule-to-sns-cdk-typescript/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "eventbridge-schedule-to-sns-cdk-typescript",
+  "version": "0.1.0",
+  "bin": {
+    "eventbridge-schedule-to-sns-cdk-typescript": "bin/eventbridge-schedule-to-sns-cdk-typescript.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "test": "jest",
+    "cdk": "cdk"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.4.0",
+    "@types/node": "18.14.6",
+    "jest": "^29.5.0",
+    "ts-jest": "^29.0.5",
+    "aws-cdk": "2.70.0",
+    "ts-node": "^10.9.1",
+    "typescript": "~4.9.5"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "2.70.0",
+    "constructs": "^10.0.0"
+  }
+}

--- a/eventbridge-schedule-to-sns-cdk-typescript/tsconfig.json
+++ b/eventbridge-schedule-to-sns-cdk-typescript/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": [
+      "es2020"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": [
+      "./node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "cdk.out"
+  ]
+}


### PR DESCRIPTION
…peScript

*Description of changes:*

Creates an EventBridge Scheduler schedule that publishes messages to Amazon SNS every 5 minutes. Resources are deployed using the AWS CDK for TypeScript. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
