### PR TITLE
update node version to 18.x as 12 is no longer a supported Lambda run…

### DIFF
--- a/sqs-lambda/template.yaml
+++ b/sqs-lambda/template.yaml
@@ -13,7 +13,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs18.x
       Timeout: 3
       MemorySize: 128
       Events:


### PR DESCRIPTION
*Description of changes:* 
Update of node version to 18.x as 12 is no longer a supported Lambda runtime. The current template fails to deploy due to this issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
