### PR TITLE
New pattern: Eventbridge API Destination example for OAuth API integration

### DIFF
--- a/eventbridge-api-destinations/11-oauth-api/template.yaml
+++ b/eventbridge-api-destinations/11-oauth-api/template.yaml
@@ -1,0 +1,162 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Create an API Destination in EventBridge with OAuth Credentials
+
+Parameters:
+  ExternalAPIURL:
+    Type: String
+    Description: Enter External API URL
+    Default: '<>'
+  ExternalAuthEndpoint:
+    Type: String
+    Description: Enter Authorization Endpoint
+    Default: '<>'
+  ExternalAPIClientID:
+    Type: String
+    Description: Enter OAuth Client ID
+    Default: '<>'
+  ExternalAPIClientSecret:
+    Type: String
+    NoEcho: True
+    Description: Enter OAuth Client Secret
+    Default: '<>'
+  ExternalAPIUserName:
+    Type: String
+    Description: Enter OAuth Username
+    Default: '<>'
+  ExternalAPIPassword:
+    Type: String
+    NoEcho: True
+    Description: Enter OAuth Password  
+    Default: '<>'
+
+Resources:
+  MyEventBus:
+    Type: AWS::Events::EventBus
+    Properties:
+      Name: "ExternalOAuthEventBus"
+      
+  ConnectionSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: "ExternalOAuthCredentials"
+      Description: "OAuth connection credential secret"   
+      SecretString: !Sub >-
+        {"ClientID": "${ExternalAPIClientID}", "ClientSecret": "${ExternalAPIClientSecret}", "Username": "${ExternalAPIUserName}", "Password": "${ExternalAPIPassword}"}      
+
+  MyConnection:
+    Type: AWS::Events::Connection
+    Properties:
+      AuthorizationType: 'OAUTH_CLIENT_CREDENTIALS'
+      Description: 'My connection with an OAuth2 credentials'
+      AuthParameters:
+        OAuthParameters: 
+          AuthorizationEndpoint: !Ref ExternalAuthEndpoint
+          ClientParameters: 
+            ClientID: '{{resolve:secretsmanager:ExternalOAuthCredentials:SecretString:ClientID}}'
+            ClientSecret: '{{resolve:secretsmanager:ExternalOAuthCredentials:SecretString:ClientSecret}}'
+          HttpMethod: 'POST'
+          OAuthHttpParameters: 
+            HeaderParameters:
+              - Key: 'Content_Type'
+                Value: 'application/x-www-form-urlencoded'
+                IsValueSecret: false
+            BodyParameters:
+              - Key: 'grant_type'
+                Value: 'password'
+                IsValueSecret: true
+              - Key: 'username'
+                Value: '{{resolve:secretsmanager:ExternalOAuthCredentials:SecretString:Username}}'
+                IsValueSecret: true
+              - Key: 'password'
+                Value: '{{resolve:secretsmanager:ExternalOAuthCredentials:SecretString:Password}}'
+                IsValueSecret: true          
+    DependsOn: ConnectionSecret
+              
+
+  MyApiDestination:
+    Type: AWS::Events::ApiDestination
+    Properties:
+      Name: 'ExternalApiDestination'
+      ConnectionArn: !GetAtt MyConnection.Arn
+      InvocationEndpoint: !Ref ExternalAPIURL
+      HttpMethod: POST
+      InvocationRateLimitPerSecond: 10
+      
+  EventBridgeTargetRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - events.amazonaws.com
+            Action:
+              - sts:AssumeRole      
+      Policies:
+        - PolicyName: AllowAPIdestinationAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: 'events:InvokeApiDestination'
+                Resource: !GetAtt MyApiDestination.Arn
+              - Effect: Allow
+                Action:
+                  - secretsmanager:CreateSecret
+                  - secretsmanager:UpdateSecret
+                  - secretsmanager:DescribeSecret
+                  - secretsmanager:DeleteSecret
+                  - secretsmanager:GetSecretValue
+                  - secretsmanager:PutSecretValue
+                Resource:
+                  - arn:aws:secretsmanager:*:*:secret:events!connection/*               
+                
+  MyDLQueue: 
+    Type: AWS::SQS::Queue
+
+  EventRule: 
+    Type: AWS::Events::Rule
+    Properties: 
+      Description: "EventRule"
+      State: "ENABLED"
+      EventBusName: !Ref MyEventBus
+      EventPattern: 
+        source:
+          - "MyTestApp"
+        detail-type:
+          - "MyTestMessage"
+      Targets: 
+        - Arn: !GetAtt MyApiDestination.Arn
+          RoleArn: !GetAtt EventBridgeTargetRole.Arn
+          Id: "MyAPIdestination"
+          InputPath: "$.detail.responsePayload"
+          DeadLetterConfig:
+            Arn: !GetAtt MyDLQueue.Arn
+
+Outputs:
+  MyEventBusName:
+    Description: Application EventBus Name
+    Value: !Ref MyEventBus
+
+  MyEventBusArn:
+    Description: Application EventBus ARN
+    Value: !GetAtt MyEventBus.Arn
+
+  MyConnectionName:
+    Value: !Ref MyConnection
+  MyConnectionArn:
+    Value: !GetAtt MyConnection.Arn        
+
+  MyApiDestinationName:
+    Value: !Ref MyApiDestination
+  MyApiDestinationArn:
+    Value: !GetAtt MyApiDestination.Arn
+
+  EventBridgeTargetRoleArn:
+    Value: !GetAtt EventBridgeTargetRole.Arn
+
+  MyDLQueue:
+    Value: !GetAtt MyDLQueue.Arn

--- a/eventbridge-api-destinations/11-oauth-api/testEvent.json
+++ b/eventbridge-api-destinations/11-oauth-api/testEvent.json
@@ -1,0 +1,8 @@
+[
+    {
+        "DetailType": "MyTestMessage",
+        "EventBusName": "ExternalOAuthEventBus",
+        "Source": "MyTestApp",
+        "Detail": "{\"event\":\"Payment success\"}"
+    }
+  ]

--- a/eventbridge-api-destinations/README.md
+++ b/eventbridge-api-destinations/README.md
@@ -23,6 +23,7 @@ Important: this application uses various AWS services and there are costs associ
 * To run example #7, an account with [DataDog](hhttps://www.datadoghq.com). Follow the instructions to [Add an API key or client token](https://docs.datadoghq.com/account_management/api-app-keys/#add-an-api-key-or-client-token) and note the api key.
 * To run example #9, an account with [Shopify](https://www.shopify.com/). Follow the instructions to [Create an app and configure Admin API Access scopes](https://shopify.dev/apps/auth/admin-app-access-tokens#step-1-create-and-install-the-app). Make sure to note the Admin Key.
 * To run example #10, an account with [Stripe](https://dashboard.stripe.com/login). Follow the instructions to [Set up your development environment](https://stripe.com/docs/development/quickstart) and note the api key.
+* To run example #11, an account with [Salesforce](https://login.salesforce.com/). Follow the Prerequisites to [Create an app and configure security token](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-tutorial-salesforce.html). Make sure to note the Authorization endpoint, Client ID, Client Secret and OAuth Http Parameters Key.
 ## Deployment Instructions
 
 1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
@@ -43,6 +44,7 @@ Important: this application uses various AWS services and there are costs associ
 - To run the Datadog API Destination example, cd to `7-datadog`.
 - To run the Shopify API Destination example, cd to `9-shopify`.
 - To run the Stripe API Destination example, cd to `10-stripe`.
+- To run the API Destination with OAuth credentials example, cd to `11-oauth-api`.
 1. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
     ```
     sam deploy --guided
@@ -70,7 +72,8 @@ aws events put-events --entries file://testEvent.json
 7. For the freshdesk example use the testEvent.json within the 6-freshdesk directory
 8. For the datadog example use the testEvent.json within the 7-datadog directory
 9. For the shopify example use the testEvent.json within the 9-shopify directory
-10. For the shopify example use the testEvent.json within the 10-stripe directory
+10. For the stripe example use the testEvent.json within the 10-stripe directory
+11. For the OAuth example use the testEvent.json within the 11-oauth-api directory
 ```
 aws events put-events --entries file://3-sumologic/testEvent.json
 ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This pattern creates an Amazon Eventbridge API Destination to invoke APIs protected by OAuth authorization. Eventbrige supports Basic, OAuth, and API Key authentication. This pattern exchanges OAuth Client Credentials - Authorization endpoint, HTTP method, Client ID, and Client secret for an access token and then manages it securely using AWS Secrets Manager. The template also creates a SQS dead letter queue to track any failures during API invocation. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
