### PR TITLE
New serverless pattern - AWS Secrets Manager to CloudWatch Events to SNS (Terraform)

### DIFF
--- a/sm-cw-lambda-sns-terraform/README.md
+++ b/sm-cw-lambda-sns-terraform/README.md
@@ -1,0 +1,71 @@
+# AWS Secrets Manager to CloudWatch Events to Lambda to SNS
+
+This pattern contains a terraform template to detect and notify on Amazon Secrets Manager Secret Key Creation, Updation and Deletion using Amazon CloudWatch event and Amazon SNS.
+
+Learn more about this pattern at Serverless Land Patterns: https://serverlessland.com/patterns/sm-cw-lambda-sns-terraform
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli?in=terraform/aws-get-started) installed
+
+
+## Deployment Instructions
+
+1. Clone the project to your local working directory
+
+   ```sh
+   git clone https://github.com/aws-samples/serverless-patterns/ 
+   ```
+
+2. Change the working directory to this pattern's directory
+
+   ```sh
+   cd serverless-patterns/sm-cw-lambda-sns-terraform
+   ```
+
+1. From the command line, initialize terraform to  to downloads and installs the providers defined in the configuration:
+    ```
+    terraform init
+    ```
+1. From the command line, apply the configuration in the main.tf file:
+    ```
+    terraform apply
+    ```
+1. During the prompts:
+   -   Provide your email address to receive notification from SNS:
+   -   Enter yes
+## How it works
+
+This template is used to monitor AWS Secrets Manager secret keys. This helps in reporting when something is wrong, and take automatic actions when appropriate. Once the template is deployed, you will receive an email notification on the email address you defined. Make sure to confirm email subscription in order to receive updates related to your Secret Keys present in AWS Secret manager.
+
+## Testing
+
+Once the template deployed successfully, first thing to do is to confirm the Email subscription. You will receive an email to confirm it.  Then, head to AWS Secrets Manager console and Create a Secret Key by following these steps - https://docs.aws.amazon.com/secretsmanager/latest/userguide/create_secret.html . That's it. You will soon receive a notification about the key you created. Now any event (Like Update or Delete) happens related to that Secret Key, you will receive the notification.
+Log into the AWS Console, browse to AWS IoT Core:
+
+
+## Cleanup
+
+1. Change directory to the pattern directory:
+    ```
+    cd sm-cw-lambda-sns-terraform
+    ```
+1. Delete all created resources by terraform
+    ```bash
+    terraform destroy
+    ```
+1. During the prompts:
+    * Provide your email address to receive notification from SNS:
+    * Enter yes
+1. Confirm all created resources has been deleted
+    ```bash
+    terraform show
+    ```
+----
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+SPDX-License-Identifier: MIT-0

--- a/sm-cw-lambda-sns-terraform/README.md
+++ b/sm-cw-lambda-sns-terraform/README.md
@@ -1,4 +1,4 @@
-# AWS Secrets Manager to CloudWatch Events to Lambda to SNS
+# AWS Secrets Manager to CloudWatch Events to SNS
 
 This pattern contains a terraform template to detect and notify on Amazon Secrets Manager Secret Key Creation, Updation and Deletion using Amazon CloudWatch event and Amazon SNS.
 
@@ -66,6 +66,8 @@ Log into the AWS Console, browse to AWS IoT Core:
     ```bash
     terraform show
     ```
+
 ----
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+
 SPDX-License-Identifier: MIT-0

--- a/sm-cw-lambda-sns-terraform/README.md
+++ b/sm-cw-lambda-sns-terraform/README.md
@@ -46,8 +46,6 @@ This template is used to monitor AWS Secrets Manager secret keys. This helps in 
 ## Testing
 
 Once the template deployed successfully, first thing to do is to confirm the Email subscription. You will receive an email to confirm it.  Then, head to AWS Secrets Manager console and Create a Secret Key by following these steps - https://docs.aws.amazon.com/secretsmanager/latest/userguide/create_secret.html . That's it. You will soon receive a notification about the key you created. Now any event (Like Update or Delete) happens related to that Secret Key, you will receive the notification.
-Log into the AWS Console, browse to AWS IoT Core:
-
 
 ## Cleanup
 

--- a/sm-cw-lambda-sns-terraform/example-pattern.json
+++ b/sm-cw-lambda-sns-terraform/example-pattern.json
@@ -12,7 +12,7 @@
   },
   "gitHub": {
     "template": {
-      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/iot-sns-sqs-terraform",
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/sm-cw-lambda-sns-terraform",
       "templateURL": "serverless-patterns/sm-cw-lambda-sns-terraform",
       "projectFolder": "sm-cw-lambda-sns-terraform",
       "templateFile": "sm-cw-lambda-sns-terraform/main.tf"
@@ -50,7 +50,7 @@
 			"name": "Makendran G",
 			"image": "https://drive.google.com/file/d/1mUObnbmn52UWL-Zn39EpgpneiBNv3LCN/view?usp=sharing",
 			"bio": "Cloud Support Engineer @ AWS",
-			"linkedin": "https://www.linkedin.com/in/makendran",
+			"linkedin": "makendran",
 			"twitter": "@MakendranG"
 		}
 	]

