### PR TITLE
upgrading s3-lambda to node 18 and aws sdk 3.32

### DIFF
--- a/s3-lambda/src/app.js
+++ b/s3-lambda/src/app.js
@@ -2,9 +2,8 @@
  *  SPDX-License-Identifier: MIT-0
  */
 
-const AWS = require('aws-sdk')
-AWS.config.update({ region: process.env.AWS_REGION })
-const s3 = new AWS.S3()
+const { GetObjectCommand, PutObjectCommand, S3Client } = require("@aws-sdk/client-s3");
+const s3 = new S3Client({ region: process.env.AWS_REGION });
 
 const gm = require('gm')
 const NEW_SIZE_PX = 480
@@ -17,23 +16,25 @@ exports.handler = async (event) => {
     // console.log(JSON.stringify(event, null, 2))
     const Key = decodeURIComponent(event.Records[0].s3.object.key.replace(/\+/g, " "))
 
+
     // Read the object from S3
-    const s3Object = await s3.getObject({
+    const commandGet = new GetObjectCommand({
         Bucket: event.Records[0].s3.bucket.name,
         Key
-    }).promise()
+      });
+    const s3Object = await s3.send(commandGet);
 
     // Resize the image
     const data = await resizeImage(s3Object.Body)
     
-    // Write to S3    
-    const result = await s3.putObject({
+    // Write to S3
+    const commandPut = new PutObjectCommand({
         Bucket: process.env.DESTINATION_BUCKETNAME,
         Key,
         ContentType: 'image/jpeg',
         Body: data,
-        ACL: 'public-read'
-    }).promise()
+      });
+    const result = await s3.send(commandPut);
     console.log('Write result: ', result)
 }
 

--- a/s3-lambda/src/package.json
+++ b/s3-lambda/src/package.json
@@ -10,6 +10,7 @@
   "author": "James Beswick",
   "license": "MIT-0",
   "dependencies": {
-    "gm": "^1.23.1"
+    "gm": "^1.25.0",
+    "@aws-sdk/client-s3": "^3.32.0"
   }
 }

--- a/s3-lambda/template.yaml
+++ b/s3-lambda/template.yaml
@@ -25,7 +25,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs18.x
       MemorySize: 2048
       Layers:
         - !Sub 'arn:aws:lambda:${AWS::Region}:175033217214:layer:graphicsmagick:2'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The s3-lambda example is using a version of node unsupported by lambda. Updated node to 18, and upgraded the gm and AWS sdk to a recent version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
