### PR TITLE
New serverless pattern - s3-eventbridge-sns-cdk

### DIFF
--- a/s3-eventbridge-sns-cdk/README.md
+++ b/s3-eventbridge-sns-cdk/README.md
@@ -1,0 +1,82 @@
+# S3 to EventBridge to SNS
+
+Publish events directly from S3 to EventBridge and send notifications to SNS when an object is created. This template creates an S3 bucket that publishes events to Amazon EventBridge. When an object is uploaded to the bucket, the EventBridge is triggered and a SNS notification is sent.
+
+Learn more about this pattern at Serverless Land Patterns: https://serverlessland.com/patterns/s3-eventbridge-sns-cdk
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+- [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+- [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+- [AWS CDK](https://docs.aws.amazon.com/cdk/latest/guide/cli.html) installed and configured
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+   ```
+   git clone https://github.com/aws-samples/serverless-patterns
+   ```
+2. Change directory to the pattern directory:
+   ```
+   cd s3-eventbridge-sns-cdk/src
+   ```
+3. Install dependencies:
+   ```
+   npm install
+   ```
+4. This project uses typescript as client language for AWS CDK. Run the given command to compile typescript to javascript
+   ```
+   npm run build
+   ```
+5. From the command line, configure AWS CDK (if you had not done it):
+   ```
+   cdk bootstrap ACCOUNT-NUMBER/REGION # e.g.
+   cdk bootstrap 1111111111/us-east-1
+   cdk bootstrap --profile test 1111111111/us-east-1
+   ```
+6. Synthesize CloudFormation template from the AWS CDK app
+   ```
+   cdk synth
+   ```
+7. From the command line, use AWS CDK to deploy the AWS resources for the pattern as specified in the `lib/s3-eventbridge-sns-stack`
+   ```
+   cdk deploy
+   ```
+8. The CDK template successfully creates a new S3 bucket, a SNS Topic and an EventBridge rule targeting the SNS Topic for the S3 `Object Created` event.
+
+9. Note the outputs from the CDK deployment process. It contains the ARN of S3 bucket, SNS Topic & Eventbridge Rule.
+
+## How it works
+
+This CDK template creates a new S3 bucket, a SNS Topic and an EventBridge rule targeting the SNS Topic for the S3 `Object Created` event. Once you upload a new object to the S3 bucket, the Eventbridge rule triggers a notification message to SNS Topic which is then published to the subscribers.
+
+## Testing
+
+1. Subscribe your email address to the SNS topic:
+    ```bash
+    aws sns subscribe --topic-arn ENTER_YOUR_TOPIC_ARN --protocol email --notification-endpoint ENTER_YOUR_EMAIL_ADDRESS
+    ```
+1. Click the confirmation link delivered to your email to verify the endpoint.
+
+1. Upload an object to the S3 bucket created by the deployment. You can also use the below command to upload a file:
+    ```bash
+    aws s3 cp README.md s3://ENTER_YOUR_S3_BUCKET_NAME
+    ```
+1. The notification message is delivered to your email address.
+
+## Cleanup
+
+1. Delete all files from the S3 bucket
+
+1. Delete the stack
+   ```bash
+   sam delete
+   ```
+---
+
+Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/s3-eventbridge-sns-cdk/example-pattern.json
+++ b/s3-eventbridge-sns-cdk/example-pattern.json
@@ -1,0 +1,66 @@
+{
+  "title": "S3 to EventBridge to SNS",
+  "description": "Publish events directly from S3 to EventBridge and send notifications to SNS when an object is created.",
+  "language": "Typescript",
+  "level": "200",
+  "framework": "CDK",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "This sample project demonstrates how to use AWS SNS to deliver notifications to subscribers for objects uploaded to a S3 bucket.",
+      "This pattern uses AWS CDK to setup an S3 bucket that publishes events to Amazon EventBridge. When an object is uploaded to the bucket, the EventBridge is triggered and a SNS notification is sent to subscribers.",
+      "This pattern deploys one S3 Bucket, SNS Topic, EventBridge rule and a Lambda function which is used internally by CDK to apply configuration notifications on the bucket"
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/s3-eventbridge-sns-cdk",
+      "templateURL": "serverless-patterns/s3-eventbridge-sns-cdk",
+      "projectFolder": "s3-eventbridge-sns-cdk",
+      "templateFile": "s3-eventbridge-sns-cdk/lib/s3-eventbridge-sns-stack.ts"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "Getting started with the AWS CDK",
+        "link": "https://docs.aws.amazon.com/cdk/v2/guide/getting_started.html"
+      },
+      {
+        "text": "Setup SNS topic",
+        "link": "https://docs.aws.amazon.com/sns/latest/dg/sns-create-topic.html"
+      },
+      {
+        "text": "Use Amazon S3 Event Notifications with Amazon EventBridge",
+        "link": "https://aws.amazon.com/blogs/aws/new-use-amazon-s3-event-notifications-with-amazon-eventbridge/"
+      },
+      {
+        "text": "Use Amazon EventBridge to Build Decoupled, Event-Driven Architectures",
+        "link": "https://serverlessland.com/learn/eventbridge"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "cdk deploy"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the GitHub repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>cdk destroy</code>."
+    ]
+  },
+  "authors": [
+    {
+      "name": "Rajesh Raghu ",
+      "image": "https://drive.google.com/file/d/1J0G40015K4sX4EzGQ7-OfGYqXT19O0DP/view?usp=sharing",
+      "bio": "Cloud Support Engineer @ AWS",
+      "linkedin": "https://www.linkedin.com/in/rajesh-raghu-97a321b4/"
+    }
+  ]
+}

--- a/s3-eventbridge-sns-cdk/src/.gitignore
+++ b/s3-eventbridge-sns-cdk/src/.gitignore
@@ -1,0 +1,8 @@
+*.js
+!jest.config.js
+*.d.ts
+node_modules
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/s3-eventbridge-sns-cdk/src/.npmignore
+++ b/s3-eventbridge-sns-cdk/src/.npmignore
@@ -1,0 +1,6 @@
+*.ts
+!*.d.ts
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/s3-eventbridge-sns-cdk/src/README.md
+++ b/s3-eventbridge-sns-cdk/src/README.md
@@ -1,0 +1,14 @@
+# Welcome to your CDK TypeScript project
+
+This is a blank project for CDK development with TypeScript.
+
+The `cdk.json` file tells the CDK Toolkit how to execute your app.
+
+## Useful commands
+
+* `npm run build`   compile typescript to js
+* `npm run watch`   watch for changes and compile
+* `npm run test`    perform the jest unit tests
+* `cdk deploy`      deploy this stack to your default AWS account/region
+* `cdk diff`        compare deployed stack with current state
+* `cdk synth`       emits the synthesized CloudFormation template

--- a/s3-eventbridge-sns-cdk/src/bin/s3-eventbridge-sns-cdk.ts
+++ b/s3-eventbridge-sns-cdk/src/bin/s3-eventbridge-sns-cdk.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import 'source-map-support/register';
+import * as cdk from 'aws-cdk-lib';
+import { S3EventbridgeSnsStack } from '../lib/s3-eventbridge-sns-stack';
+
+const app = new cdk.App();
+new S3EventbridgeSnsStack(app, 's3-eventbridge-sns-stack', {
+  /* If you don't specify 'env', this stack will be environment-agnostic.
+   * Account/Region-dependent features and context lookups will not work,
+   * but a single synthesized template can be deployed anywhere. */
+
+  /* Uncomment the next line to specialize this stack for the AWS Account
+   * and Region that are implied by the current CLI configuration. */
+  // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
+
+  /* Uncomment the next line if you know exactly what Account and Region you
+   * want to deploy the stack to. */
+  // env: { account: '123456789012', region: 'us-east-1' },
+
+  /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
+});

--- a/s3-eventbridge-sns-cdk/src/cdk.json
+++ b/s3-eventbridge-sns-cdk/src/cdk.json
@@ -1,0 +1,60 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/s3-eventbridge-sns-cdk.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ],
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+    "@aws-cdk/core:enablePartitionLiterals": true,
+    "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
+    "@aws-cdk/aws-iam:standardizedServicePrincipals": true,
+    "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
+    "@aws-cdk/aws-iam:importedRoleStackSafeDefaultPolicyName": true,
+    "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
+    "@aws-cdk/aws-route53-patters:useCertificate": true,
+    "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
+    "@aws-cdk/aws-rds:databaseProxyUniqueResourceName": true,
+    "@aws-cdk/aws-codedeploy:removeAlarmsFromDeploymentGroup": true,
+    "@aws-cdk/aws-apigateway:authorizerChangeDeploymentLogicalId": true,
+    "@aws-cdk/aws-ec2:launchTemplateDefaultUserData": true,
+    "@aws-cdk/aws-secretsmanager:useAttachedSecretResourcePolicyForSecretTargetAttachments": true,
+    "@aws-cdk/aws-redshift:columnId": true,
+    "@aws-cdk/aws-stepfunctions-tasks:enableEmrServicePolicyV2": true,
+    "@aws-cdk/aws-ec2:restrictDefaultSecurityGroup": true,
+    "@aws-cdk/aws-apigateway:requestValidatorUniqueId": true,
+    "@aws-cdk/aws-kms:aliasNameRef": true,
+    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true,
+    "@aws-cdk/core:includePrefixInUniqueNameGeneration": true,
+    "@aws-cdk/aws-efs:denyAnonymousAccess": true,
+    "@aws-cdk/aws-opensearchservice:enableOpensearchMultiAzWithStandby": true,
+    "@aws-cdk/aws-lambda-nodejs:useLatestRuntimeVersion": true,
+    "@aws-cdk/aws-efs:mountTargetOrderInsensitiveLogicalId": true
+  }
+}

