### PR TITLE
New serverless pattern - S3 to EventBridge to SNS

### DIFF
--- a/s3-eventbridge-cloudformation/README.md
+++ b/s3-eventbridge-cloudformation/README.md
@@ -1,0 +1,69 @@
+# S3 to EventBridge to SNS
+
+Publish events directly from S3 to EventBridge and send notifications to SNS when an object is created. This template creates an S3 bucket that publishes events to Amazon EventBridge. When an object is uploaded to the bucket, the EventBridge is triggered and a SNS notification is sent.
+
+Learn more about this pattern at Serverless Land Patterns:https://serverlessland.com/patterns/s3-eventbridge-cloudformation
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+- [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+- [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+- [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+   ```
+   git clone https://github.com/aws-samples/serverless-patterns
+   ```
+1. Change directory to the pattern directory:
+   ```
+   cd s3-eventbridge-cloudformation
+   ```
+1. From the command line, use AWS CLI to deploy the AWS resources for the pattern as specified in the template.yml file:
+   ```
+   aws cloudformation create-stack --stack-name <NameOfTheStack> --template-body file://template.yaml
+   ```
+1. You can also use AWS CloudFormation console and paste the template.yml file in the designer and deploy it by passing the below required parameters.
+
+   - Enter a stack name
+
+## How it works
+
+This template creates an S3 bucket that publishes events to Amazon EventBridge, allows you to upload objects to that bucket, and will send you notifications from EventBridge to SNS when an object is created in that bucket.
+
+## Testing
+
+1. Subscribe your email address to the SNS topic:
+    ```bash
+    aws sns subscribe --topic-arn ENTER_YOUR_TOPIC_ARN --protocol email --notification-endpoint ENTER_YOUR_EMAIL_ADDRESS
+    ```
+1. Click the confirmation link delivered to your email to verify the endpoint.
+
+1. Upload an object to the S3 bucket created by the deployment. You can also use the below command to upload a file:
+    ```bash
+    aws s3 cp README.md s3://ENTER_YOUR_S3_BUCKET_NAME
+    ```
+1. The notification message is delivered to your email address.
+
+## Cleanup
+
+1. Change directory to the pattern directory:
+    ```
+    cd s3-eventbridge-cloudformation
+    ```
+1. Delete all files from the S3 bucket
+
+1. Delete the stack
+   ```bash
+   aws cloudformation delete-stack --stack-name <NameOfTheStack>
+   ```
+
+---
+
+Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/s3-eventbridge-cloudformation/example-pattern.json
+++ b/s3-eventbridge-cloudformation/example-pattern.json
@@ -1,9 +1,9 @@
 {
 	"title": "S3 to EventBridge to SNS",
 	"description": "Publish events directly from S3 to EventBridge and send notifications to SNS when an object is created. This template creates an S3 bucket that publishes events to Amazon EventBridge. When an object is uploaded to the bucket, the EventBridge is triggered and a SNS notification is sent.",
-	"language": "",
+	"language": "YAML",
 	"level": "200",
-	"framework": "CloudFormation",
+	"framework": "SAM",
 	"introBox": {
 		"headline": "How it works",
 		"text": [

--- a/s3-eventbridge-cloudformation/example-pattern.json
+++ b/s3-eventbridge-cloudformation/example-pattern.json
@@ -1,0 +1,55 @@
+{
+	"title": "S3 to EventBridge to SNS",
+	"description": "Publish events directly from S3 to EventBridge and send notifications to SNS when an object is created. This template creates an S3 bucket that publishes events to Amazon EventBridge. When an object is uploaded to the bucket, the EventBridge is triggered and a SNS notification is sent.",
+	"language": "",
+	"level": "200",
+	"framework": "CloudFormation",
+	"introBox": {
+		"headline": "How it works",
+		"text": [
+			"This template creates an S3 bucket that publishes events to Amazon EventBridge, allows you to upload objects to that bucket, and will send you notifications from EventBridge to SNS when an object is created in that bucket."
+		]
+	},
+	"gitHub": {
+		"template": {
+			"repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/s3-eventbridge-cloudformation",
+			"templateURL": "serverless-patterns/s3-eventbridge-cloudformation",
+			"projectFolder": "s3-eventbridge-cloudformation",
+			"templateFile": "s3-eventbridge-cloudformation/template.yaml"
+		}
+	},
+	"resources": {
+		"bullets": [
+			{
+				"text": "Use Amazon EventBridge to Build Decoupled, Event-Driven Architectures",
+				"link": "https://serverlessland.com/learn/eventbridge"
+			},
+			{
+				"text": "Use Amazon S3 Event Notifications with Amazon EventBridge",
+				"link": "https://aws.amazon.com/blogs/aws/new-use-amazon-s3-event-notifications-with-amazon-eventbridge/"
+			},
+			{
+				"text": "Reducing custom code by using advanced rules in Amazon EventBridge",
+				"link": "https://aws.amazon.com/blogs/compute/reducing-custom-code-by-using-advanced-rules-in-amazon-eventbridge/"
+			}
+		]
+	},
+	"deploy": {
+		"text": ["aws cloudformation create-stack --stack-name <NameOfTheStack> --template-body file://template.yaml"]
+	},
+	"testing": {
+		"text": ["See the Github repo for detailed testing instructions."]
+	},
+	"cleanup": {
+		"text": ["Delete the stack: <code>aws cloudformation delete-stack --stack-name <NameOfTheStack></code>"]
+	},
+	"authors": [
+		{
+			"name": "Makendran G",
+			"image": "https://drive.google.com/file/d/1mUObnbmn52UWL-Zn39EpgpneiBNv3LCN/view?usp=sharing",
+			"bio": "Cloud Support Engineer @ AWS",
+			"linkedin": "https://www.linkedin.com/in/makendran",
+			"twitter": "@MakendranG"
+		}
+	]
+}

--- a/s3-eventbridge-cloudformation/template.yaml
+++ b/s3-eventbridge-cloudformation/template.yaml
@@ -1,0 +1,57 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  MyS3Bucket:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      BucketName: !Sub 'serverlessland-s3-eventbridge-bucket-${AWS::StackName}'
+      NotificationConfiguration:
+        EventBridgeConfiguration:
+          EventBridgeEnabled: 'true'
+  MySNSTopic:
+    Type: 'AWS::SNS::Topic'
+    Properties:
+      TopicName: MySNSTopic
+  MyEventRule:
+    Type: 'AWS::Events::Rule'
+    Properties:
+      Description: !Sub 'Object create events on bucket s3://${MyS3Bucket}'
+      EventPattern:
+        source:
+          - aws.s3
+        detail-type:
+          - Object Created
+        detail:
+          bucket:
+            name:
+              - !Ref MyS3Bucket
+      State: ENABLED
+      Targets:
+        - Arn: !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:MySNSTopic'
+          Id: MySNSTopicTarget
+  MySNSTopicPolicy:
+    Type: 'AWS::SNS::TopicPolicy'
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AWSEventsPermission
+            Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: 'sns:Publish'
+            Resource: !Ref MySNSTopic
+            Condition:
+              ArnEquals:
+                'aws:SourceArn': !GetAtt MyEventRule.Arn
+      Topics:
+        - !Ref MySNSTopic
+Outputs:
+  S3Bucket:
+    Value: !Ref MyS3Bucket
+    Description: The S3 Bucket
+  SNSTopicARN:
+    Value: !Ref MySNSTopic
+    Description: The SNS Topic ARN
+  EventBridgeRule:
+    Value: !Ref MyEventRule
+    Description: The EventBridge Rule Name


### PR DESCRIPTION
*Issue https://github.com/aws-samples/serverless-patterns/issues/1444, if available:*

*Description of changes:*

This template creates an S3 bucket that publishes events to Amazon EventBridge, allows you to upload objects to that bucket, and will send you notifications from EventBridge to SNS when an object is created in that bucket.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
