### PR TITLE
New serverless pattern - eventbridge-schedule-to-cloudwatch-terraform

### DIFF
--- a/eventbridge-schedule-to-batch-terraform/.gitignore
+++ b/eventbridge-schedule-to-batch-terraform/.gitignore
@@ -1,0 +1,7 @@
+# terraform
+
+/.terraform
+/terraform.lock.hcl
+*.tfstate*
+*.tfstate.backup
+*.tfvars

--- a/eventbridge-schedule-to-batch-terraform/README.md
+++ b/eventbridge-schedule-to-batch-terraform/README.md
@@ -1,8 +1,8 @@
-# AWS Service 1 to AWS Service 2
+# Amazon EventBridge Scheduler to AWS Batch
 
 This pattern will create an [EventBridge Scheduler](https://docs.aws.amazon.com/scheduler/latest/UserGuide/getting-started.html) to submit an [AWS Batch](https://docs.aws.amazon.com/batch/latest/userguide/Batch_GetStarted.html) job from a job definition every 5 minutes. The pattern is deployed using Terraform to create the required VPC, Batch and EventBridge Scheduler resources. 
 
-Learn more about this pattern at Serverless Land Patterns: << Add the live URL here >>
+Learn more about this pattern at Serverless Land Patterns: https://serverlessland.com/patterns/eventbridge-schedule-to-batch-terraform
 
 Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
 
@@ -21,7 +21,7 @@ Important: this application uses various AWS services and there are costs associ
     ```
 1. Change directory to the pattern directory:
     ```
-    cd _patterns-model
+    cd eventbridge-schedule-to-batch-terraform
     ```
 1. From the command line, initialize Terraform:
     ```

--- a/eventbridge-schedule-to-batch-terraform/README.md
+++ b/eventbridge-schedule-to-batch-terraform/README.md
@@ -1,0 +1,54 @@
+# AWS Service 1 to AWS Service 2
+
+This pattern will create an [EventBridge Scheduler](https://docs.aws.amazon.com/scheduler/latest/UserGuide/getting-started.html) to submit an [AWS Batch](https://docs.aws.amazon.com/batch/latest/userguide/Batch_GetStarted.html) job from a job definition every 5 minutes. The pattern is deployed using Terraform to create the required VPC, Batch and EventBridge Scheduler resources. 
+
+Learn more about this pattern at Serverless Land Patterns: << Add the live URL here >>
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli?in=terraform/aws-get-started) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ```
+    cd _patterns-model
+    ```
+1. From the command line, initialize Terraform:
+    ```
+    terraform init
+    ```
+1. From the commend line, apply the configuration in the main.tf file and follow the prompts:
+    ```
+    terraform apply
+    ```
+
+
+## How it works
+
+An Amazon EventBridge Schedule is created that submits an AWS Batch job from a job definition every 5 minutes. The Terraform stack creates a VPC, Batch compute environment, jobs and job queues, and EventBridge Scheduler that invokes the submitJob API to run the AWS Batch job.
+
+## Testing
+
+1. After deployment, view the schedule created in the Amazon EventBridge console under Scheduler>Schedules. 
+2. From the AWS Batch console, navigate to the Jobs section. The schedule will trigger a new job every 5 minutes, which will be visable in the Jobs section. You can also view the job status from the Dashboard section of the AWS Batch console in the Job queue overview. 
+
+## Cleanup
+ 
+1. Delete all created resources and follow prompts:
+    ```
+    terraform destroy
+    ```
+----
+Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/eventbridge-schedule-to-batch-terraform/example-pattern.json
+++ b/eventbridge-schedule-to-batch-terraform/example-pattern.json
@@ -1,0 +1,56 @@
+{
+  "title": "Amazon EventBridge Scheduler to AWS Batch",
+  "description": "Schedule AWS Batch jobs using Amazon EventBridge Scheduler",
+  "level": "200",
+  "framework": "Terraform",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "This sample project demonstrates how to use Amazon EventBridge Scheduler to schedule batch compute jobs with AWS Batch. This pattern leverages universal targets with EventBridge Scheduler to talk directly to Batch, which uses only JSON_based, structured language to define the implementation.",
+      "This pattern deploys one VPC, EventBridge Scheduler Schedule, one Batch compute environment, Batch Job and Queue."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-schedule-to-batch-terraform",
+      "templateURL": "serverless-patterns/eventbridge-schedule-to-batch-terraform",
+      "projectFolder": "eventbridge-schedule-to-batch-terraform",
+      "templateFile": "eventbridge-schedule-to-batch-terraform/main.tf"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "Amazon EventBridge Scheduler",
+        "link": "https://docs.aws.amazon.com/eventbridge/latest/userguide/scheduler.html"
+      },
+      {
+        "text": "AWS Batch",
+        "link": "https://docs.aws.amazon.com/batch/latest/userguide/what-is-batch.html"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "terraform apply"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the Github repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>terraform destroy</code>."
+    ]
+  },
+  "authors": [
+    {
+      "name": "Ian Lodge",
+      "image": "https://avatars.githubusercontent.com/u/135351711?v=4",
+      "bio": "Ian is a Solutions Architect at Amazon Web Services based in the US.",
+      "linkedin": "https://www.linkedin.com/in/ian-lodge"
+    }
+  ]
+}