--- a/sm-cw-lambda-sns-terraform/example-pattern.json
+++ b/sm-cw-lambda-sns-terraform/example-pattern.json
@@ -7,7 +7,7 @@
   "introBox": {
     "headline": "How it works",
     "text": [
-      "Once the template deployed successfully, first thing to do is to confirm the Email subscription. You will receive an email to confirm it.  Then, head to AWS Secrets Manager console and Create a Secret Key by following these steps - https://docs.aws.amazon.com/secretsmanager/latest/userguide/create_secret.html . That's it. You will soon receive a notification about the key you created. Now any event (Like Update or Delete) happens related to that Secret Key, you will receive the notification.",
+      "Once the template deployed successfully, first thing to do is to confirm the Email subscription. You will receive an email to confirm it.  Then, head to AWS Secrets Manager console and Create a Secret Key by following these steps - https://docs.aws.amazon.com/secretsmanager/latest/userguide/create_secret.html . That's it. You will soon receive a notification about the key you created. Now any event (Like Update or Delete) happens related to that Secret Key, you will receive the notification."
     ]
   },
   "gitHub": {

--- a/sm-cw-lambda-sns-terraform/example-pattern.json
+++ b/sm-cw-lambda-sns-terraform/example-pattern.json
@@ -1,7 +1,7 @@
 {
   "title": "AWS Secrets Manager to CloudWatch Events to Lambda to SNS",
   "description": "An terraform template that detects and notifies on Amazon Secrets Manager secret key creation, Updation and deletion using Amazon CloudWatch event and Amazon SNS",
-  "language": "",
+  "language": "YAML",
   "level": "200",
   "framework": "Terraform",
   "introBox": {

--- a/sm-cw-lambda-sns-terraform/example-pattern.json
+++ b/sm-cw-lambda-sns-terraform/example-pattern.json
@@ -1,5 +1,5 @@
 {
-  "title": "AWS Secrets Manager to CloudWatch Events to Lambda to SNS",
+  "title": "AWS Secrets Manager to CloudWatch Events to SNS",
   "description": "An terraform template that detects and notifies on Amazon Secrets Manager secret key creation, Updation and deletion using Amazon CloudWatch event and Amazon SNS",
   "language": "YAML",
   "level": "200",

--- a/sm-cw-lambda-sns-terraform/example-pattern.json
+++ b/sm-cw-lambda-sns-terraform/example-pattern.json
@@ -1,0 +1,57 @@
+{
+  "title": "AWS Secrets Manager to CloudWatch Events to Lambda to SNS",
+  "description": "An terraform template that detects and notifies on Amazon Secrets Manager secret key creation, Updation and deletion using Amazon CloudWatch event and Amazon SNS",
+  "language": "",
+  "level": "200",
+  "framework": "Terraform",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "Once the template deployed successfully, first thing to do is to confirm the Email subscription. You will receive an email to confirm it.  Then, head to AWS Secrets Manager console and Create a Secret Key by following these steps - https://docs.aws.amazon.com/secretsmanager/latest/userguide/create_secret.html . That's it. You will soon receive a notification about the key you created. Now any event (Like Update or Delete) happens related to that Secret Key, you will receive the notification.",
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/iot-sns-sqs-terraform",
+      "templateURL": "serverless-patterns/sm-cw-lambda-sns-terraform",
+      "projectFolder": "sm-cw-lambda-sns-terraform",
+      "templateFile": "sm-cw-lambda-sns-terraform/main.tf"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "Create an AWS Secrets Manager secret",
+        "link": "https://docs.aws.amazon.com/secretsmanager/latest/userguide/create_secret.html"
+      },
+      {
+        "text": "Monitor AWS Secrets Manager secrets",
+        "link": "https://docs.aws.amazon.com/secretsmanager/latest/userguide/monitoring.html"
+      }
+    ]
+  },
+	"deploy": {
+		"text": [
+		          "terraform init",
+		          "terraform apply"
+		        ]
+	},
+	"testing": {
+		"text": ["See the Github repo for detailed testing instructions."]
+	},
+	"cleanup": {
+		"text": [
+		          "terraform destroy",
+		          "terraform show"
+		        ]
+	},
+	"authors": [
+		{
+			"name": "Makendran G",
+			"image": "https://drive.google.com/file/d/1mUObnbmn52UWL-Zn39EpgpneiBNv3LCN/view?usp=sharing",
+			"bio": "Cloud Support Engineer @ AWS",
+			"linkedin": "https://www.linkedin.com/in/makendran",
+			"twitter": "@MakendranG"
+		}
+	]
+} 

--- a/sm-cw-lambda-sns-terraform/example-pattern.json
+++ b/sm-cw-lambda-sns-terraform/example-pattern.json
@@ -1,6 +1,6 @@
 {
   "title": "AWS Secrets Manager to CloudWatch Events to SNS",
-  "description": "An terraform template that detects and notifies on Amazon Secrets Manager secret key creation, Updation and deletion using Amazon CloudWatch event and Amazon SNS",
+  "description": "A terraform template that detects AWS Secrets Manager changes via CloudWatch and notify with SNS.",
   "language": "YAML",
   "level": "200",
   "framework": "Terraform",
@@ -15,7 +15,7 @@
       "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/sm-cw-lambda-sns-terraform",
       "templateURL": "serverless-patterns/sm-cw-lambda-sns-terraform",
       "projectFolder": "sm-cw-lambda-sns-terraform",
-      "templateFile": "sm-cw-lambda-sns-terraform/main.tf"
+      "templateFile": "main.tf"
     }
   },
   "resources": {

--- a/sm-cw-lambda-sns-terraform/example-pattern.json
+++ b/sm-cw-lambda-sns-terraform/example-pattern.json
@@ -54,4 +54,4 @@
 			"twitter": "@MakendranG"
 		}
 	]
