### PR TITLE
New serverless pattern - Eventbridge fan-in using Terraform

### DIFF
--- a/eventbridge-fan-in-terraform/.gitignore
+++ b/eventbridge-fan-in-terraform/.gitignore
@@ -1,0 +1,2 @@
+*.tfstate*
+*.terraform*

--- a/eventbridge-fan-in-terraform/.gitignore
+++ b/eventbridge-fan-in-terraform/.gitignore
@@ -1,2 +1,3 @@
 *.tfstate*
 *.terraform*
+!terraform.tfvars

--- a/eventbridge-fan-in-terraform/README.md
+++ b/eventbridge-fan-in-terraform/README.md
@@ -2,7 +2,7 @@
 
 This pattern demonstrates how to aggregate all your events from multiple Eventbus (in the same region) to a central Eventbus in a different region. This pattern is deployed using Terraform to create a central EventBridge bus, Eventbridge rules on fan-in buses and all IAM resources required. The Eventbuses to aggregate can be defined in terraform.tfvars file (Sample ARNs is provided, replace with Eventbus ARNs as needed). The provider.tf file also lists the AWS regions of the fan-in Eventbus and central Eventbus (replace these based on where your Eventbuses exist and where you want your central bus to be created).
 
-Learn more about this pattern at Serverless Land Patterns: << Add the live URL here >>
+Learn more about this pattern at Serverless Land Patterns: https://serverlessland.com/patterns/eventbridge-fan-in-terraform
 
 Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
 

--- a/eventbridge-fan-in-terraform/README.md
+++ b/eventbridge-fan-in-terraform/README.md
@@ -4,6 +4,7 @@ This pattern demonstrates how to aggregate all your events from multiple Eventbu
 
 This pattern is deployed using Terraform to create a central EventBridge bus, Eventbridge rules on fan-in buses and all IAM resources required. The Eventbuses to aggregate can be defined in terraform.tfvars file (Sample ARNs is provided, replace with Eventbus ARNs as needed). The provider.tf file also lists the AWS regions of the fan-in Eventbus and central Eventbus (replace these based on where your Eventbuses exist and where you want your central bus to be created).
 
+Note: The pattern assumes you already have a minimum of 2 eventbuses that you want to aggregate onto a central Eventbus (the central bus will be created as part of this deployment). The fan-in Eventbuses can be created manually or using any of the Infrastructure-as-code platforms.
 
 Learn more about this pattern at Serverless Land Patterns: https://serverlessland.com/patterns/eventbridge-fan-in-terraform
 
@@ -28,7 +29,7 @@ Important: this application uses various AWS services and there are costs associ
     ```
 3. In the provider.tf file, add the regions where the Eventbuses exist in the provider block with alias "others". Also add the region where you want the central Eventbus to be created in the provider block with alias "central"
 
-4. In the terraform.tfvars file, add the ARNs of the Eventbuses you want to aggregate. Note that these Eventbus should exist in the same region
+4. In the terraform.tfvars file, add the ARNs of the existing Eventbuses you want to aggregate. Note that all of these fan-in Eventbuses should exist in the same region. 
 
 5. From the command line, initialize Terraform:
     ```
@@ -44,6 +45,8 @@ Important: this application uses various AWS services and there are costs associ
 This application picks the configurations from terraform.tfvars files to create Eventbridge rules on all entered Eventbus for fan-in to a central Eventbus. The terraform creates the rules, along with the required IAM roles and policies and configures the target as the central Eventbus which it also creates. The central Eventbus has a rule that routes all events to a Cloudwatch log group for testing.
 
 ## Testing
+
+Note: To test this pattern, you will need a minimum of 2 existing event buses in the fan-in region. 
 
 Login to the AWS account where the terraform is deployed. Publish an event on any of the fan-in Eventbuses. Switch to the region where the central Eventbus is created and navigate to Cloudwatch logs. You should see the event you published in the log group of the Central Eventbus.
 

--- a/eventbridge-fan-in-terraform/README.md
+++ b/eventbridge-fan-in-terraform/README.md
@@ -1,6 +1,9 @@
 # Amazon Eventbridge Eventbus fan-in to Central Eventbus to different region
 
