### PR TITLE
add folder and files for eventbridge-rule-to-ssm-automation pattern

### DIFF
--- a/eventbridge-rule-to-ssm-automation-sam/README.md
+++ b/eventbridge-rule-to-ssm-automation-sam/README.md
@@ -1,0 +1,61 @@
+# Amazon EventBridge Rule to AWS Systems Manager Automation
+
+This pattern demonstrates how to create an Amazon EventBridge Rule to trigger based on a specific event, and then run an AWS Systems Manager Automation Runbook using information from the event.
+
+Learn more about this pattern at Serverless Land Patterns: https://serverlessland.com/patterns/eventbridge-rule-to-ssm-automation-sam
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ```
+    cd eventbridge-rule-to-ssm-automation-sam
+    ```
+1. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
+    ```
+    sam deploy --guided
+    ```
+1. During the prompts:
+    * Enter a stack name
+    * Enter the desired AWS Region
+    * Enter a value for the MetadataHttpPutResponseHopLimit parameter (or use the default)
+    * Allow SAM CLI to create IAM roles with the required permissions.
+
+    Once you have run `sam deploy --guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+
+1. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## How it works
+
+This pattern will create an EventBridge rule that is configured to trigger when an EC2 instance goes into the "running" state. The rule will then execute the [AWSSupport-ConfigureEC2Metadata](https://docs.aws.amazon.com/systems-manager-automation-runbooks/latest/userguide/automation-awssupport-configureec2metadata.html) Automation Runbook against that instance to disable IMDSv1.
+
+## Testing
+
+Once the stack is deployed, launch a new EC2 Instance, and then navigate to https://console.aws.amazon.com/systems-manager/automation/executions. There will be a new Execution of the `AWSSupport-ConfigureEC2Metadata` Document against the new instance.
+
+## Cleanup
+ 
+1. Delete the stack
+    ```bash
+    aws cloudformation delete-stack --stack-name STACK_NAME
+    ```
+1. Confirm the stack has been deleted
+    ```bash
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus"
+    ```
+----
+Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/eventbridge-rule-to-ssm-automation-sam/example-pattern.json
+++ b/eventbridge-rule-to-ssm-automation-sam/example-pattern.json
@@ -1,0 +1,56 @@
+{
+  "title": "Amazon EventBridge Rule to AWS Systems Manager Automation",
+  "description": "Create an EventBridge Rule to trigger based on a specific event, and then run an AWS Systems Manager Automation Runbook using information from the event",
+  "language": "YAML",
+  "level": "200",
+  "framework": "SAM",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "This pattern will create an EventBridge rule that is configured to trigger when an EC2 instance goes into the \"running\" state. The rule will then execute the [AWSSupport-ConfigureEC2Metadata](https://docs.aws.amazon.com/systems-manager-automation-runbooks/latest/userguide/automation-awssupport-configureec2metadata.html) Automation Runbook against that instance to disable IMDSv1."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-rule-to-ssm-automation-sam",
+      "templateURL": "serverless-patterns/eventbridge-rule-to-ssm-automation-sam",
+      "readmeURL":"https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-rule-to-ssm-automation-sam/README.md",
+      "projectFolder": "eventbridge-rule-to-ssm-automation-sam",
+      "templateFile": "eventbridge-rule-to-ssm-automation-sam/template.yaml"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "EventBridge Rules User Guide",
+        "link": "https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-rules.html"
+      },
+      {
+        "text": "SSM Automation User Guide",
+        "link": "https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-automation.html"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "<code>sam deploy --guided</code>"
+    ]
+  },
+  "testing": {
+    "text": [
+      "Once the stack is deployed, launch a new EC2 Instance, and then navigate to https://console.aws.amazon.com/systems-manager/automation/executions. There will be a new Execution of the `AWSSupport-ConfigureEC2Metadata` Document against the new instance."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "See the Github repo for detailed clean-up instructions."
+    ]
+  },
+  "authors": [
+    {
+      "name": "Syed Hussain",
+      "image": "https://avatars.githubusercontent.com/u/6500837?v=4",
+      "bio": "AWS Partner Solutions Architect"
+    }
+  ]
+}

--- a/eventbridge-rule-to-ssm-automation-sam/template.yaml
+++ b/eventbridge-rule-to-ssm-automation-sam/template.yaml
@@ -1,0 +1,96 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Serverless patterns - Amazon EventBridge Rule to AWS Systems Manager Automation
+
+Parameters:
+  MetadataHttpPutResponseHopLimit:
+    Type: Number
+    Default: 1
+    MinValue: 1
+    MaxValue: 64
+    Description: The value to use when setting the HttpPutResponseHopLimit property.
+
+Resources:
+  RuleAssumeRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "events.amazonaws.com"
+            Action: "sts:AssumeRole"
+      Path: "/"
+      Policies:
+        - PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Action:
+                  - iam:PassRole
+                Resource:
+                  - !GetAtt AutomationAssumeRole.Arn
+                Effect: Allow
+          PolicyName: PassRolePolicy
+        - PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Action:
+                  - ssm:StartAutomationExecution
+                Resource:
+                  - !Sub "arn:aws:ssm:${AWS::Region}::automation-definition/AWSSupport-ConfigureEC2Metadata:$DEFAULT"
+                Effect: Allow
+          PolicyName: StartAutomationPolicy
+  AutomationAssumeRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "ssm.amazonaws.com"
+            Action: "sts:AssumeRole"
+      Path: "/"
+      Policies:
+        - PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Action:
+                  - ec2:DescribeInstances
+                  - ec2:ModifyInstanceMetadataOptions
+                  - ssm:GetAutomationExecution
+                  - ssm:StartAutomationExecution
+                Resource:
+                  - "*"
+                Effect: Allow
+          PolicyName: ConfigureEC2MetadataPolicy
+  EventBridgeRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: "Trigger AWSSupport-ConfigureEC2Metadata document to disable IMDSv1 when an EC2 Instance is started."
+      EventPattern:
+        source:
+          - "aws.ec2"
+        detail-type:
+          - "EC2 Instance State-change Notification"
+        detail:
+          state:
+            - "running"
+      Targets:
+        - Arn: !Sub "arn:aws:ssm:${AWS::Region}::automation-definition/AWSSupport-ConfigureEC2Metadata"
+          Id: "DisableIMDSv1Rule"
+          RoleArn: !GetAtt RuleAssumeRole.Arn
+          InputTransformer:
+            InputPathsMap:
+              "instance": "$.detail.instance-id"
+            InputTemplate: !Sub |
+              {
+                "InstanceId": ["<instance>"],
+                "HttpPutResponseHopLimit": ["${MetadataHttpPutResponseHopLimit}"],
+                "EnforceIMDSv2": ["required"],
+                "MetadataAccess": ["enabled"],
+                "AutomationAssumeRole": ["${AutomationAssumeRole.Arn}"]
+              }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/serverless-patterns/issues/1344
*Description of changes:*
This pattern demonstrates how to create an Amazon EventBridge Rule to trigger based on a specific event, and then run an AWS Systems Manager Automation Runbook using information from the event.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
