### PR TITLE
New serverless pattern - Amazon Aurora Serverless V2 Primary to Secondary Global Database

### DIFF
--- a/aurora-serverless-global-db-cdk/.gitignore
+++ b/aurora-serverless-global-db-cdk/.gitignore
@@ -1,0 +1,10 @@
+*.js
+!jest.config.js
+*.d.ts
+node_modules
+.DS_Store
+package-lock.json
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/aurora-serverless-global-db-cdk/.gitignore
+++ b/aurora-serverless-global-db-cdk/.gitignore
@@ -1,4 +1,3 @@
-*.js
 !jest.config.js
 *.d.ts
 node_modules

--- a/aurora-serverless-global-db-cdk/.npmignore
+++ b/aurora-serverless-global-db-cdk/.npmignore
@@ -1,0 +1,6 @@
+*.ts
+!*.d.ts
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/aurora-serverless-global-db-cdk/README.md
+++ b/aurora-serverless-global-db-cdk/README.md
@@ -1,0 +1,115 @@
+# Amazon Aurora Serverless V2 Primary to Secondary Global Database
+The pattern creates a serverless global database cluster enabling data replication from the primary to secondary cluster. The regional primary cluster contains a serverless db instance supporting both writes and reads. The regional secondary cluster contains a serverless db instance supporting only reads. In the unlikely event of a regional degradation or outage, the secondary region can be promoted to read and write capabilities in less than 1 minute. Also the pattern adopts the multiple stack capability of CDK to provision the resources across the primary and secondary regions. You can deploy each stack indvidually or deploy all the stacks using --all option.
+
+Learn more about this pattern at Serverless Land Patterns: << Add the live URL here >>
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [Node and NPM](https://nodejs.org/en/download/) installed.
+* [AWS CDK](https://docs.aws.amazon.com/cdk/latest/guide/cli.html) installed and configured
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+2. Change directory to the pattern directory:
+    ```
+    cd aurora-serverless-global-db-cdk
+    ```
+3. Install dependencies:
+    ```
+    npm install
+    ```
+4. Configure AWS CDK to bootstrap the AWS account, primary region and secondary region :
+    ```
+    cdk bootstrap 111111111111/eu-west-1
+    cdk bootstrap 111111111111/eu-west-2
+    ```
+5. From the command line, use AWS CDK to deploy the all the stacks synthesized: 
+    ```
+    cdk deploy --all
+    ```
+    Alternatively you can also deploy each stack individually. From the command line, use AWS CDK to deploy each stack: 
+    ```
+    cdk deploy aurora-global-cluster
+    cdk deploy primary-cluster
+    cdk deploy secondary-cluster
+    cdk deploy primary-test-app
+    cdk deploy secondary-test-app
+    ```
+7. Note the outputs from the CDK deployment process. These contain the primary and secondary URLs which are used for testing.
+
+## How it works
+
+- The template in this pattern synthesizes five stacks for deployment using the multiple stack approach of CDK. 
+- The first stack named aurora-global-cluster creates the Aurora Global Cluster. 
+- The second stack named primary-cluster deploys the primary cluster with a serverless v2 instance in the primary region defined.
+- The third stack named secondary-cluster deploys the secondary cluster with a serverless v2 instance in the secondary region defined.
+- The fourth and fifth stack named primary-test-app and secondary-test-app deploys a fargate container with a nodejs app for testing the global database tables. 
+- The primary cluster supports both write and read operations. The secondary cluster supports read operation only.
+- Once you deploy all the stacks, you have built a global database that automatically replicates data from the primary to the secondary region.
+
+## Testing
+
+Note down the primary-test-app.FargateServiceURL and secondary-test-app.FargateServiceURL values from the CDK output and update them in each of the test commands below. 
+
+1.  Initialize the Global Database by creating a table 
+
+    ```
+    curl primary-test-app.FargateServiceURL/init
+    ```
+
+    Expected Response :
+    "Task table created.."
+
+2. Write a task into the Primary Cluster 
+    ```
+    curl primary-test-app.FargateServiceURL/tasks -H 'Content-Type: application/json' -d '{"name":"Task1","status":"created"}'
+    ```
+    Expected Response : Task added with ID: 1
+3. Read the tasks from the Secondary cluster 
+    ```
+    curl secondary-test-app.FargateServiceURL/tasks 
+    ```
+    Expected Response : 
+    [{"id":1,"name":"Task1","status":"created"}]
+
+4. Attempt to write a task into the Secondary cluster 
+    ```
+    curl secondary-test-app.FargateServiceURL/tasks -H 'Content-Type: application/json' -d '{"name":"Task1","status":"created"}'
+    ```
+    Expected Response : error : cannot execute INSERT in a read-only transaction
+    
+    Note : You can enable Write forwarding feature to continue to use the Secondary cluster endpoint for write transactions as well. 
+
+5. You can also try to update and delete the task on the Primary cluster 
+    ```
+    curl -X PUT primary-test-app.FargateServiceURL/tasks/1 -H 'Content-Type: application/json' -d '{"name":"Task1","status":"in-progress"}'
+
+    curl -X DELETE primary-test-app.FargateServiceURL/tasks/1
+
+    ```
+6. Check if the task is deleted from the Secondary cluster 
+    ```
+    curl secondary-test-app.FargateServiceURL/tasks 
+    ```
+    Expected Response : 
+    []
+
+## Cleanup
+ 
+1. Delete the stack
+    ```
+    cdk destroy --all 
+    ```
+----
+Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/aurora-serverless-global-db-cdk/README.md
+++ b/aurora-serverless-global-db-cdk/README.md
@@ -71,7 +71,7 @@ Note down the primary-test-app.FargateServiceURL and secondary-test-app.FargateS
 
 2. Write a task into the Primary Cluster 
     ```
-    curl primary-test-app.FargateServiceURL/tasks -H 'Content-Type: application/json' -d '{"name":"Task1","status":"created"}'
+    curl -X POST primary-test-app.FargateServiceURL/tasks -H 'Content-Type: application/json' -d '{"name":"Task1","status":"created"}'
     ```
     Expected Response : Task added with ID: 1
 3. Read the tasks from the Secondary cluster 
@@ -83,7 +83,7 @@ Note down the primary-test-app.FargateServiceURL and secondary-test-app.FargateS
 
 4. Attempt to write a task into the Secondary cluster 
     ```
-    curl secondary-test-app.FargateServiceURL/tasks -H 'Content-Type: application/json' -d '{"name":"Task1","status":"created"}'
+    curl -X POST secondary-test-app.FargateServiceURL/tasks -H 'Content-Type: application/json' -d '{"name":"Task1","status":"created"}'
     ```
     Expected Response : error : cannot execute INSERT in a read-only transaction
     

--- a/aurora-serverless-global-db-cdk/bin/aurora-global-db-multistack.ts
+++ b/aurora-serverless-global-db-cdk/bin/aurora-global-db-multistack.ts
@@ -1,0 +1,50 @@
+import { App } from 'aws-cdk-lib';
+import { AuroraGlobalClusterStack } from '../lib/aurora-global-cluster-stack';
+import { AuroraRegionalClusterStack } from '../lib/aurora-regional-cluster-stack';
+import { FargateTestAppStack } from '../lib/fargate-test-app-stack';
+
+const app = new App();
+
+const account = app.node.tryGetContext('account') || process.env.CDK_INTEG_ACCOUNT || process.env.CDK_DEFAULT_ACCOUNT;
+const primaryRegion = { account: account, region: 'eu-west-1' };
+const secondaryRegion = { account: account, region: 'eu-west-2' };
+
+const globalCluster = new AuroraGlobalClusterStack(app, "aurora-global-cluster", {
+    env: primaryRegion
+});
+
+const primaryclusterstack = new AuroraRegionalClusterStack(app, `primary-cluster`, {
+    env: primaryRegion, cfnGlobalCluster: globalCluster.cfnGlobalCluster, isPrimary: true
+});
+
+const secondaryclusterstack = new AuroraRegionalClusterStack(app, `secondary-cluster`, {
+    env: secondaryRegion, cfnGlobalCluster: globalCluster.cfnGlobalCluster, isPrimary: false
+});
+
+primaryclusterstack.addDependency(globalCluster);
+secondaryclusterstack.addDependency(primaryclusterstack)
+
+const primarytestappstack = new FargateTestAppStack(app, `primary-test-app`, {
+    env: primaryRegion,
+    endpoint: primaryclusterstack.endpoint,
+    port: primaryclusterstack.port,
+    vpc: primaryclusterstack.vpc,
+    isPrimary: true,
+    region: primaryclusterstack.region,
+    dbSecurityGroupId: primaryclusterstack.dbSecurityGroupId
+});
+
+const secondarytestappstack = new FargateTestAppStack(app, `secondary-test-app`, {
+    env: secondaryRegion,
+    endpoint: secondaryclusterstack.endpoint,
+    port: secondaryclusterstack.port,
+    vpc: secondaryclusterstack.vpc,
+    isPrimary: false,
+    region: primaryclusterstack.region,
+    dbSecurityGroupId: secondaryclusterstack.dbSecurityGroupId
+});
+
+primarytestappstack.addDependency(primaryclusterstack);
+secondarytestappstack.addDependency(secondaryclusterstack);
+
+app.synth();

--- a/aurora-serverless-global-db-cdk/cdk.json
+++ b/aurora-serverless-global-db-cdk/cdk.json
@@ -1,0 +1,57 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/aurora-global-db-multistack.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ],
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+    "@aws-cdk/core:enablePartitionLiterals": true,
+    "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
+    "@aws-cdk/aws-iam:standardizedServicePrincipals": true,
+    "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
+    "@aws-cdk/aws-iam:importedRoleStackSafeDefaultPolicyName": true,
+    "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
+    "@aws-cdk/aws-route53-patters:useCertificate": true,
+    "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
+    "@aws-cdk/aws-rds:databaseProxyUniqueResourceName": true,
+    "@aws-cdk/aws-codedeploy:removeAlarmsFromDeploymentGroup": true,
+    "@aws-cdk/aws-apigateway:authorizerChangeDeploymentLogicalId": true,
+    "@aws-cdk/aws-ec2:launchTemplateDefaultUserData": true,
+    "@aws-cdk/aws-secretsmanager:useAttachedSecretResourcePolicyForSecretTargetAttachments": true,
+    "@aws-cdk/aws-redshift:columnId": true,
+    "@aws-cdk/aws-stepfunctions-tasks:enableEmrServicePolicyV2": true,
+    "@aws-cdk/aws-ec2:restrictDefaultSecurityGroup": true,
+    "@aws-cdk/aws-apigateway:requestValidatorUniqueId": true,
+    "@aws-cdk/aws-kms:aliasNameRef": true,
+    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true,
+    "@aws-cdk/core:includePrefixInUniqueNameGeneration": true,
+    "@aws-cdk/aws-opensearchservice:enableOpensearchMultiAzWithStandby": true
+  }
+}

