### PR TITLE
Add s3 to sns then to sqs template

### DIFF
--- a/s3-sns-sqs/README.md
+++ b/s3-sns-sqs/README.md
@@ -1,0 +1,69 @@
+# AWS S3 to AWS SNS 
+
+Sends notifications from S3 to SNS, then to SQS when an object is created.
+
+Learn more about this pattern at Serverless Land Patterns: [https://serverlessland.com/patterns/s3-lambda](https://serverlessland.com/patterns/s3-lambda)
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ```
+    cd s3-sns-sqs
+    ```
+1. From the command line, use AWS SAM to build and deploy the AWS resources for the pattern as specified in the template.yml file:
+    ```
+    sam build
+    sam deploy --guided
+    ```
+1. During the prompts:
+    * Enter a stack name
+    * Enter the desired AWS Region
+    * Enter a bucket name
+    * Allow SAM CLI to create IAM roles with the required permissions.
+
+    Once you have run `sam deploy --guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+
+1. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## How it works
+
+This SAM template creates an S3 bucket, allows you to upload objects to that bucket, and will send you notifications from S3 to SNS, then to SQS when an object is created in that bucket. You must create a subscription on the SQS queue to receive the notification messages. 
+
+==============================================
+
+## Testing
+
+1. Upload an object to the S3 bucket created by the deployment.
+2. In the console, check the SQS queue created by the deployment for new messages containing the S3 event.
+3. You can also use the SQS CLI to fetch new messages from the queue:
+    ```
+    aws sqs receive-message --queue-url <<QUEUE_URL>> --max-number-of-messages 10
+    ```
+
+## Cleanup
+ 
+1. Delete the stack
+    ```bash
+    aws cloudformation delete-stack --stack-name STACK_NAME
+    ```
+1. Confirm the stack has been deleted
+    ```bash
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus"
+    ```
+----
+Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/s3-sns-sqs/template.yaml
+++ b/s3-sns-sqs/template.yaml
@@ -58,7 +58,6 @@ Resources:
             Principal:
               Service:
                 - "sns.amazonaws.com"
-                - "localhost:4566"
             Action:
               - sqs:SendMessage
             Resource: !Ref SQSQueue
@@ -81,7 +80,6 @@ Resources:
             Principal:
               Service:
                 - "s3.amazonaws.com"
-                - "localhost:4566"
             Action:
               - sns:Publish
             Resource: !Ref SNSTopic

--- a/s3-sns-sqs/template.yaml
+++ b/s3-sns-sqs/template.yaml
@@ -1,0 +1,101 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: Sends notifications from S3 to SNS, then to SQS when an object is created
+
+Parameters:
+  BucketName:
+    Type: String
+    Default: bucket-1
+  QueueName:
+    Type: String
+    Default: queue-1
+  TopicName:
+    Type: String
+    Default: topic-1
+
+Resources:
+  # Create SQS Topic
+  SQSQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Ref QueueName
+
+  # Create SQS Queue
+  SNSTopic:
+    Type: AWS::SNS::Topic
+    DependsOn:
+      - SQSQueue
+    Properties:
+      TopicName: !Ref TopicName
+      Subscription:
+        - Endpoint: !GetAtt SQSQueue.Arn
+          Protocol: sqs
+
+  # Create S3 Bucket
+  S3Bucket:
+    Type: AWS::S3::Bucket
+    DependsOn:
+      - SNSTopicPolicy
+    Properties:
+      BucketName: !Ref BucketName
+      NotificationConfiguration:
+        TopicConfigurations:
+          - Topic: !Ref SNSTopic
+            Event: "s3:ObjectCreated:*"
+
+  # Attach SQS Policy to allow SNS to send messages
+  SQSQueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    DependsOn:
+      - SNSTopic
+    Properties:
+      Queues:
+        - !Ref SQSQueue
+      PolicyDocument:
+        Statement:
+          - Sid: AllowSNSTopic
+            Effect: Allow
+            Principal:
+              Service:
+                - "sns.amazonaws.com"
+                - "localhost:4566"
+            Action:
+              - sqs:SendMessage
+            Resource: !Ref SQSQueue
+            Condition:
+              ArnEquals:
+                aws:SourceArn: !Ref SNSTopic
+
+  # Attach SNS Policy to allow S3 to publish notifications
+  SNSTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    DependsOn:
+      - SNSTopic
+    Properties:
+      Topics:
+        - !Ref SNSTopic
+      PolicyDocument:
+        Statement:
+          - Sid: AllowS3Bucket
+            Effect: Allow
+            Principal:
+              Service:
+                - "s3.amazonaws.com"
+                - "localhost:4566"
+            Action:
+              - sns:Publish
+            Resource: !Ref SNSTopic
+            Condition:
+              ArnEquals:
+                aws:SourceArn: !Join ["", ["arn:aws:s3:::", !Ref BucketName]]
+
+Outputs:
+  S3BucketArn:
+    Description: S3 Bucket Arn
+    Value: !GetAtt S3Bucket.Arn
+  SQSQueueArn:
+    Description: SQS Queue Arn
+    Value: !GetAtt SQSQueue.Arn
+  SNSTopicArn:
+    Description: SNS Topic Arn
+    Value: !Ref SNSTopic


### PR DESCRIPTION
### *Description of changes:*
This PR will add a template to covert the following scenario:
![image](https://github.com/aws-samples/serverless-patterns/assets/60075865/856a7036-0caa-46c5-b94f-9d3abf0598d0)
Triggered when a new object has upload to the s3 bucket, the notification will be sent to SNS then enqueued on SQS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