--- a/s3-eventbridge-sns-cdk/src/jest.config.js
+++ b/s3-eventbridge-sns-cdk/src/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  testEnvironment: 'node',
+  roots: ['<rootDir>/test'],
+  testMatch: ['**/*.test.ts'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest'
+  }
+};

--- a/s3-eventbridge-sns-cdk/src/lib/s3-eventbridge-sns-stack.ts
+++ b/s3-eventbridge-sns-cdk/src/lib/s3-eventbridge-sns-stack.ts
@@ -1,0 +1,46 @@
+import { RemovalPolicy, CfnOutput, Stack, StackProps } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as events from 'aws-cdk-lib/aws-events';
+import { Topic } from 'aws-cdk-lib/aws-sns';
+import { SnsTopic } from 'aws-cdk-lib/aws-events-targets';
+
+export class S3EventbridgeSnsStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+   //Create S3 bucket
+    const bucket = new s3.Bucket(this, 'sample-s3eventbridgesns-bucket', {
+      eventBridgeEnabled: true,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      removalPolicy: RemovalPolicy.DESTROY
+    });
+
+    //Create SNS Topic
+    const mySnsTopic = new Topic(this, 'my-sns-topic');
+    
+    //Create EventBridge Rule
+    const rule = new events.Rule(this, 'rule', {
+      eventPattern: {
+        source: ['aws.s3'],
+        detailType: [
+          'Object Created'
+        ],
+        detail: {
+          bucket: {
+            name: [
+              bucket.bucketName
+            ]
+          }
+        }
+      },
+    });
+
+    //Add SNS Topic as target to EventBridge Rule
+    rule.addTarget(new SnsTopic(mySnsTopic));
+
+    new CfnOutput(this, 'S3BucketName', { value: bucket.bucketName });
+    new CfnOutput(this, 'SnsTopicARN', { value: mySnsTopic.topicArn });
+    new CfnOutput(this, 'EventBridgeRuleARN', { value: rule.ruleArn });
+  }
+}

