### PR TITLE
fix: Granted EventBridge Pipes permission to write to Cloudwatch & Cloudwatch Logs for pattern eventbridge-pipes-sqs-to-eventbridge-with-filters

### DIFF
--- a/cdk-vpc-lambda-sfn/README.md
+++ b/cdk-vpc-lambda-sfn/README.md
@@ -22,14 +22,15 @@ Important: this application uses various AWS services and there are costs associ
     ```
 2. Change directory to the pattern directory:
     ```
-    cd cdk-vpc-lambda-stepfunctions
+    cd cdk-vpc-lambda-sfn
     ```
 3. To deploy from the command line use the following:
     ```bash
+      npm install
       npx cdk bootstrap aws://accountnumber/region
       npm run lambda
       npx cdk synth
-      npx cdk deploy
+      npx cdk deploy --all
     ```
 
 ## How it works

--- a/eventbridge-pipes-sqs-to-eventbridge-with-filters/README.md
+++ b/eventbridge-pipes-sqs-to-eventbridge-with-filters/README.md
@@ -23,7 +23,7 @@ Important: this application uses various AWS services and there are costs associ
    ```
 1. Change directory to the pattern directory:
    ```
-   cd eventbridge-sfn
+   cd serverless-patterns/eventbridge-pipes-sqs-to-eventbridge-with-filters
    ```
 1. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
    ```

--- a/eventbridge-pipes-sqs-to-eventbridge-with-filters/template.yaml
+++ b/eventbridge-pipes-sqs-to-eventbridge-with-filters/template.yaml
@@ -27,6 +27,15 @@ Resources:
             Action:
               - sts:AssumeRole
       Policies:
+        - PolicyName: CloudWatch
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'logs:*'
+                  - 'cloudwatch:*'
+                Resource: '*'
         - PolicyName: SourcePolicy
           PolicyDocument:
             Version: 2012-10-17

--- a/eventbridge-pipes-sqs-to-eventbridge-with-filters/template.yaml
+++ b/eventbridge-pipes-sqs-to-eventbridge-with-filters/template.yaml
@@ -33,8 +33,12 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  - 'logs:*'
-                  - 'cloudwatch:*'
+                  - 'logs:PutLogEvents'
+                  - 'logs:CreateLogGroup'
+                  - 'logs:CreateLogStream'
+                  - 'logs:DescribeLogStreams'
+                  - 'logs:DescribeLogGroups'
+                  - 'cloudwatch:PutMetricData'
                 Resource: '*'
         - PolicyName: SourcePolicy
           PolicyDocument:


### PR DESCRIPTION
*Issue #, if available:* aws-samples/serverless-patterns#1559

*Description of changes:*

Granted EventBridge Pipes permission to write to Cloudwatch & Cloudwatch Logs for pattern eventbridge-pipes-sqs-to-eventbridge-with-filters

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
