### PR TITLE
fix: adding permissions for eventbridge pipes to send messages to the SQS DLQ... 

### DIFF
--- a/eventbridge-pipes-ddbstream-with-filters-to-eventbridge/template.yaml
+++ b/eventbridge-pipes-ddbstream-with-filters-to-eventbridge/template.yaml
@@ -66,6 +66,14 @@ Resources:
                 Action:
                   - 'events:PutEvents'
                 Resource: !GetAtt ApplicationEventBus.Arn
+        - PolicyName: !Sub ${AWS::StackName}-dlq-policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "SQS:SendMessage"
+                Resource: !GetAtt PipeDLQueue.Arn
 
   # EventBridge Pipe to listen to all created items in DDB table             
   OrderCreatedPipe:


### PR DESCRIPTION
… for eventbridge-pipes-ddbstream-with-filters-to-eventbridge

*Issue #, if available:*  #1543

*Description of changes:* Added policy to the IAM Role (PipeRole) which is associated with the OrderUpdatedPipe and OrderCreatedPipe to grant permission for the pipes to write to the SQS DLQ (PipeDLQueue).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