-This pattern demonstrates how to aggregate all your events from multiple Eventbus (in the same region) to a central Eventbus in a different region. This pattern is deployed using Terraform to create a central EventBridge bus, Eventbridge rules on fan-in buses and all IAM resources required. The Eventbuses to aggregate can be defined in terraform.tfvars file (Sample ARNs is provided, replace with Eventbus ARNs as needed). The provider.tf file also lists the AWS regions of the fan-in Eventbus and central Eventbus (replace these based on where your Eventbuses exist and where you want your central bus to be created).
+This pattern demonstrates how to aggregate all your events from multiple Eventbus (in the same region) to a central Eventbus in a different region. This allows you to centrally accumulate events coming in from different event sources for downstream consumption.
+
+This pattern is deployed using Terraform to create a central EventBridge bus, Eventbridge rules on fan-in buses and all IAM resources required. The Eventbuses to aggregate can be defined in terraform.tfvars file (Sample ARNs is provided, replace with Eventbus ARNs as needed). The provider.tf file also lists the AWS regions of the fan-in Eventbus and central Eventbus (replace these based on where your Eventbuses exist and where you want your central bus to be created).
+
 
 Learn more about this pattern at Serverless Land Patterns: https://serverlessland.com/patterns/eventbridge-fan-in-terraform
 
@@ -19,15 +22,19 @@ Important: this application uses various AWS services and there are costs associ
     ``` 
     git clone https://github.com/aws-samples/serverless-patterns
     ```
-1. Change directory to the pattern directory:
+2. Change directory to the pattern directory:
     ```
     cd eventbridge-fan-in-terraform
     ```
-1. From the command line, initialize Terraform:
+3. In the provider.tf file, add the regions where the Eventbuses exist in the provider block with alias "others". Also add the region where you want the central Eventbus to be created in the provider block with alias "central"
+
+4. In the terraform.tfvars file, add the ARNs of the Eventbuses you want to aggregate. Note that these Eventbus should exist in the same region
+
+5. From the command line, initialize Terraform:
     ```
     terraform init
     ```
-1. From the command line, apply the configuration in the main.tf file and follow the prompts:
+6. From the command line, apply the configuration in the main.tf file and follow the prompts:
      ```
     terraform apply
     ```

--- a/eventbridge-fan-in-terraform/README.md
+++ b/eventbridge-fan-in-terraform/README.md
@@ -1,0 +1,53 @@
+# Amazon Eventbridge Eventbus fan-in to Central Eventbus to different region
+
+This pattern demonstrates how to aggregate all your events from multiple Eventbus (in the same region) to a central Eventbus in a different region. This pattern is deployed using Terraform to create a central EventBridge bus, Eventbridge rules on fan-in buses and all IAM resources required. The Eventbuses to aggregate can be defined in terraform.tfvars file (Sample ARNs is provided, replace with Eventbus ARNs as needed). The provider.tf file also lists the AWS regions of the fan-in Eventbus and central Eventbus (replace these based on where your Eventbuses exist and where you want your central bus to be created).
+
+Learn more about this pattern at Serverless Land Patterns: << Add the live URL here >>
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli?in=terraform/aws-get-started) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ```
+    cd eventbridge-fan-in-terraform
+    ```
+1. From the command line, initialize Terraform:
+    ```
+    terraform init
+    ```
+1. From the command line, apply the configuration in the main.tf file and follow the prompts:
+     ```
+    terraform apply
+    ```
+
+## How it works
+
+This application picks the configurations from terraform.tfvars files to create Eventbridge rules on all entered Eventbus for fan-in to a central Eventbus. The terraform creates the rules, along with the required IAM roles and policies and configures the target as the central Eventbus which it also creates. The central Eventbus has a rule that routes all events to a Cloudwatch log group for testing.
+
+## Testing
+
+Login to the AWS account where the terraform is deployed. Publish an event on any of the fan-in Eventbuses. Switch to the region where the central Eventbus is created and navigate to Cloudwatch logs. You should see the event you published in the log group of the Central Eventbus.
+
+
+## Cleanup
+ 
+1. Delete all created resources and follow the prompts:
+     ```
+    terraform destroy
+    ```
+----
+Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/eventbridge-fan-in-terraform/data.tf
+++ b/eventbridge-fan-in-terraform/data.tf
@@ -1,0 +1,22 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "event_bus_invoke_central_event_bus_policy" {
+  statement {
+    effect    = "Allow"
+    actions   = ["events:PutEvents"]
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}

--- a/eventbridge-fan-in-terraform/example-pattern.json
+++ b/eventbridge-fan-in-terraform/example-pattern.json
@@ -1,0 +1,47 @@
+{
+  "title": "Eventbridge fan-in",
+  "description": "Aggregate your Eventbridge eventbuses to a central bus",
+  "language": "Python",
+  "level": "200",
+  "framework": "Terraform",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "This pattern demonstrates how to aggregate all your events from multiple Eventbus (in the same region) to a central Eventbus in a different region.",
+      "This pattern is deployed using Terraform to create a central EventBridge bus, Eventbridge rules on fan-in buses and all IAM resources required.",
+      "The Eventbuses to aggregate can be defined in terraform.tfvars file (Sample ARNs is provided, replace with Eventbus ARNs as needed).",
+      "The provider.tf file also lists the AWS regions of the fan-in Eventbus and central Eventbus (replace these based on where your Eventbuses exist and where you want your central bus to be created)."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-fan-in-terraform",
+      "templateURL": "serverless-patterns/eventbridge-fan-in-terraform",
+      "projectFolder": "eventbridge-fan-in-terraform",
+      "templateFile": "eventbridge-fan-in-terraform/main.tf"
+    }
+  },
+  "deploy": {
+    "text": [
+      "terraform init && terraform apply"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the GitHub repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "terraform destroy"
+    ]
+  },
+  "authors": [
+    {
+      "name": "Aniket Bulbule",
+      "image": "link-to-your-photo.jpg",
+      "bio": "Your bio.",
+      "linkedin": "linked-in-ID"
+    }
+  ]
+}

