### PR TITLE
New Pattern: EventBridge Scheduler to SQS (AWS CDK Java)

### DIFF
--- a/eventbridge-schedule-to-sqs-cdk-java/.gitignore
+++ b/eventbridge-schedule-to-sqs-cdk-java/.gitignore
@@ -1,0 +1,13 @@
+.classpath.txt
+target
+.classpath
+.project
+.idea
+.settings
+.vscode
+*.iml
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out
+

--- a/eventbridge-schedule-to-sqs-cdk-java/README.md
+++ b/eventbridge-schedule-to-sqs-cdk-java/README.md
@@ -1,0 +1,55 @@
+# Amazon EventBridge Schedule to Amazon SQS
+
+This pattern will create an EventBridge schedule to send a message to an Amazon SQS queue every 5 minutes. The pattern is deployed using the AWS Cloud Development Kit (AWS CDK) for Java.
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the AWS Pricing page for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) installed and configured
+* [AWS CDK](https://docs.aws.amazon.com/cdk/latest/guide/cli.html) installed and configured
+* [Maven](https://maven.apache.org/download.cgi) installed and configured
+* [Java 11+](https://docs.aws.amazon.com/corretto/latest/corretto-11-ug/downloads-list.html) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ```
+    cd serverless-patterns/eventbridge-schedule-to-sqs-cdk-java
+    ```
+1. From the command line, use Maven to build and package the project
+    ```
+    mvn clean package
+    ```
+1. From the command line, bootstrap the CDK if you haven't already done so. 
+    ```
+    cdk bootstrap 
+    ```
+1. Deploy the CDK stack to your default AWS account and region. 
+    ```
+    cdk deploy
+    ```
+
+## How it works
+The CDK stack creates an EventBridge Scheduler that sends a message to an Amazon SQS queue every 5 minutes. Along with a schedule and SQS queue, the CDK stack creates an IAM role and policy for EventBridge Scheduler to assume and send messages. 
+
+## Testing
+1. You can confirm messages are being published to the SQS queue by navigating to the Amazon SQS web console, selecting the SQS queue from the list (check the CloudFormation Outputs for the queue name), and clicking the "Send and receive message" button in the top right to poll for messages.
+
+You can also check the queues "ApproximateNumberOfMessagesVisible" metric in CloudWatch and verifying positive data points. 
+
+## Cleanup
+
+1. Delete the stack
+```bash
+   cdk destroy
+```
+----
+Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/eventbridge-schedule-to-sqs-cdk-java/cdk.json
+++ b/eventbridge-schedule-to-sqs-cdk-java/cdk.json
@@ -1,0 +1,46 @@
+{
+  "app": "mvn -e -q compile exec:java",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "target",
+      "pom.xml",
+      "src/test"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ],
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+    "@aws-cdk/core:enablePartitionLiterals": true,
+    "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
+    "@aws-cdk/aws-iam:standardizedServicePrincipals": true,
+    "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
+    "@aws-cdk/aws-iam:importedRoleStackSafeDefaultPolicyName": true,
+    "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
+    "@aws-cdk/aws-route53-patters:useCertificate": true,
+    "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
+    "@aws-cdk/aws-rds:databaseProxyUniqueResourceName": true,
+    "@aws-cdk/aws-codedeploy:removeAlarmsFromDeploymentGroup": true,
+    "@aws-cdk/aws-apigateway:authorizerChangeDeploymentLogicalId": true,
+    "@aws-cdk/aws-ec2:launchTemplateDefaultUserData": true,
+    "@aws-cdk/aws-secretsmanager:useAttachedSecretResourcePolicyForSecretTargetAttachments": true,
+    "@aws-cdk/aws-redshift:columnId": true
+  }
+}

--- a/eventbridge-schedule-to-sqs-cdk-java/example-pattern.json
+++ b/eventbridge-schedule-to-sqs-cdk-java/example-pattern.json
@@ -1,0 +1,55 @@
+{
+    "title": "Amazon EventBridge Schedule to Amazon SQS",
+    "description": "Simple pattern that publishes a message to an SQS queue every 5 minutes.",
+    "language": "Java",
+    "level": "200",
+    "framework": "CDK",
+    "introBox": {
+        "headline": "How it works",
+        "text": [
+            "This sample pattern demonstrates how to send a message to an Amazon SQS queue every 5 minutes using EventBridge Scheduler and deployed using the AWS CDK for Java."
+        ]
+    },
+    "gitHub": {
+        "template": {
+            "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-schedule-to-sqs-cdk-java",
+            "templateURL": "serverless-patterns/eventbridge-schedule-to-sqs-cdk-java",
+            "projectFolder": "eventbridge-schedule-to-sqs-cdk-java",
+            "templateFile": "eventbridge-schedule-to-sqs-cdk-java/src/main/java/com.myorg/EventBridgeScheduleToSqsCdkStack.java"
+        }
+    },
+    "resources": {
+        "bullets": [
+            {
+                "text": "Getting Started with EventBridge Scheduler",
+                "link": "https://docs.aws.amazon.com/scheduler/latest/UserGuide/getting-started.html"
+            },
+            {
+                "text": "Getting started with Amazon SQS",
+                "link": "https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-getting-started.html"
+            }
+        ]
+    },
+    "deploy": {
+        "text": [
+            "See the Github repo for detailed deployment instructions."
+        ]
+    },
+    "testing": {
+        "text": [
+            "See the Github repo for detailed testing instructions."
+        ]
+    },
+    "cleanup": {
+        "text": [
+            "cdk destroy"
+        ]
+    },
+    "authors": [
+        {
+          "name": "Tadhg O'Brien",
+          "bio": "Tadhg is a Technical Account Manager at Amazon Web Services supporting Public Sector customers and has a passion for Serverless",
+          "linkedin": "tadhgobrien"
+        }
+      ]
+}

--- a/eventbridge-schedule-to-sqs-cdk-java/pom.xml
+++ b/eventbridge-schedule-to-sqs-cdk-java/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.myorg</groupId>
+    <artifactId>java-sqs-cdk</artifactId>
+    <version>0.1</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <cdk.version>2.70.0</cdk.version>
+        <constructs.version>[10.0.0,11.0.0)</constructs.version>
+        <junit.version>5.7.1</junit.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <mainClass>com.myorg.EventBridgeScheduleToSqsCdkApp</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <!-- AWS Cloud Development Kit -->
+        <dependency>
+            <groupId>software.amazon.awscdk</groupId>
+            <artifactId>aws-cdk-lib</artifactId>
+            <version>${cdk.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>software.constructs</groupId>
+            <artifactId>constructs</artifactId>
+            <version>${constructs.version}</version>
+        </dependency>
+
+        <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter</artifactId>
+          <version>${junit.version}</version>
+          <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/eventbridge-schedule-to-sqs-cdk-java/src/main/java/com/myorg/EventBridgeScheduleToSqsCdkApp.java
+++ b/eventbridge-schedule-to-sqs-cdk-java/src/main/java/com/myorg/EventBridgeScheduleToSqsCdkApp.java
@@ -1,0 +1,40 @@
+package com.myorg;
+
+import software.amazon.awscdk.App;
+import software.amazon.awscdk.Environment;
+import software.amazon.awscdk.StackProps;
+
+public class EventBridgeScheduleToSqsCdkApp {
+    public static void main(final String[] args) {
+        App app = new App();
+
+        new EventBridgeScheduleToSqsCdkStack(app, "EventBridgeScheduleToSqsCdkJava", StackProps.builder()
+                // If you don't specify 'env', this stack will be environment-agnostic.
+                // Account/Region-dependent features and context lookups will not work,
+                // but a single synthesized template can be deployed anywhere.
+
+                // Uncomment the next block to specialize this stack for the AWS Account
+                // and Region that are implied by the current CLI configuration.
+                //
+                // .env(Environment.builder()
+                // .account(System.getenv("CDK_DEFAULT_ACCOUNT"))
+                // .region(System.getenv("CDK_DEFAULT_REGION"))
+                // .build())
+                //
+
+                // Uncomment the next block if you know exactly what Account and Region you
+                // want to deploy the stack to.
+                /*
+                 * .env(Environment.builder()
+                 * .account("123456789012")
+                 * .region("us-east-1")
+                 * .build())
+                 */
+
+                // For more information, see
+                // https://docs.aws.amazon.com/cdk/latest/guide/environments.html
+                .build());
+
+        app.synth();
+    }
+}

--- a/eventbridge-schedule-to-sqs-cdk-java/src/main/java/com/myorg/EventBridgeScheduleToSqsCdkStack.java
+++ b/eventbridge-schedule-to-sqs-cdk-java/src/main/java/com/myorg/EventBridgeScheduleToSqsCdkStack.java
@@ -1,0 +1,68 @@
+package com.myorg;
+
+import software.constructs.Construct;
+
+import java.util.Arrays;
+
+import software.amazon.awscdk.CfnOutput;
+import software.amazon.awscdk.Stack;
+import software.amazon.awscdk.StackProps;
+import software.amazon.awscdk.services.sqs.Queue;
+import software.amazon.awscdk.services.iam.*;
+import software.amazon.awscdk.services.scheduler.CfnSchedule;
+
+public class EventBridgeScheduleToSqsCdkStack extends Stack {
+        public EventBridgeScheduleToSqsCdkStack(final Construct scope, final String id) {
+                this(scope, id, null);
+        }
+
+        public EventBridgeScheduleToSqsCdkStack(final Construct scope, final String id, final StackProps props) {
+                super(scope, id, props);
+
+                // Create the SQS queue
+                Queue SqsQueue = Queue.Builder.create(this, "SQS-Queue")
+                                .build();
+
+                // Create IAM role for the scheduler to assume
+                Role schedulerRole = Role.Builder.create(this, "Scheduler-Role")
+                                .assumedBy(new ServicePrincipal("scheduler.amazonaws.com"))
+                                .build();
+
+                // Create IAM statement
+                PolicyStatement sqsSendMessageStatement = PolicyStatement.Builder.create()
+                                .effect(Effect.ALLOW)
+                                .actions(Arrays.asList("sqs:SendMessage"))
+                                .resources(Arrays.asList(SqsQueue.getQueueArn()))
+                                .build();
+
+                // Add statement to IAM role
+                schedulerRole.addToPolicy(sqsSendMessageStatement);
+
+                // Creates target for Schedule
+                CfnSchedule.TargetProperty sqsTarget = CfnSchedule.TargetProperty.builder()
+                                .arn(SqsQueue.getQueueArn())
+                                .roleArn(schedulerRole.getRoleArn())
+                                .input("This message was sent using EventBridge Scheduler!")
+                                .build();
+
+                // Creates EventBridge Schedule to send a message to SQS every 5 minutes
+                CfnSchedule sqsSchedule = CfnSchedule.Builder.create(this, "SQS-Scheduler")
+                                .flexibleTimeWindow(CfnSchedule.FlexibleTimeWindowProperty.builder()
+                                                .mode("OFF")
+                                                .build())
+                                .scheduleExpression("rate(5 minute)")
+                                .target(sqsTarget)
+                                .build();
+
+                // Outputs
+                CfnOutput.Builder.create(this, "ScheduleName")
+                                .description("Name of the EventBridge schedule")
+                                .value(sqsSchedule.getRef())
+                                .build();
+
+                CfnOutput.Builder.create(this, "SqsQueueName")
+                                .description("Name of the SQS Queue")
+                                .value(SqsQueue.getQueueName())
+                                .build();
+        }
+}

--- a/eventbridge-schedule-to-sqs-cdk-java/src/test/java/com/myorg/EventBridgeScheduleToSqsCdkStackTest.java
+++ b/eventbridge-schedule-to-sqs-cdk-java/src/test/java/com/myorg/EventBridgeScheduleToSqsCdkStackTest.java
@@ -1,0 +1,26 @@
+// package com.myorg;
+
+// import software.amazon.awscdk.App;
+// import software.amazon.awscdk.assertions.Template;
+// import java.io.IOException;
+
+// import java.util.HashMap;
+
+// import org.junit.jupiter.api.Test;
+
+// example test. To run these tests, uncomment this file, along with the
+// example resource in java/src/main/java/com/myorg/JavaSqsCdkStack.java
+// public class JavaSqsCdkTest {
+
+//     @Test
+//     public void testStack() throws IOException {
+//         App app = new App();
+//         JavaSqsCdkStack stack = new JavaSqsCdkStack(app, "test");
+
+//         Template template = Template.fromStack(stack);
+
+//         template.hasResourceProperties("AWS::SQS::Queue", new HashMap<String, Number>() {{
+//           put("VisibilityTimeout", 300);
+//         }});
+//     }
+// }


### PR DESCRIPTION
*Description of changes:*

Pattern that creates an EventBridge Scheduler schedule to send messages to Amazon SQS. Resources are deployed using AWS CDK for Java.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