--- a/aurora-serverless-global-db-cdk/example-pattern.json
+++ b/aurora-serverless-global-db-cdk/example-pattern.json
@@ -1,0 +1,57 @@
+{
+  "title": "Amazon Aurora Serverless Primary to Secondary Global Database",
+  "description": "Create an Aurora Serverless Global database to replicate across regions",
+  "language": "Typescript",
+  "level": "300",
+  "framework": "CDK",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "The pattern provisions an Amazon Aurora serverless v2 global database enabling data replication from the primary to secondary region. The regional primary cluster contains a serverless db instance and supports both writes and reads. The regional secondary cluster contains a serverless db instance and supports only reads. In the unlikely event of a regional degradation or outage, the secondary region can be promoted to read and write capabilities in less than 1 minute",
+      "Also the pattern adopts the multiple stack capability of CDK to provision the resources across the primary and secondary regions."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/aurora-serverless-global-db-cdk",
+      "templateURL": "serverless-patterns/aurora-serverless-global-db-cdk",
+      "projectFolder": "aurora-serverless-global-db-cdk",
+      "templateFile": "aurora-serverless-global-db-cdk/lib/aurora-regional-cluster-stack.ts"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "Using Aurora Serverless V2",
+        "link": "https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.html"
+      },
+      {
+        "text": "Amazon Aurora Global Database",
+        "link": "https://aws.amazon.com/rds/aurora/global-database/"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "cdk deploy --all"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the GitHub repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>cdk destroy --all</code>."
+    ]
+  },
+  "authors": [
+    {
+      "name": "Nihilson Gnanadason",
+      "image": "https://drive.google.com/file/d/1m82LvtdoipI9nI_q2G6qoRGpZ36JNzHU/view?usp=sharing",
+      "bio": "Nihilson is a Sr.Solutions Architect at AWS working with ISVs in the UK to build, run, and scale their software products on AWS.",
+      "linkedin": "https://www.linkedin.com/in/nihilson/"
+    }
+  ]
+}