--- a/eventbridge-schedule-to-batch-terraform/main.tf
+++ b/eventbridge-schedule-to-batch-terraform/main.tf
@@ -1,0 +1,346 @@
+# eventbridge-schedule-to-batch-terraform
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~>4.0"
+    }
+  }
+}
+
+provider "aws" {
+  region  = var.region
+}
+
+locals {
+  project_name = "batch-job"
+}
+
+resource "random_string" "random" {
+  length           = 16
+  special          = false
+  upper            = false
+}
+
+# This section creates the Batch job and any IAM resources required for the job to execute
+resource "aws_iam_role" "batch_job_execution_role" {
+  name               = "StepFunctions-BatchJobManagementRole-${random_string.random.result}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
+}
+
+data "aws_iam_policy_document" "assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "batch_job_execution_policy" {
+  role       = aws_iam_role.batch_job_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_batch_job_definition" "batch_job" {
+  name = "StepFunctions-BatchJobManagement-${random_string.random.result}"
+  type = "container"
+  container_properties = jsonencode({
+    command = ["ls", "-la"],
+    image   = "busybox"
+
+    resourceRequirements = [
+      {
+        type  = "VCPU"
+        value = "1"
+      },
+      {
+        type  = "MEMORY"
+        value = "512"
+      }
+    ]
+
+    volumes = [
+      {
+        host = {
+          sourcePath = "/tmp"
+        }
+        name = "tmp"
+      }
+    ]
+
+    environment = [
+      {
+        name  = "VARNAME"
+        value = "VARVAL"
+      }
+    ]
+
+    mountPoints = [
+      {
+        sourceVolume  = "tmp"
+        containerPath = "/tmp"
+        readOnly      = false
+      }
+    ]
+
+    ulimits = [
+      {
+        hardLimit = 1024
+        name      = "nofile"
+        softLimit = 1024
+      }
+    ]
+    executionRoleArn = aws_iam_role.batch_job_execution_role.arn
+  })
+}
+
+data "aws_iam_policy_document" "ec2_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "ecs_instance_role" {
+  name               = "ecs_instance_role_${random_string.random.result}"
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_instance_role" {
+  role       = aws_iam_role.ecs_instance_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+resource "aws_iam_instance_profile" "ecs_instance_role" {
+  name = "ecs_instance_role_${random_string.random.result}"
+  role = aws_iam_role.ecs_instance_role.name
+}
+
+data "aws_iam_policy_document" "batch_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["batch.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+# This section creates a VPC and related resources for the AWS Batch environment
+
+# VPC to hold all Batch resources
+resource "aws_vpc" "vpc" {
+  cidr_block = var.vpc_cidr
+
+}
+
+# Create an Internet Gateway
+resource "aws_internet_gateway" "gw" {
+  vpc_id = aws_vpc.vpc.id
+}
+
+# Public Route Table
+resource "aws_route_table" "public_route" {
+  vpc_id = aws_vpc.vpc.id
+  route {
+
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.gw.id
+  }
+
+}
+
+#Create a single subnet which allows public IP's
+resource "aws_subnet" "subnet" {
+  vpc_id                  = aws_vpc.vpc.id
+  cidr_block              = var.subnet_cidr
+  map_public_ip_on_launch = true
+}
+
+# Associate the route table with the subnet
+resource "aws_route_table_association" "subnet_rt" {
+  subnet_id      = aws_subnet.subnet.id
+  route_table_id = aws_route_table.public_route.id
+}
+
+#Create a security group for the batch job
+resource "aws_security_group" "batch_sg" {
+  name        = "${local.project_name}-sg"
+  description = "Security group for Batch environment"
+  vpc_id      = aws_vpc.vpc.id
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+
+  }
+}
+
+# Create the Role and Policies for the Batch environment
+resource "aws_iam_role" "batch_role" {
+  name = "${local.project_name}-batch-svc-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "batch.amazonaws.com"
+        }
+      },
+    ]
+  })
+  managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"]
+}
+
+#Create the ECS instance role
+resource "aws_iam_role" "batch_ecs_role" {
+  name = "${local.project_name}-batch-ecs-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      },
+    ]
+  })
+  managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"]
+}
+
+# Create the ECS instance profile
+resource "aws_iam_instance_profile" "ecs_profile" {
+  name = "${local.project_name}-batch-profile"
+  role = aws_iam_role.batch_ecs_role.name
+}
+
+# Create the Batch compute environment
+resource "aws_batch_compute_environment" "batch_compute_env" {
+  compute_environment_name = "BatchComputeEnvironment-${random_string.random.result}"
+  type         = "MANAGED"
+  service_role = aws_iam_role.batch_role.arn
+  compute_resources {
+    max_vcpus     = 64
+    min_vcpus     = 0
+    desired_vcpus = 2
+    type          = "EC2"
+    instance_role = aws_iam_instance_profile.ecs_profile.arn
+    security_group_ids = [
+      aws_security_group.batch_sg.id
+    ]
+    instance_type = ["optimal"]
+    subnets = [
+      aws_subnet.subnet.id
+    ]
+  }
+  depends_on = [
+    aws_iam_role.batch_ecs_role,
+    aws_subnet.subnet,
+    aws_security_group.batch_sg,
+    aws_iam_role.batch_role
+  ]
+}
+
+# Create the Batch job queue
+resource "aws_batch_job_queue" "batch_job_queue" {
+  name     = "Scheduler-Batch-Queue-${random_string.random.result}"
+  state    = "ENABLED"
+  priority = 1
+  compute_environments = [
+    aws_batch_compute_environment.batch_compute_env.arn
+  ]
+}
+
+# This section creates schedules using Amazon EventBridge Scheduler, as well as the required IAM roles to interact with Batch
+
+resource "aws_scheduler_schedule" "batch-schedule" {
+  name = "batch-submit-job-schedule"
+  
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  schedule_expression = "rate(5 minutes)"
+  schedule_expression_timezone = "US/Eastern" # Default is UTC
+  description = "submitJob Batch event"
+
+  target {
+    arn = "arn:aws:scheduler:::aws-sdk:batch:submitJob"
+    role_arn = aws_iam_role.scheduler-batch-role.arn
+  
+    input = jsonencode({
+        "JobName": "scheduled-job",
+        "JobDefinition": "${aws_batch_job_definition.batch_job.arn}",
+        "JobQueue": "${aws_batch_job_queue.batch_job_queue.arn}"
+    })
+  }
+}
+
+resource "aws_iam_policy" "scheduler_batch_policy" {
+  name = "scheduler_batch_policy"
+
+    policy = jsonencode({
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "batch:SubmitJob",
+                "batch:DescribeJobs",
+                "batch:TerminateJob"
+            ],
+            "Resource": "*",
+            "Effect": "Allow"
+        },
+        {
+            "Action": [
+                "events:PutTargets",
+                "events:PutRule",
+                "events:DescribeRule"
+            ],
+            "Resource": [
+                "*"
+            ],
+            "Effect": "Allow"
+        }
+       ]
+      }
+    )
+}
+
+resource "aws_iam_role" "scheduler-batch-role" {
+  name = "scheduler-batch-role"
+  managed_policy_arns = [aws_iam_policy.scheduler_batch_policy.arn]
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "scheduler.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+

--- a/eventbridge-schedule-to-batch-terraform/variables.tf
+++ b/eventbridge-schedule-to-batch-terraform/variables.tf
@@ -1,0 +1,23 @@
+variable "region" {
+    type=string
+    description = "AWS Region where deploying resources"
+    default = "us-east-1"
+}
+
+variable "aws_profile_name" {
+    type=string
+    description = "AWS CLI credentials profile name"
+    default="default"
+}
+
+variable "vpc_cidr" {
+    type=string
+    description = "CIDR block for Batch VPC"
+    default = "10.0.0.0/16"
+}
+
+variable "subnet_cidr" {
+    type=string
+    description = "CIDR block for Batch subnet"
+    default = "10.0.0.0/24"
+}

--- a/eventbridge-schedule-to-cloudwatch-terraform/.gitignore
+++ b/eventbridge-schedule-to-cloudwatch-terraform/.gitignore
@@ -1,0 +1,7 @@
+# terraform
+
+/.terraform
+/terraform.lock.hcl
+*.tfstate*
+*.tfstate.backup
+*.tfvars

--- a/eventbridge-schedule-to-cloudwatch-terraform/README.md
+++ b/eventbridge-schedule-to-cloudwatch-terraform/README.md
@@ -1,4 +1,4 @@
-# AWS Service 1 to AWS Service 2
+# Amazon EventBridge Scheduler to Amazon CloudWatch
 
 This pattern will create an [EventBridge Scheduler](https://docs.aws.amazon.com/scheduler/latest/UserGuide/getting-started.html) to publish [custom metrics to Amazon Cloudwatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html). The pattern is deployed using Terraform to create the EventBridge Scheduler and IAM resources required for Scheduler to interact with CloudWatch. 
 

--- a/eventbridge-schedule-to-cloudwatch-terraform/README.md
+++ b/eventbridge-schedule-to-cloudwatch-terraform/README.md
@@ -1,0 +1,54 @@
+# AWS Service 1 to AWS Service 2
+
+This pattern will create an [EventBridge Scheduler](https://docs.aws.amazon.com/scheduler/latest/UserGuide/getting-started.html) to publish [custom metrics to Amazon Cloudwatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html). The pattern is deployed using Terraform to create the EventBridge Scheduler and IAM resources required for Scheduler to interact with CloudWatch. 
+
+Learn more about this pattern at Serverless Land Patterns: https://serverlessland.com/patterns/eventbridge-schedule-to-cloudwatch-terraform.
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli?in=terraform/aws-get-started) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ```
+    cd eventbridge-schedule-to-cloudwatch-terraform
+    ```
+1. From the command line, initialize Terraform:
+    ```
+    terraform init
+    ```
+1. From the commend line, apply the configuration in the main.tf file and follow the prompts:
+    ```
+    terraform apply
+    ```
+
+
+## How it works
+
+An Amazon EventBridge Schedule is used to publish custom metrics to Amazon CloudWatch every minute. The Terraform stack creates an EventBridge Schedule and the required IAM resource for Scheduler to interact with CloudWatch.
+
+## Testing
+
+1. After deployment, view the schedule created in the Amazon EventBridge console under Scheduler>Schedules. 
+2. From the Amazon CloudWatch console, navigate to the Metrics dashboard and view the CustomMetrics namespace which contains the metrics published by the schedule. You can view additional metrics published each minute in the same CustomMetrics namespace.  
+
+## Cleanup
+ 
+1. Delete all created resources and follow prompts:
+    ```
+    terraform destroy
+    ```
+----
+Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/eventbridge-schedule-to-cloudwatch-terraform/example-pattern.json
+++ b/eventbridge-schedule-to-cloudwatch-terraform/example-pattern.json
@@ -12,7 +12,7 @@
     },
     "gitHub": {
       "template": {
-        "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-schedule-to-batch-terraform",
+        "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-schedule-to-cloudwatch-terraform",
         "templateURL": "serverless-patterns/eventbridge-schedule-to-cloudwatch-terraform",
         "projectFolder": "eventbridge-schedule-to-cloudwatch-terraform",
         "templateFile": "eventbridge-schedule-to-cloudwatch-terraform/main.tf"

--- a/eventbridge-schedule-to-cloudwatch-terraform/example-pattern.json
+++ b/eventbridge-schedule-to-cloudwatch-terraform/example-pattern.json
@@ -1,6 +1,7 @@
 {
     "title": "Amazon EventBridge Scheduler to Amazon CloudWatch",
     "description": "Use EventBridge Scheduler to insert custom metric data into CloudWatch on a schedule",
+    "language" : "",
     "level": "200",
     "framework": "Terraform",
     "introBox": {

--- a/eventbridge-schedule-to-cloudwatch-terraform/example-pattern.json
+++ b/eventbridge-schedule-to-cloudwatch-terraform/example-pattern.json
@@ -1,0 +1,57 @@
+{
+    "title": "Amazon EventBridge Scheduler to Amazon CloudWatch",
+    "description": "Use EventBridge Scheduler to insert custom metric data into CloudWatch on a schedule",
+    "level": "200",
+    "framework": "Terraform",
+    "introBox": {
+      "headline": "How it works",
+      "text": [
+        "This sample project demonstrates how to use Amazon EventBridge Scheduler to publish your own metrics to CloudWatch on a schedule. This pattern leverages templated targets with EventBridge Scheduler to talk directly to CloudWatch using the PutEvents API operation.",
+        "This pattern deploys an EventBridge Schedule and the required IAM resource for Scheduler to interact with CloudWatch."
+      ]
+    },
+    "gitHub": {
+      "template": {
+        "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-schedule-to-batch-terraform",
+        "templateURL": "serverless-patterns/eventbridge-schedule-to-cloudwatch-terraform",
+        "projectFolder": "eventbridge-schedule-to-cloudwatch-terraform",
+        "templateFile": "eventbridge-schedule-to-cloudwatch-terraform/main.tf"
+      }
+    },
+    "resources": {
+      "bullets": [
+        {
+          "text": "Amazon EventBridge Scheduler",
+          "link": "https://docs.aws.amazon.com/eventbridge/latest/userguide/scheduler.html"
+        },
+        {
+          "text": "Publish custom metrics to Amazon CloudWatch",
+          "link": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html"
+        }
+      ]
+    },
+    "deploy": {
+      "text": [
+        "terraform apply"
+      ]
+    },
+    "testing": {
+      "text": [
+        "See the Github repo for detailed testing instructions."
+      ]
+    },
+    "cleanup": {
+      "text": [
+        "Delete the stack: <code>terraform destroy</code>."
+      ]
+    },
+    "authors": [
+      {
+        "name": "Ian Lodge",
+        "image": "https://avatars.githubusercontent.com/u/135351711?v=4",
+        "bio": "Ian is a Solutions Architect at Amazon Web Services based in the US.",
+        "linkedin": "https://www.linkedin.com/in/ian-lodge"
+      }
+    ]
+  }
+  

--- a/eventbridge-schedule-to-cloudwatch-terraform/main.tf
+++ b/eventbridge-schedule-to-cloudwatch-terraform/main.tf
@@ -1,0 +1,95 @@
+# This template uses EventBridge Scheduler to insert custom metric data into CloudWatch on a schedule. 
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.64.0"
+    }
+  }
+
+  required_version = ">= 0.14.9"
+}
+
+provider "aws" {
+  profile = "default"
+  region  = "us-east-1"
+}
+
+data "aws_caller_identity" "current" {}
+
+
+
+# This section creates cron schedules using Amazon EventBridge Scheduler, as well as the required IAM roles to interact with CloudWatch
+
+resource "aws_scheduler_schedule" "cloudwatch-schedule" {
+  name = "cloudwatch-schedule"
+  
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  schedule_expression = "rate(1 minutes)"
+  schedule_expression_timezone = "US/Eastern" # Default is UTC
+  description = "Start putMetric event"
+
+  target {
+    arn = "arn:aws:scheduler:::aws-sdk:cloudwatch:putMetricData"
+    role_arn = aws_iam_role.scheduler-cloudwatch-role.arn
+  
+    input = jsonencode(
+        {
+            "MetricData": [
+                {
+                    "MetricName": "CustomSchedulerData",
+                    "Dimensions": [
+                        { "Name": "Type", "Value": "1" }
+                    ],
+                    "Unit": "Count",
+                    "Value": 1
+                }
+            ],
+            "Namespace": "MyData"
+        }
+    )
+  }
+}
+
+
+resource "aws_iam_policy" "scheduler_cloudwatch_policy" {
+  name = "scheduler_cloudwatch_policy"
+
+  policy = jsonencode(
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                "cloudwatch:PutMetricData"
+                ],
+                "Resource": "*"
+            }
+        ]
+    }
+  )
+}
+
+resource "aws_iam_role" "scheduler-cloudwatch-role" {
+  name = "scheduler-cloudwatch-role"
+  managed_policy_arns = [aws_iam_policy.scheduler_cloudwatch_policy.arn]
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "scheduler.amazonaws.com"
+        }
+      },
+    ]
+  })
+}


### PR DESCRIPTION
New pattern using Terraform for EventBridge Scheduler to custom metrics to CloudWatch a schedule.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