--- a/s3-eventbridge-sns-cdk/src/package.json
+++ b/s3-eventbridge-sns-cdk/src/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "src",
+  "version": "0.1.0",
+  "bin": {
+    "src": "bin/src.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "test": "jest",
+    "cdk": "cdk"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.4",
+    "@types/node": "20.5.7",
+    "jest": "^29.6.4",
+    "ts-jest": "^29.1.1",
+    "aws-cdk": "2.94.0",
+    "ts-node": "^10.9.1",
+    "typescript": "~5.2.2"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "2.94.0",
+    "constructs": "^10.0.0",
+    "source-map-support": "^0.5.21"
+  }
+}

--- a/s3-eventbridge-sns-cdk/src/test/src.test.ts
+++ b/s3-eventbridge-sns-cdk/src/test/src.test.ts
@@ -1,0 +1,17 @@
+// import * as cdk from 'aws-cdk-lib';
+// import { Template } from 'aws-cdk-lib/assertions';
+// import * as Src from '../lib/src-stack';
+
+// example test. To run these tests, uncomment this file along with the
+// example resource in lib/src-stack.ts
+test('SQS Queue Created', () => {
+//   const app = new cdk.App();
+//     // WHEN
+//   const stack = new Src.SrcStack(app, 'MyTestStack');
+//     // THEN
+//   const template = Template.fromStack(stack);
+
+//   template.hasResourceProperties('AWS::SQS::Queue', {
+//     VisibilityTimeout: 300
+//   });
+});

--- a/s3-eventbridge-sns-cdk/src/tsconfig.json
+++ b/s3-eventbridge-sns-cdk/src/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": [
+      "es2020",
+      "dom"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": [
+      "./node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "cdk.out"
+  ]
+}


### PR DESCRIPTION
*Issue #1636, if available:*

*Description of changes:*
* Adding a new Serverless pattern S3-Eventbridge-SNS using CDK.
* This pattern deploys one S3 Bucket, SNS Topic, EventBridge rule and a Lambda function which is used internally by CDK to apply configuration notifications on the bucket. 
* This pattern uses AWS CDK to setup an S3 bucket that publishes events to Amazon EventBridge. When an object is uploaded to the bucket, the EventBridge is triggered and a SNS notification is sent to subscribers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