--- a/aurora-serverless-global-db-cdk/example-pattern.json
+++ b/aurora-serverless-global-db-cdk/example-pattern.json
@@ -1,7 +1,7 @@
 {
   "title": "Amazon Aurora Serverless Primary to Secondary Global Database",
   "description": "Create an Aurora Serverless Global database to replicate across regions",
-  "language": "Typescript",
+  "language": "TypeScript",
   "level": "300",
   "framework": "CDK",
   "introBox": {

--- a/aurora-serverless-global-db-cdk/fargate/Dockerfile
+++ b/aurora-serverless-global-db-cdk/fargate/Dockerfile
@@ -1,0 +1,9 @@
+FROM --platform=linux/amd64 node:16-alpine
+WORKDIR /usr
+COPY package.json ./
+COPY src ./src
+RUN npm install
+RUN npm install pg
+COPY . .
+EXPOSE 80
+CMD ["npm","start"]

--- a/aurora-serverless-global-db-cdk/fargate/package.json
+++ b/aurora-serverless-global-db-cdk/fargate/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "fargate",
+  "version": "1.0.0",
+  "description": "Fargate ECS container to run an express app",
+  "main": "src/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node src/index.js"
+  },
+  "author": "nihilson",
+  "license": "ISC",
+  "dependencies": {
+    "express": "^4.18.2",
+    "pg": "^8.11.3",
+    "aws-sdk": "latest"
+  }
+}