-} 
+}

--- a/sm-cw-lambda-sns-terraform/main.tf
+++ b/sm-cw-lambda-sns-terraform/main.tf
@@ -1,0 +1,84 @@
+provider "aws" {
+  region = "us-east-1"  # Set your desired AWS region here
+}
+
+variable "SNSEndpoint" {
+  description = "Provide your email address to receive notification from SNS"
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_cloudwatch_event_rule" "event_rule" {
+  name        = "detect-secret-key-changes"
+  description = "A CloudWatch Event Rule that detects changes to Secret Manager secret keys and publishes change events to an SNS topic for notification."
+  event_pattern = jsonencode({
+    detail_type: ["AWS API Call via CloudTrail"],
+    detail: {
+      eventSource: ["secretsmanager.amazonaws.com"],
+      eventName: ["CreateSecret", "UpdateSecret", "GetSecretValue", "PutSecretValue"],
+    },
+  })
+  is_enabled = true
+}
+
+resource "aws_sns_topic" "sns_topic" {
+  name = "event-rule-action"
+}
+
+resource "aws_sns_topic_policy" "sns_topic_policy" {
+  arn = aws_sns_topic.sns_topic.arn
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Id      = "__default_policy_ID",
+    Statement = [
+      {
+        Sid       = "__default_statement_ID",
+        Effect    = "Allow",
+        Principal = "*",
+        Action    = [
+          "SNS:GetTopicAttributes",
+          "SNS:SetTopicAttributes",
+          "SNS:AddPermission",
+          "SNS:RemovePermission",
+          "SNS:DeleteTopic",
+          "SNS:Subscribe",
+          "SNS:ListSubscriptionsByTopic",
+          "SNS:Publish",
+          "SNS:Receive",
+        ],
+        Resource  = aws_sns_topic.sns_topic.arn,
+        Condition = {
+          StringEquals = {
+            "AWS:SourceOwner" = data.aws_caller_identity.current.account_id,
+          },
+        },
+      },
+      {
+        Sid       = "TrustCWEToPublishEventsToMyTopic",
+        Effect    = "Allow",
+        Principal = {
+          Service = "events.amazonaws.com",
+        },
+        Action    = "sns:Publish",
+        Resource  = aws_sns_topic.sns_topic.arn,
+      },
+    ],
+  })
+}
+
+resource "aws_sns_topic_subscription" "sns_topic_subscription" {
+  topic_arn = aws_sns_topic.sns_topic.arn
+  protocol  = "email"
+  endpoint  = var.SNSEndpoint
+}
+
+output "MySnsTopicName" {
+  description = "SNS topic name"
+  value       = aws_sns_topic.sns_topic.name
+}
+
+output "MySnsTopicArn" {
+  description = "SNS topic ARN"
+  value       = aws_sns_topic.sns_topic.arn
+}

--- a/sm-cw-lambda-sns-terraform/main.tf
+++ b/sm-cw-lambda-sns-terraform/main.tf
@@ -73,6 +73,12 @@ resource "aws_sns_topic_subscription" "sns_topic_subscription" {
   endpoint  = var.SNSEndpoint
 }
 
+resource "aws_cloudwatch_event_target" "sns_target" {
+  rule      = aws_cloudwatch_event_rule.event_rule.name
+  target_id = "sns_target"
+  arn       = aws_sns_topic.sns_topic.arn
+}
+
 output "MySnsTopicName" {
   description = "SNS topic name"
   value       = aws_sns_topic.sns_topic.name


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-samples/serverless-patterns/issues/1723

*Description of changes:*

This pattern contains a terraform template to detect and notify on Amazon Secrets Manager Secret Key Creation, Updation and Deletion using Amazon CloudWatch event and Amazon SNS.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
