### PR TITLE
New Serverless Pattern - Adding custom headers using APIGW and Lambda Token Authorizer

### DIFF
--- a/apigw-lambda-authorizer-custom-header/README.md
+++ b/apigw-lambda-authorizer-custom-header/README.md
@@ -1,0 +1,74 @@
+# Amazon API Gateway API using Lambda Token Authorizer and Mapping Template to add custom header
+
+The SAM template deploys an Amazon API Gateway API endpoint that uses a Lambda Token Authorizer for access control as well as added logic in the Authorizer function to enrich the request with additional data. 
+
+This aproach can be used to inject data that downstream legacy systems expect and that is dependent on data that is available to authorizer.
+
+* If the request to the endpoint does not include a 'authorizationToken' header, the Lambda Authorizer will not be invoked and API Gateway will return a 401 Forbidden. 
+* If the request to the endpoint includes a 'authorizationToken' header, the Lambda Authorizer will be invoked and its response will depend on the value of the 'authorizationToken' header. 
+* If the value of 'authorizationToken' header is 'unauthorized', API Gateway will return a 401 Unauthorized error. 
+* If the value of 'authorizationToken' header is 'deny', API Gateway will return a 403 error. 
+* Only if the value of 'authorizationToken' header is 'allow', API Gateway will successfully call the HTTP backend and return a 200. 
+* For any other case, API Gateway will return a 403 error.
+
+TODO: Learn more about this pattern at Serverless Land Patterns: [https://serverlessland.com/patterns/apigw-lambda-authorizer](https://serverlessland.com/patterns/apigw-lambda-authorizer)
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+2. Change directory to the pattern directory:
+    ```
+    TODO cd apigw-lambda-authorizer
+    ```
+3. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
+    ```
+    sam deploy -g
+    ```
+1. During the prompts:
+    * Enter a stack name
+    * Select the desired AWS Region
+    * Allow SAM to create roles with the required permissions if needed.
+
+    Once you have run guided mode once, you can use `sam deploy` in future to use these defaults.
+
+1. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## Testing
+
+The stack will output the **api endpoint**. Use *curl* to make a HTTP request to the API Gateway that includes a header with the authorization token to test the Resource Lambda Token Authorizer.
+   
+```
+curl -i https://12345abcde.execute-api.{region}.amazonaws.com/Prod -H "authorizationToken: allow"
+```
+
+will successfully return a 200 HTTP code and the request from API Gateway to the HTTP endpoint in the response body. You should see a header named `enrichmentHeader` with a string provided from the Lambda Token Authorizer `This data comes from Lambda Authorizer`
+
+
+## Cleanup
+ 
+1. Delete the stack
+    ```bash
+    sam delete
+    ```
+1. Confirm the stack has been deleted
+    ```bash
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus"
+    ```
+----
+
+## Author bio
+Shaun Guo
+https://www.linkedin.com/in/shaun-guo/
+Senior Technical Account Manager

--- a/apigw-lambda-authorizer-custom-header/example-pattern.json
+++ b/apigw-lambda-authorizer-custom-header/example-pattern.json
@@ -1,0 +1,56 @@
+{
+    "title": "AWS API Gateway API with AWS Lambda Token Authorizer and mapping template adding custom headers",
+    "description": "Create an API with a mapping template that enriches the request with additional data from Lambda Token Authorizer.",
+    "language": "Node.js",
+    "level": "200",
+    "framework": "SAM",
+    "introBox": {
+      "headline": "How it works",
+      "text": [
+        "This SAM template creates an API that uses additional logic from the Lambda Token Authorizer to add data to the request.",
+        "The data is passed to the HTTP endpoint in the form of a custom header.",
+        "This aproach can be used to inject data that downstream legacy systems expect and that is dependent on data that is available to authorizer.",
+        "The HTTP endpoint in the example returns a response showing the headers that are received."
+      ]
+    },
+    "gitHub": {
+      "template": {
+        "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/apigw-lambda-authorizer-custom-header",
+        "templateURL": "serverless-patterns/apigw-lambda-authorizer-custom-header",
+        "projectFolder": "apigw-lambda-authorizer-custom-header",
+        "templateFile": "apigw-lambda-authorizer-custom-header/template.yml"
+      }
+    },
+    "resources": {
+      "bullets": [
+        {
+          "text": "Working with API Gateway and mapping templates",
+          "link": "https://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html"
+        }
+      ]
+    },
+    "deploy": {
+      "text": [
+        "sam deploy"
+      ]
+    },
+    "testing": {
+      "text": [
+        "Once the application is deployed, retrieve the API URL and a request from Postman or from a terminal using the curl command with an AuthorizationToken header of 'allow'."
+      ]
+    },
+    "cleanup": {
+      "text": [
+        "Delete the stack: <code>sam delete</code>."
+      ]
+    },
+    "authors": [
+      {
+        "headline": "Presented by Shaun Guo, Technical Account Manager",
+        "name": "Shaun Guo",
+        "image": "https://media.licdn.com/dms/image/C5103AQG3KMyMdEIKpA/profile-displayphoto-shrink_800_800/0/1517283953925?e=1692835200&v=beta&t=AxJ9ST_8K_bw8nqTPDaJB2F5dnQspES9FuJ64DBScC8",
+        "bio": "Shaun is a Senior Technical Account Manager at Amazon Web Services based in Australia",
+        "linkedin": "https://www.linkedin.com/in/shaun-guo/"
+      }
+    ]
+  }

--- a/apigw-lambda-authorizer-custom-header/src/authorizer.js
+++ b/apigw-lambda-authorizer-custom-header/src/authorizer.js
@@ -1,0 +1,44 @@
+export const handler =  function(event, context, callback) {
+    console.log(event);
+    var token = event.authorizationToken;
+    
+    switch (token) {
+        case 'allow':
+            // callback(null, generatePolicy('user', 'Allow', event.methodArn));
+            callback(null, generatePolicy('user', 'Allow', event.methodArn));
+            break;
+        case 'deny':
+            // callback(null, generatePolicy('user', 'Deny', event.methodArn));
+            callback(null, generatePolicy('user', 'Deny', event.methodArn));
+            break;
+        case 'unauthorized':
+            callback("Unauthorized");   // Return a 401 Unauthorized response
+            break;
+        default:
+            callback(null, generatePolicy('user', 'Deny', event.methodArn));
+    }
+};
+
+// Help function to generate an IAM policy
+var generatePolicy = function(principalId, effect, resource) {
+    var authResponse = {};
+    
+    authResponse.principalId = principalId;
+    if (effect && resource) {
+        var policyDocument = {};
+        policyDocument.Version = '2012-10-17'; 
+        policyDocument.Statement = [];
+        var statementOne = {};
+        statementOne.Action = 'execute-api:Invoke'; 
+        statementOne.Effect = effect;
+        statementOne.Resource = resource;
+        policyDocument.Statement[0] = statementOne;
+        authResponse.policyDocument = policyDocument;
+    }
+    
+    // enrichment stub, add code here to add enrichment data
+    authResponse.context = {
+        "enrichment": "This data comes from Lambda Authorizer"
+    };
+    return authResponse;
+}

--- a/apigw-lambda-authorizer-custom-header/template.yaml
+++ b/apigw-lambda-authorizer-custom-header/template.yaml
@@ -1,0 +1,64 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Serverless Pattern - Amazon API Gateway using Lambda Authorizer and Mapping Template to inject customer HTTP headers
+Transform: AWS::Serverless-2016-10-31
+Globals:
+  Function:
+    Runtime: nodejs18.x
+Resources:
+  # REST API
+  AppApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      Name: apigw-lambda-authorizer-mapping-template
+      Description: API Gateway using Lambda Authorizer and Mapping Template to inject customer HTTP headers with additional data.
+      StageName: Prod
+      Auth:
+        DefaultAuthorizer: MyLambdaTokenAuthorizer
+        Authorizers:
+          MyLambdaTokenAuthorizer:
+            FunctionArn: !GetAtt AuthorizerFunction.Arn
+            Identity:
+              Header: AuthorizationToken
+            AuthorizerPayloadFormatVersion: 2.0
+            EnableSimpleResponses: true
+      DefinitionBody:
+        swagger: "2.0"
+        paths:
+          /:
+            get:
+                x-amazon-apigateway-integration:
+                  httpMethod: GET
+                  passthroughBehavior: when_no_templates
+                  type: http
+                  uri: "https://httpbin.org/get"
+                  responses:
+                    "200":
+                      statusCode: '200'
+                  requestTemplates:
+                    application/json: |
+                      {
+                        #set($enrichmentHeaderValue = "$context.authorizer.enrichment")
+                        #set($context.requestOverride.header.enrichmentHeader = $enrichmentHeaderValue)
+                      }
+                responses:
+                  "200":
+                      statusCode: '200'
+
+  # Authorizer function
+  AuthorizerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: authorizer.handler
+    Metadata: # Manage esbuild properties
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: false
+        Target: "es2020"
+        EntryPoints: 
+        - authorizer.js
+Outputs:
+  # API Gateway endpoint to be used during tests
+  AppApiEndpoint:
+    Description: API Endpoint
+    Value: !Sub "https://${AppApi}.execute-api.${AWS::Region}.amazonaws.com/Prod"


### PR DESCRIPTION
*Description of changes:*

This pattern provides users a way to inject additional information in the form of a HTTP header by using Lambda Authorizer. It can be used in the use-case where downstream legacy systems expect additional data not available from the original API request.