--- a/aurora-serverless-global-db-cdk/fargate/src/index.js
+++ b/aurora-serverless-global-db-cdk/fargate/src/index.js
@@ -1,0 +1,112 @@
+const express = require("express");
+const app = express();
+const port = 80;
+
+var AWS = require('aws-sdk');
+const Pool = require('pg').Pool
+
+var client = new AWS.SecretsManager({
+  region: process.env.REGION
+});
+
+var pool;
+
+client.getSecretValue({ SecretId: 'aurora-serverless-global-db-secret' }, function (err, data) {
+  if (err) {
+    console.log(err, err.stack);
+  }
+  else {
+    secretParams = JSON.parse(data.SecretString);
+    pool = new Pool({
+      user: secretParams.username,
+      host: process.env.DB_HOST,
+      database: 'sample',
+      password: secretParams.password,
+      port: process.env.DB_PORT
+    });
+  }
+});
+
+app.use(express.urlencoded({ extended: false }));
+app.use(express.json());
+
+const errorHandler = (error, request, response) => {
+  console.log(`error ${error.message}`)
+  const status = error.status || 400
+  response.status(status).send(`error : ${error.message}`)
+}
+
+app.get('/', (req, res) => {
+  res.status(200).send('Hello from Fargate Test App :-)');
+});
+
+
+app.get('/init', (req, res) => {
+  pool.query('CREATE TABLE IF NOT EXISTS tasks ( ID SERIAL PRIMARY KEY,name VARCHAR(30), status VARCHAR(30))', (error, results) => {
+    if (error) {
+      return errorHandler(error, req, res)
+    }
+    res.status(200).json('Task table created..')
+  })
+
+});
+
+app.get('/tasks', (req, res) => {
+  pool.query('SELECT * FROM tasks ORDER BY id ASC', (error, results) => {
+    if (error) {
+      return errorHandler(error, req, res)
+    }
+    res.status(200).json(results.rows)
+  })
+});
+
+app.get('/tasks/:id', (req, res) => {
+  const id = parseInt(req.params.id)
+  pool.query('SELECT * FROM tasks WHERE id = $1', [id], (error, results) => {
+    if (error) {
+      return errorHandler(error, req, res)
+    }
+    res.status(200).json(results.rows)
+  })
+});
+
+app.post('/tasks', (req, res) => {
+  const { name, status } = req.body
+  pool.query('INSERT INTO tasks (name, status) VALUES ($1, $2) RETURNING id', [name, status], (error, results) => {
+    if (error) {
+      return errorHandler(error, req, res)
+    }
+    console.log(results)
+    res.status(201).send(`Task added with ID: ${results.rows[0].id}`)
+  })
+
+});
+
+app.put('/tasks/:id', (req, res) => {
+  const id = parseInt(req.params.id)
+  const { name, status } = req.body
+  pool.query('UPDATE tasks SET name = $1, status = $2 WHERE id = $3', [name, status, id], (error, results) => {
+    if (error) {
+      return errorHandler(error, req, res)
+    }
+    res.status(200).send(`Task modified with ID: ${id}`)
+  }
+  )
+
+});
+
+app.delete('/tasks/:id', (req, res) => {
+  const id = parseInt(req.params.id)
+  pool.query('DELETE FROM tasks WHERE id = $1', [id], (error, results) => {
+    if (error) {
+      return errorHandler(error, req, res)
+    }
+    res.status(200).send(`Task deleted with ID: ${id}`)
+  })
+});
+
+app.use(errorHandler)
+
+app.listen(port, () => {
+  console.log(`server started at http://localhost:${port}`);
+});

