### PR TITLE
1382: fixed memory size for apigw-lambda-dynamodb-sam-java

### DIFF
--- a/apigw-lambda-dynamodb-sam-java/template.yaml
+++ b/apigw-lambda-dynamodb-sam-java/template.yaml
@@ -5,7 +5,7 @@ Description: AWS-SAM-APIGW-Lambda-DDB
 Globals:
   Function:
     Runtime: java11
-    MemorySize: 3072
+    MemorySize: 3008
     Timeout: 25
 
   Api:


### PR DESCRIPTION
fixed memory size for apigw-lambda-dynamodb-sam-java

*Issue 1382*

*Description of changes:*
fixed memory size to fix the creation of the publisher

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
