### PR TITLE
fix: upgrade aurora version to `5.7.mysql_aurora.2.11.2`

### DIFF
--- a/apigw-http-api-lambda-rds-proxy-java/template-rds-proxy.yaml
+++ b/apigw-http-api-lambda-rds-proxy-java/template-rds-proxy.yaml
@@ -13,7 +13,7 @@ Mappings:
   ClusterSettings:
     global:
       dbSchema: mylab
-      dbVersion: 5.7.mysql_aurora.2.09.1
+      dbVersion: 5.7.mysql_aurora.2.11.2
       dbEngine: aurora-mysql
       dbFamily: aurora-mysql5.7
       port: 3306

--- a/apigw-http-api-lambda-rds-proxy-terraform/vpc-rds-setup/main.tf
+++ b/apigw-http-api-lambda-rds-proxy-terraform/vpc-rds-setup/main.tf
@@ -197,7 +197,7 @@ resource "random_password" "db_password" {
 resource "aws_rds_cluster" "aurora_mysql" {
   cluster_identifier      = "aurora-cluster-demo"
   engine                  = "aurora-mysql"
-  engine_version          = "5.7.mysql_aurora.2.10.2"
+  engine_version          = "5.7.mysql_aurora.2.11.2"
   availability_zones      = ["us-east-1a", "us-east-1b", "us-east-1c"]
   db_subnet_group_name    = aws_db_subnet_group.default.id
   database_name           = "mydb"

--- a/apigw-http-api-lambda-rds-proxy/template-rds-proxy.yaml
+++ b/apigw-http-api-lambda-rds-proxy/template-rds-proxy.yaml
@@ -13,7 +13,7 @@ Mappings:
   ClusterSettings:
     global:
       dbSchema: mylab
-      dbVersion: 5.7.mysql_aurora.2.09.1
+      dbVersion: 5.7.mysql_aurora.2.11.2
       dbEngine: aurora-mysql
       dbFamily: aurora-mysql5.7
       port: 3306


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`5.7.mysql_aurora.2.09.1`, `5.7.mysql_aurora.2.10.2` is not supported now.

```zsh
$ aws rds describe-db-engine-versions --engine aurora-mysql --query 'DBEngineVersions[].EngineVersion'
[
    "5.7.mysql_aurora.2.07.0",
    "5.7.mysql_aurora.2.07.1",
    "5.7.mysql_aurora.2.07.2",
    "5.7.mysql_aurora.2.07.3",
    "5.7.mysql_aurora.2.07.4",
    "5.7.mysql_aurora.2.07.5",
    "5.7.mysql_aurora.2.07.6",
    "5.7.mysql_aurora.2.07.7",
    "5.7.mysql_aurora.2.07.8",
    "5.7.mysql_aurora.2.07.9",
    "5.7.mysql_aurora.2.08.3",
    "5.7.mysql_aurora.2.11.1",
    "5.7.mysql_aurora.2.11.2",
    "8.0.mysql_aurora.3.01.0",
    "8.0.mysql_aurora.3.01.1",
    "8.0.mysql_aurora.3.02.0",
    "8.0.mysql_aurora.3.02.1",
    "8.0.mysql_aurora.3.02.2",
    "8.0.mysql_aurora.3.02.3",
    "8.0.mysql_aurora.3.03.0"
]
```

```zsh
$ tf apply
...
╷
│ Error: error creating RDS cluster: InvalidParameterCombination: Cannot find version 5.7.mysql_aurora.2.10.2 for aurora-mysql
│       status code: 400, request id: be0a576d-6ac3-46f8-8bfe-db4b933e1312
│ 
│   with aws_rds_cluster.aurora_mysql,
│   on main.tf line 197, in resource "aws_rds_cluster" "aurora_mysql":
│  197: resource "aws_rds_cluster" "aurora_mysql" {
│ 
╵
...
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