--- a/aurora-serverless-global-db-cdk/jest.config.js
+++ b/aurora-serverless-global-db-cdk/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  testEnvironment: 'node',
+  roots: ['<rootDir>/test'],
+  testMatch: ['**/*.test.ts'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest'
+  }
+};

--- a/aurora-serverless-global-db-cdk/lib/aurora-global-cluster-stack.ts
+++ b/aurora-serverless-global-db-cdk/lib/aurora-global-cluster-stack.ts
@@ -1,0 +1,24 @@
+import { Construct } from 'constructs';
+import { StackProps, Stack } from 'aws-cdk-lib'
+import { CfnGlobalCluster } from 'aws-cdk-lib/aws-rds';
+
+export class AuroraGlobalClusterStack extends Stack {
+    public readonly cfnGlobalCluster: CfnGlobalCluster;
+    constructor(scope: Construct, id: string, props?: StackProps) {
+        super(scope, id, props);
+
+        // Aurora Global Cluster
+        const cfnGlobalCluster = new CfnGlobalCluster(this, 'AuroraGlobalCluster', {
+            engine: 'aurora-postgresql',
+            engineVersion: '14.6',
+            globalClusterIdentifier: 'aurora-serverless-global-cluster',
+        });
+
+        this.cfnGlobalCluster = cfnGlobalCluster;
+    }
+}
+
+export interface GlobalClusterProps extends StackProps {
+    cfnGlobalCluster: CfnGlobalCluster,
+    isPrimary?: boolean
+}