--- a/eventbridge-fan-in-terraform/example-pattern.json
+++ b/eventbridge-fan-in-terraform/example-pattern.json
@@ -39,9 +39,9 @@
   "authors": [
     {
       "name": "Aniket Bulbule",
-      "image": "link-to-your-photo.jpg",
-      "bio": "Your bio.",
-      "linkedin": "linked-in-ID"
+      "image": "https://drive.google.com/file/d/1g5X8juFALsl44ZACvcZSKGmCVUS4IKqi/view?usp=sharing",
+      "bio": "Partner Solutions Architect @AWS, Serverless Enthusiast",
+      "linkedin": "www.linkedin.com/in/aniket-bulbule"
     }
   ]
 }

--- a/eventbridge-fan-in-terraform/main.tf
+++ b/eventbridge-fan-in-terraform/main.tf
@@ -1,0 +1,136 @@
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+}
+
+// Loop over all Eventbus and create rule for each
+resource "aws_cloudwatch_event_rule" "ebrule" {
+  provider = aws.others
+  for_each = nonsensitive(toset(var.buses))
+  event_bus_name = each.value
+  event_pattern = jsonencode({
+    account = [
+      local.account_id
+    ]
+  })
+  is_enabled = true
+}
+
+//IAM role and policy for Event rule
+resource "aws_iam_role" "event_bus_invoke_central_event_bus" {
+  name               = "event-bus-invoke-central-event-bus"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+resource "aws_iam_policy" "event_bus_invoke_central_event_bus" {
+  name   = "event_bus_invoke_central_event_bus_policy"
+  policy = data.aws_iam_policy_document.event_bus_invoke_central_event_bus_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "event_bus_invoke_central_event_bus" {
+  role       = aws_iam_role.event_bus_invoke_central_event_bus.name
+  policy_arn = aws_iam_policy.event_bus_invoke_central_event_bus.arn
+}
+
+
+// Create Cloudwatch log group for central bus
+resource "aws_cloudwatch_log_group" "log-group" {
+  provider = aws.central
+  name  = "/aws/events/central-bus-logs/logs"
+  retention_in_days =  7  
+}
+
+// Create log policy
+data "aws_iam_policy_document" "log_policy" {
+  depends_on = [ module.central_eventbridge ]
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogStream"
+    ]
+
+    resources = [
+      "${aws_cloudwatch_log_group.log-group.arn}:*"
+    ]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "events.amazonaws.com",
+        "delivery.logs.amazonaws.com"
+      ]
+    }
+ }
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:PutLogEvents"
+    ]
+
+    resources = [
+      "${aws_cloudwatch_log_group.log-group.arn}:*:*"
+    ]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "events.amazonaws.com",
+        "delivery.logs.amazonaws.com"
+      ]
+    }
+    condition {
+      test     = "ArnEquals"
+      values   = [module.central_eventbridge.eventbridge_rule_arns.log-rule]
+      variable = "aws:SourceArn"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_resource_policy" "log-resource-policy" {
+  policy_document = data.aws_iam_policy_document.log_policy.json
+  policy_name     = "eventbridge-log-publishing-policy"
+}
+
+//Use Eventbridge module to create Central Eventbus
+module "central_eventbridge" {
+  providers = {
+    aws = aws.central
+  }
+  source = "terraform-aws-modules/eventbridge/aws"
+
+  bus_name = "central-event-bus"
+
+  rules = {
+    log-rule={
+        name          = "central-bus-event-rule"
+        description   = "Send all events from Central Eventbus to Cloudwatch logs"
+        event_bus_name = "central-event-bus"
+        event_pattern = jsonencode({
+          account = [
+          local.account_id
+          ]
+          })
+        enabled = true
+     }
+  }
+
+  targets = {
+    log-rule = [
+      {
+        name = "send-logs-to-cloudwatch"
+        arn  = aws_cloudwatch_log_group.log-group.arn
+      }
+    ]
+  }
+  tags = {
+    Name = "my-bus"
+  }
+}
+
+//Create targets on each rule to send events to Central Eventbus
+resource "aws_cloudwatch_event_target" "EBtargets" {
+  for_each       = tomap(aws_cloudwatch_event_rule.ebrule)
+  event_bus_name = each.key
+  rule           = each.value.name
+  arn            = module.central_eventbridge.eventbridge_bus_arn
+  role_arn       = aws_iam_role.event_bus_invoke_central_event_bus.arn
+}

