### PR TITLE
New serverless pattern  - DynamoDB Streams to SQS using EventBridge Pipes

### DIFF
--- a/eventbridge-pipes-dynamodbstream-to-sqs-serverless/README.md
+++ b/eventbridge-pipes-dynamodbstream-to-sqs-serverless/README.md
@@ -1,0 +1,82 @@
+# DynamoDB Stream to SQS queue using EventBridge Pipes
+
+This serverless pattern demonstrates how to send events from DynamoDB Stream to SQS using EventBridge Pipes.
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git CLI](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) installed
+* [NodeJS](https://nodejs.org/en/download/) (LTS version) installed
+* [Serverless Framework CLI](https://www.serverless.com/framework/docs/getting-started) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+
+    ``` sh
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ``` sh
+    cd serverless-patterns/eventbridge-pipes-dynamodbstream-to-sqs-serverless
+    ```
+1. From the command line, use npm/yarn to install the development dependencies:
+    ``` sh
+    npm install
+    ```
+    -or-
+    ``` sh
+    yarn install
+    ```
+1. From the command line, use Serverless Framework to deploy the AWS resources for the pattern as specified in the serverless.yml file:
+    ``` sh
+    serverless deploy --verbose
+    ```
+    The above command will deploy resources to `ap-south-1` region by default. You can override the target region with `--region <region>` CLI option, e.g.
+    ``` sh
+    serverless deploy --verbose --region us-west-2
+    ```
+
+## How it works
+
+This template will create a DynamoDB table, EventBridge Pipe and a SQS queue. DynamoDB Stream is enabled in the DynamoDB table.
+
+Whenever an item is inserted in DynamoDB table, the stream picks up the event & send it to EventBridge Pipes. The EventBridge Pipes Filter function in the Pipes filters the event and passes to the next states accordingly. For this example pattern, it checks for `INSERT` events & passes it to Enrichment Lambda function if found one. The Lambda function makes some logs regarding to event & event name & finally passes it to the Target SQS queue. In Target SQS queue, when new messages are polled, the event information information can be retrieved. 
+
+## Testing
+
+Once this stack is deployed in your AWS account, copy the `DynamoDBSourceTableName` value from the output.
+
+Then, insert one record to the DynamoDB table as follows:
+```sh
+    aws dynamodb put-item \ 
+    --table-name DynamoDBSourceTable \
+    --item \
+        '{"Album": {"S": "Item-One"}}'
+```
+When you check the Target SQS queue, you can see the message from DynamoDB stream is available in the SQS queue.
+Optional - Under the Enrichment Lambda Function of EventBrudge Pipes, you can see the CloudWatch logs for the event information and eventName.
+
+
+## Cleanup
+1. Delete the stack
+    ```sh
+    serverless remove --verbose
+    ```
+1. Confirm the stack has been deleted
+    ```sh
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'dynamodbstream-ebpipes-sqs-serverless-prod')].StackStatus"
+    ```
+    Expected output
+    ```json
+    [
+        "DELETE_COMPLETE"
+    ]
+    ```
+    NOTE: You might need to add `--region <region>` option to AWS CLI command if you AWS CLI default region does not match the one, that you used for the Serverless Framework deployment.
+----
+Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0

--- a/eventbridge-pipes-dynamodbstream-to-sqs-serverless/example-pattern.json
+++ b/eventbridge-pipes-dynamodbstream-to-sqs-serverless/example-pattern.json
@@ -1,0 +1,60 @@
+{
+  "title": "DynamoDB Stream to SQS queue using EventBridge Pipes",
+  "description": "Serverless pattern that sends events from DynamoDB Stream to SQS using EventBridge Pipes. Implemented with serverless framework",
+  "language": "Node.js",
+  "level": "200",
+  "framework": "Serverless Framework",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "This serverless pattern demonstrates how to send events from DynamoDB Stream to SQS using EventBridge Pipes. Whenever an item is inserted in DynamoDB table, the stream picks up the event & send it to EventBridge Pipes. ",
+      "The EventBridge Pipes Filter function in the Pipes filters the event and passes to the next states accordingly. For this example pattern, it checks for INSERT events & passes it to Enrichment Lambda function if found one. The Lambda function makes some logs regarding to event & event name & finally passes it to the Target SQS queue.",
+      "The intermediate Filter & Enrichment Lambda functions are optional & can be skipped as part of editing the implementation."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/sfn-athena-cdk-python",
+      "templateURL": "serverless-patterns/eventbridge-pipes-dynamodbstream-to-sqs-serverless",
+      "projectFolder": "eventbridge-pipes-dynamodbstream-to-sqs-serverless",
+      "templateFile": "eventbridge-pipes-dynamodbstream-to-sqs-serverless/serverless.yml"
+    }
+  },
+  "resources": {
+    "headline": "Additional resources",
+    "bullets": [
+      {
+        "text": "AWS EventBridge Pipes",
+        "link": "https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-pipes.html"
+      },
+      {
+        "text": "serverless-pipes - Serverless Framework plugin",
+        "link": "https://www.npmjs.com/package/serverless-pipes"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "<code>serverless deploy --verbose</code>"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the GitHub repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "<code>serverless remove --verbose</code>."
+    ]
+  },
+  "authors": [
+    {  
+      "headline": "Presented by Anjali Modi, Senior Software Engineer, Distinction-Dev",
+      "name": "Anjali Modi",
+      "image": "https://en.gravatar.com/userimage/147444966/1aad7adb8eca7d94a2f25dbe079bec81.jpeg?size=256",
+      "bio": "Anjali Modi is a Senior Software Engineer, passionate for developing Serverless solutions at Distinction-Dev, India",
+      "linkedin":"https://www.linkedin.com/in/anjali-modi-068045119/"
+    }
+  ]
+}

--- a/eventbridge-pipes-dynamodbstream-to-sqs-serverless/index.js
+++ b/eventbridge-pipes-dynamodbstream-to-sqs-serverless/index.js
@@ -1,0 +1,9 @@
+"use strict";
+
+module.exports.handler = async(event) => {
+    // TODO implement
+    console.log("enrichment function called")
+    console.log(JSON.stringify(event[0]));
+    console.log("Event Name: ", event[0]?.eventName)
+    return event
+};

--- a/eventbridge-pipes-dynamodbstream-to-sqs-serverless/package.json
+++ b/eventbridge-pipes-dynamodbstream-to-sqs-serverless/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "eventbridge-pipes-dynamodbstream-to-sqs-serverless",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "devDependencies": {
+    "serverless": "^3.34.0"
+  },
+  "dependencies": {
+    "serverless-pipes": "^1.0.0"
+  }
+}

--- a/eventbridge-pipes-dynamodbstream-to-sqs-serverless/serverless.yml
+++ b/eventbridge-pipes-dynamodbstream-to-sqs-serverless/serverless.yml
@@ -1,0 +1,80 @@
+service: dynamodbstream-ebpipes-sqs-serverless
+frameworkVersion: '^3.28.1'
+useDotenv: true
+
+custom:
+# specify the region using --region flag while deploying the stack, else the default region ap-south-1 will be chosen
+  region: ${opt:region, "ap-south-1"}
+
+provider:
+  name: aws
+  runtime: nodejs16.x
+  memorySize: 256
+  timeout: 30
+  # override the default stage (dev) to be `prod`, or you can use the `--stage` CLI option
+  stage: ${opt:stage, "prod"}
+  region: ${self:custom.region}
+
+
+plugins:
+# creates eventbridge-pipes using the below serverless framework plugin.
+  - serverless-pipes
+
+functions:
+  pipes-enrichment:
+    handler: index.handler
+
+
+# Serverless Framework plugin called as "pipes", used to create EventBridge Pipes 
+# by providing the required event sources, targets and other parameters as needed.
+# Refer `https://github.com/distinction-dev/serverless-pipes` for its usage.
+pipes:
+  testPatternPipes:
+    enabled: true
+    source:
+      dynamodb:
+        arn:
+          Fn::GetAtt: [DynamoDBSourceTable, StreamArn]
+        startingPosition: TRIM_HORIZON
+    target:
+      sqs:
+        arn:
+          Fn::GetAtt: [TargetSQSQueue, Arn]
+    enrichment: 
+      name: pipes-enrichment
+    filter:
+      - Pattern: "{ \"eventName\": [ \"INSERT\" ]}"
+    iamRolePipes:
+      type: "individual"
+    
+
+# creates the source DynamoDB-Stream, target SQS resources & outputs their ARN
+resources:
+  Resources:
+    DynamoDBSourceTable: 
+      Type: AWS::DynamoDB::Table
+      Properties:
+        AttributeDefinitions:
+          - AttributeName: 'Album'
+            AttributeType: 'S'
+        KeySchema: 
+          - AttributeName: 'Album'
+            KeyType: 'HASH'
+        ProvisionedThroughput: 
+          ReadCapacityUnits: 5
+          WriteCapacityUnits: 5
+        StreamSpecification:
+          StreamViewType: 'NEW_AND_OLD_IMAGES'
+        TableName: 'DynamoDBSourceTable'
+    TargetSQSQueue:
+      Type: AWS::SQS::Queue
+      Properties:
+        QueueName: 'TargetSQSQueue'
+  Outputs:
+      DynamoDBSourceTableName:
+        Value:
+          Ref: DynamoDBSourceTable
+      TargetSQSQueueArn:
+        Value: 
+          Fn::GetAtt: [TargetSQSQueue, Arn]
+


### PR DESCRIPTION
Description of changes:
Created a new serverless framework pattern for DynamoDB Streams to SQS using EventBridge Pipes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.