--- a/aurora-serverless-global-db-cdk/lib/aurora-regional-cluster-stack.ts
+++ b/aurora-serverless-global-db-cdk/lib/aurora-regional-cluster-stack.ts
@@ -1,0 +1,116 @@
+import { Construct } from 'constructs';
+import { Stack, StackProps, aws_secretsmanager as sm, CfnDynamicReference, CfnDynamicReferenceService  } from 'aws-cdk-lib'
+import { SubnetType, Vpc, SecurityGroup, IpAddresses } from 'aws-cdk-lib/aws-ec2';
+import { AuroraCapacityUnit, CfnDBCluster, CfnDBInstance, CfnDBSubnetGroup } from 'aws-cdk-lib/aws-rds';
+import { GlobalClusterProps } from './aurora-global-cluster-stack';
+
+export class AuroraRegionalClusterStack extends Stack {
+  public readonly endpoint: string;
+  public readonly port: string;
+  public readonly vpc: Vpc;
+  public readonly region: string;
+  public readonly dbSecurityGroupId: string;
+  constructor(scope: Construct, id: string, props: GlobalClusterProps) {
+    super(scope, id, props);
+
+    const cfnGlobalCluster = props.cfnGlobalCluster;
+    const databasename = 'sample';
+
+    // VPC 
+    const vpc = new Vpc(this, 'Vpc', {
+      ipAddresses: IpAddresses.cidr('10.0.0.0/16'),
+      natGateways: 0,
+      subnetConfiguration: [
+        {
+          cidrMask: 24,
+          name: 'aurora_isolated_',
+          subnetType: SubnetType.PRIVATE_ISOLATED
+        },
+        {
+          cidrMask: 24,
+          name: 'public',
+          subnetType: SubnetType.PUBLIC
+        }
+      ]
+    });
+
+    // Security group 
+    const dbSecurityGroup: SecurityGroup = new SecurityGroup(this, 'db-security-group', {
+      securityGroupName: 'db-security-group',
+      description: 'db-security-group',
+      allowAllOutbound: true,
+      vpc: vpc,
+    });
+
+    // DB Subnet Group
+    const subnetIds: string[] = [];
+    vpc.isolatedSubnets.forEach((subnet, index) => { subnetIds.push(subnet.subnetId); });
+
+    const dbSubnetGroup: CfnDBSubnetGroup = new CfnDBSubnetGroup(this, 'AuroraSubnetGroup', {
+      dbSubnetGroupDescription: 'Subnet group to access aurora',
+      dbSubnetGroupName: 'aurora-serverless-subnet-group',
+      subnetIds
+    });
+
+    // Secret Manager
+    const secret = new sm.CfnSecret(this, "AuroraGlobalServerlessDBSecret", {
+      name: `aurora-serverless-global-db-secret`,
+      generateSecretString: {
+        secretStringTemplate: JSON.stringify({ username: 'postgres' }),
+        excludePunctuation: true,
+        includeSpace: false,
+        generateStringKey: "password",
+      },
+    });
+
+    // Aurora DB Cluster
+    const cfndbclusterprops = {
+      dbClusterIdentifier: id,
+      dbSubnetGroupName: dbSubnetGroup.dbSubnetGroupName,
+      engine: cfnGlobalCluster.engine,
+      engineVersion: cfnGlobalCluster.engineVersion,
+      globalClusterIdentifier: cfnGlobalCluster.globalClusterIdentifier,
+      ...(props.isPrimary as boolean && { databaseName: databasename }),
+      ...(props.isPrimary as boolean && { masterUsername: new CfnDynamicReference(CfnDynamicReferenceService.SECRETS_MANAGER, 'aurora-serverless-global-db-secret:SecretString:username').toString() }),
+      ...(props.isPrimary as boolean && { masterUserPassword: new CfnDynamicReference(CfnDynamicReferenceService.SECRETS_MANAGER, 'aurora-serverless-global-db-secret:SecretString:password').toString() }),
+      serverlessV2ScalingConfiguration: {
+        maxCapacity: AuroraCapacityUnit.ACU_4,
+        minCapacity: AuroraCapacityUnit.ACU_2,
+      },
+      vpcSecurityGroupIds: [dbSecurityGroup.securityGroupId]
+    };
+
+    const dbcluster = new CfnDBCluster(this, "db-cluster", cfndbclusterprops);
+    dbcluster.addDependency(dbSubnetGroup);
+    dbcluster.addDependency(secret);
+
+
+    // Aurora Serverless DB Instance
+    const cfndbinstanceprops = {
+      dbClusterIdentifier: dbcluster.dbClusterIdentifier,
+      dbInstanceClass: 'db.serverless',
+      dbInstanceIdentifier: 'serverless-db-instance',
+      engine: cfnGlobalCluster.engine,
+      engineVersion: cfnGlobalCluster.engineVersion,
+    };
+
+    const dbinstance = new CfnDBInstance(this, "serverless-db-instance", cfndbinstanceprops);
+
+    dbinstance.addDependency(dbcluster);
+
+    this.endpoint = dbcluster.attrEndpointAddress;
+    this.port = dbcluster.attrEndpointPort;
+    this.vpc = vpc;
+    this.region = Stack.of(this).region;
+    this.dbSecurityGroupId = dbSecurityGroup.securityGroupId;
+  }
+}
+export interface DBClusterProps extends StackProps {
+  endpoint: string,
+  port: string
+  vpc: Vpc,
+  isPrimary?: boolean,
+  region: string,
+  dbSecurityGroupId: string
+}
+