--- a/eventbridge-fan-in-terraform/outputs.tf
+++ b/eventbridge-fan-in-terraform/outputs.tf
@@ -1,0 +1,15 @@
+output "all_rules" {
+  value = resource.aws_cloudwatch_event_rule.ebrule
+}
+
+output "ebRole" {
+  value = aws_iam_role.event_bus_invoke_central_event_bus.arn
+}
+
+output "central_bus_arn" {
+  value = module.central_eventbridge.eventbridge_bus_arn
+}
+
+output "central_bus_rule_arn" {
+  value = module.central_eventbridge.eventbridge_rule_arns
+}

--- a/eventbridge-fan-in-terraform/provider.tf
+++ b/eventbridge-fan-in-terraform/provider.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.9.0"
+    }
+  }
+}
+
+//Region where Central EventBus will exist
+provider "aws" {
+  region = "ca-central-1"
+  alias = "central"
+}
+    
+//Region where current Eventbuses exist for fan-in
+provider "aws" {
+  region = "us-east-2"
+  alias = "others"
+}

--- a/eventbridge-fan-in-terraform/src/app.js
+++ b/eventbridge-fan-in-terraform/src/app.js
@@ -1,0 +1,10 @@
+/*! Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: MIT-0
+ */
+
+'use strict'
+
+exports.handler = async (event) => {
+  // Lambda handler code
+  console.log(JSON.stringify(event, 0, null))
+}

--- a/eventbridge-fan-in-terraform/terraform.tfvars
+++ b/eventbridge-fan-in-terraform/terraform.tfvars
@@ -1,0 +1,1 @@
+buses= ["arn:aws:events:{region}:{accountId}:event-bus/eventBus1", "arn:aws:events:{region}:{accountId}:event-bus/eventBus2","arn:aws:events:{region}:{accountId}:event-bus/eventBus3"]

--- a/eventbridge-fan-in-terraform/variables.tf
+++ b/eventbridge-fan-in-terraform/variables.tf
@@ -1,0 +1,11 @@
+variable "buses" {
+  type        = list(string)
+  description = "Name of the first EventBus"
+  sensitive = true
+}
+
+variable "centralEB" {
+  type        = string
+  default     = "centralEB"
+  description = "Name of central EventBus"
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

New serverless pattern to allow eventbridge fan-in of multiple Eventbus (in same region) to a central Eventbus in another region using Terraform


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
