### PR TITLE
force amd64 archi

### DIFF
--- a/fargate-s3-cdk/cdk/src/Dockerfile
+++ b/fargate-s3-cdk/cdk/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM --platform=linux/amd64 node:14-alpine
 WORKDIR /usr
 COPY package.json ./
 COPY tsconfig.json ./
@@ -6,7 +6,7 @@ COPY src ./src
 RUN npm install
 RUN npm run build
 
-FROM node:14-alpine
+FROM --platform=linux/amd64 node:14-alpine
 WORKDIR /usr
 COPY package.json ./
 RUN npm install --only=production


### PR DESCRIPTION
useful when you build with Apple M*

force amd64 archi inside the Dockerfile


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