--- a/aurora-serverless-global-db-cdk/lib/fargate-test-app-stack.ts
+++ b/aurora-serverless-global-db-cdk/lib/fargate-test-app-stack.ts
@@ -1,0 +1,91 @@
+import { Construct } from 'constructs';
+import { Stack, aws_iam as iam } from 'aws-cdk-lib'
+import { SubnetType, Port, SecurityGroup, Peer } from 'aws-cdk-lib/aws-ec2';
+import { Cluster, ContainerImage, AssetImageProps } from 'aws-cdk-lib/aws-ecs';
+import { ApplicationLoadBalancedFargateService} from 'aws-cdk-lib/aws-ecs-patterns';
+import { DBClusterProps } from './aurora-regional-cluster-stack';
+
+export class FargateTestAppStack extends Stack {
+  constructor(scope: Construct, id: string, props: DBClusterProps) {
+    super(scope, id, props);
+
+    const dbSecurityGroup = SecurityGroup.fromSecurityGroupId(this, "db-security-group", props.dbSecurityGroupId);
+
+    const appSecurityGroup: SecurityGroup = new SecurityGroup(this, 'app-security-group', {
+      securityGroupName: 'app-security-group',
+      description: 'app-security-group',
+      allowAllOutbound: true,
+      vpc: props.vpc,
+    });
+
+    dbSecurityGroup.addIngressRule(
+      appSecurityGroup, Port.tcp(3306), 'allow port 3306 from the appSecurityGroup'
+    );
+
+    appSecurityGroup.addIngressRule(
+      Peer.ipv4('0.0.0.0/0'), Port.tcp(80), 'allow port 80'
+    );
+    // ECS Fargate Cluster
+    const cluster = new Cluster(this, 'MyCluster', {
+      vpc: props.vpc
+    });
+
+    var roleName;
+    var policyName;
+
+    if (props.isPrimary) {
+      roleName = 'primary-test-app-task-role';
+      policyName = 'primary-test-app-task-policy';
+    } else {
+      roleName = 'secondary-test-app-task-role';
+      policyName = 'secondary-test-app-task-policy';
+    }
+
+    const taskRole = new iam.Role(this, roleName, {
+      assumedBy: new iam.ServicePrincipal("ecs-tasks.amazonaws.com"),
+      roleName: roleName,
+      description: "Role that the api task definitions use to run the api code",
+    });
+
+    taskRole.attachInlinePolicy(
+      new iam.Policy(this, policyName, {
+        statements: [
+          new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            actions: ["secretsmanager:GetSecretValue"],
+            resources: ["*"],
+          }),
+        ],
+      })
+    );
+
+    // To enable image build for both primary and secondary regions
+    const assetImageprops: AssetImageProps = {
+      extraHash: Stack.of(this).region,
+      invalidation: {
+        extraHash: true,
+      },
+    }
+
+    // Fargate based test app
+    const fargate = new ApplicationLoadBalancedFargateService(this, 'Fargate', {
+      cluster: cluster,
+      cpu: 512,
+      desiredCount: 1,
+      taskImageOptions: {
+        image: ContainerImage.fromAsset('fargate', assetImageprops),
+        environment: {
+          DB_HOST: props.endpoint,
+          DB_PORT: props.port,
+          REGION: props.region
+        },
+        taskRole: taskRole
+      },
+      taskSubnets: { subnetType: SubnetType.PUBLIC },
+      assignPublicIp: true,
+      memoryLimitMiB: 2048,
+      securityGroups: [appSecurityGroup],
+    });
+  }
+}
+

--- a/aurora-serverless-global-db-cdk/package.json
+++ b/aurora-serverless-global-db-cdk/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "aurora-global-db-multistack",
+  "version": "0.1.0",
+  "bin": {
+    "aurora-serverless-global-db-cdk": "bin/aurora-global-db-multistack.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "test": "jest",
+    "cdk": "cdk"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.3",
+    "@types/node": "20.4.10",
+    "jest": "^29.6.2",
+    "ts-jest": "^29.1.1",
+    "aws-cdk": "2.92.0",
+    "ts-node": "^10.9.1",
+    "typescript": "~5.1.6"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "2.92.0",
+    "constructs": "^10.0.0",
+    "source-map-support": "^0.5.21"
+  }
+}

--- a/aurora-serverless-global-db-cdk/test/global-aurora-serverless-cdk.test.ts
+++ b/aurora-serverless-global-db-cdk/test/global-aurora-serverless-cdk.test.ts
@@ -1,0 +1,42 @@
+import { App } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { AuroraGlobalClusterStack } from '../lib/aurora-global-cluster-stack';
+import { AuroraRegionalClusterStack } from '../lib/aurora-regional-cluster-stack'
+
+test('Validate Stack Resources', () => {
+    const app = new App();
+   
+    const account = app.node.tryGetContext('account') || process.env.CDK_INTEG_ACCOUNT || process.env.CDK_DEFAULT_ACCOUNT;
+    const primaryRegion = {account: account, region: 'eu-west-1'};
+    const secondaryRegion = {account: account, region: 'eu-west-2'};
+
+    const globalclusterstack = new AuroraGlobalClusterStack(app, "AuroraGlobalCluster", {
+        env: primaryRegion
+    });
+    
+    const primaryregionstack = new AuroraRegionalClusterStack(app, `AuroraPrimaryCluster-${primaryRegion.region}`, {
+        env: primaryRegion, cfnGlobalCluster: globalclusterstack.cfnGlobalCluster, isPrimary: true
+    });
+      
+    const secondaryregionstack = new AuroraRegionalClusterStack(app, `AuroraSecondaryCluster-${secondaryRegion.region}`, {
+        env: secondaryRegion, cfnGlobalCluster: globalclusterstack.cfnGlobalCluster, isPrimary: false
+    });
+   
+    const globalclustertemplate = Template.fromStack(globalclusterstack);
+    const primarytemplate = Template.fromStack(primaryregionstack);
+    const secondarytemplate = Template.fromStack(secondaryregionstack);
+
+    globalclustertemplate.resourceCountIs('AWS::RDS::GlobalCluster', 1);
+    
+    primarytemplate.resourceCountIs('AWS::EC2::VPC', 1);
+    primarytemplate.resourceCountIs('AWS::RDS::DBSubnetGroup', 1);
+    primarytemplate.resourceCountIs('AWS::SecretsManager::Secret', 1);
+    primarytemplate.resourceCountIs('AWS::RDS::DBCluster', 1);
+    primarytemplate.resourceCountIs('AWS::RDS::DBInstance', 1);
+    
+    secondarytemplate.resourceCountIs('AWS::EC2::VPC', 1);
+    secondarytemplate.resourceCountIs('AWS::RDS::DBSubnetGroup', 1);
+    secondarytemplate.resourceCountIs('AWS::SecretsManager::Secret', 1);
+    secondarytemplate.resourceCountIs('AWS::RDS::DBCluster', 1);
+    secondarytemplate.resourceCountIs('AWS::RDS::DBInstance', 1);
+});

--- a/aurora-serverless-global-db-cdk/tsconfig.json
+++ b/aurora-serverless-global-db-cdk/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": [
+      "es2020",
+      "dom"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": [
+      "./node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "cdk.out"
+  ]
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The pattern creates a serverless global database cluster enabling data replication from the primary to secondary cluster. The regional primary cluster contains a serverless db instance supporting both writes and reads. The regional secondary cluster contains a serverless db instance supporting only reads. In the unlikely event of a regional degradation or outage, the secondary region can be promoted to read and write capabilities in less than 1 minute. A fargate based application is also provisioned to test the replication. Also the pattern adopts the multiple stack capability of CDK to provision the resources across the primary and secondary regions. You can deploy each stack individually or deploy all the stacks using --all option.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
