### PR TITLE
Add new pattern Lambda-extension-telemetryapi-s3

### DIFF
--- a/lambda-extension-telemetryapi-s3/.gitignore
+++ b/lambda-extension-telemetryapi-s3/.gitignore
@@ -1,0 +1,3 @@
+#SAM  
+/.aws-sam
+samconfig.toml

--- a/lambda-extension-telemetryapi-s3/README.md
+++ b/lambda-extension-telemetryapi-s3/README.md
@@ -1,0 +1,61 @@
+# AWS Lambda extension Telemetry API forward log to S3 with SAM 
+
+This pattern demonstrates how to use Lambda extension Telemetry API to get Lambda log and forward to S3 bucket
+
+Learn more about this pattern at Serverless Land Patterns: << Add the live URL here >>
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+2. Change directory to the pattern directory:
+    ```
+    cd lambda-extension-telemetryapi-s3
+    ```
+3. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
+    ```
+    sam build 
+    sam deploy --guided
+    ```
+4. During the prompts:
+    * Enter a stack name
+    * Enter the desired AWS Region
+    * Allow SAM CLI to create IAM roles with the required permissions.
+
+    Once you have run `sam deploy --guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+
+1. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## How it works
+
+The SAM template create Sample Lambda Application, Lambda Extension as Lambda Layer and S3 bucket to store Sample Lambda function's logs. The Lambda Extension use TelemetryAPI together with Extension API to capture Lambda Log and send to S3. 
+
+## Testing
+
+Try invoke Lambda Function in sampleappsrc folder. Observe Lambda logs forwarded and stored in S3 bucket
+
+## Cleanup
+ 
+1. Delete the stack
+    ```bash
+    aws cloudformation delete-stack --stack-name STACK_NAME
+    ```
+2. Confirm the stack has been deleted
+    ```bash
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus"
+    ```
+----
+Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/lambda-extension-telemetryapi-s3/example-pattern.json
+++ b/lambda-extension-telemetryapi-s3/example-pattern.json
@@ -8,7 +8,7 @@
     "headline": "How it works",
     "text": [
       "This pattern demonstrates how to use the Lambda extension telemetry API to persist Lambda logs to an S3 bucket",
-      "The SAM template deploy Sample Lambda Application, Lambda Extension as Lambda Layer and S3 bucket to store Sample Lambda function's logs. The Lambda Extension use TelemetryAPI together with Extension API to capture Lambda Log and send to S3."
+      "The SAM template deploys a sample Lambda application, Lambda extension as Lambda layer and an S3 bucket to store the Lambda function logs. The Lambda extension uses the  telemetry API together with the extensions API to capture Lambda Log and persist to S3."
     ]
   },
   "gitHub": {

--- a/lambda-extension-telemetryapi-s3/example-pattern.json
+++ b/lambda-extension-telemetryapi-s3/example-pattern.json
@@ -1,0 +1,54 @@
+{
+  "title": "Lambda Extension Telemetry API to S3",
+  "description": "Create a Lambda Extension to send Lambda logs to S3",
+  "language": "Python",
+  "level": "200",
+  "framework": "SAM",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "This pattern demonstrates how to use Lambda extension Telemetry API to get Lambda log and forward to S3 bucket",
+      "The SAM template deploy Sample Lambda Application, Lambda Extension as Lambda Layer and S3 bucket to store Sample Lambda function's logs. The Lambda Extension use TelemetryAPI together with Extension API to capture Lambda Log and send to S3."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/lambda-extension-telemetryapi-s3",
+      "templateURL": "serverless-patterns/lambda-extension-telemetryapi-s3",
+      "projectFolder": "lambda-extension-telemetryapi-s3",
+      "templateFile": "lambda-extension-telemetryapi-s3/template.yaml"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "Lambda Extension Telemetry API",
+        "link": "https://docs.aws.amazon.com/lambda/latest/dg/telemetry-api.html"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "sam deploy"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the GitHub repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>sam delete</code>."
+    ]
+  },
+  "authors": [
+    {
+      "name": "Thanit Youruchatangern",
+      "image": "link-to-your-photo.jpg",
+      "bio": "I am a Technical Account Manager at AWS based in Thailand. I help customer solving complex problems with simple solutions.",
+      "linkedin": "www.linkedin.com/in/thanit-youruchatangern-a90060216",
+      "twitter": ""
+    }
+  ]
+}

--- a/lambda-extension-telemetryapi-s3/example-pattern.json
+++ b/lambda-extension-telemetryapi-s3/example-pattern.json
@@ -1,6 +1,6 @@
 {
   "title": "Lambda Extension Telemetry API to S3",
-  "description": "Create a Lambda Extension to send Lambda logs to S3",
+  "description": "Create a Lambda extension to send Lambda logs to S3",
   "language": "Python",
   "level": "200",
   "framework": "SAM",

--- a/lambda-extension-telemetryapi-s3/example-pattern.json
+++ b/lambda-extension-telemetryapi-s3/example-pattern.json
@@ -7,7 +7,7 @@
   "introBox": {
     "headline": "How it works",
     "text": [
-      "This pattern demonstrates how to use Lambda extension Telemetry API to get Lambda log and forward to S3 bucket",
+      "This pattern demonstrates how to use the Lambda extension telemetry API to persist Lambda logs to an S3 bucket",
       "The SAM template deploy Sample Lambda Application, Lambda Extension as Lambda Layer and S3 bucket to store Sample Lambda function's logs. The Lambda Extension use TelemetryAPI together with Extension API to capture Lambda Log and send to S3."
     ]
   },

--- a/lambda-extension-telemetryapi-s3/extensionsrc/extensions/telemetryapi-s3-extension.py
+++ b/lambda-extension-telemetryapi-s3/extensionsrc/extensions/telemetryapi-s3-extension.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+import json
+import os
+import sys
+from pathlib import Path
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import urllib.request
+from threading import Event, Thread
+from datetime import datetime
+from queue import Queue
+
+lib_folder = Path(__file__).parent / "lib"
+sys.path.insert(0,str(lib_folder))
+
+import requests
+import boto3
+
+LAMBDA_EXTENSION_NAME = os.path.basename(__file__)
+HOST_NAME = "sandbox"
+# LOCAL_DEBUGGING_IP = "0.0.0.0"
+HOST_PORT = 8080
+LAMBDA_AGENT_IDENTIFIER_HEADER_KEY = "Lambda-Extension-Identifier"
+s3_bucket = (os.environ['S3_BUCKET_NAME'])
+s3 = boto3.resource('s3')
+extension_id = ""
+pending_queue = Queue()
+
+class TelemetryHTTPHandler(BaseHTTPRequestHandler): 
+    def do_POST(self):
+        try:
+            cl = self.headers.get("Content-Length")
+            if cl:
+                data_len = int(cl)
+            else:
+                data_len = 0
+            content = self.rfile.read(data_len)
+            self.send_response(200)
+            self.end_headers()
+            msg = json.loads(content.decode("utf-8"))
+            print(f"Incoming message ={msg}")
+            pending_queue.put(msg)
+        except Exception as e:
+            print(f"Error processing message: {e}")
+
+def push_log_to_s3(msg):
+    s3_filename = (os.environ['AWS_LAMBDA_FUNCTION_NAME'])+'-'+(datetime.now().strftime('%Y-%m-%d-%H:%M:%S.%f'))+'.log'
+    try:
+        response = s3.Bucket(s3_bucket).put_object(Key=s3_filename, Body=str(msg))
+        # print(f"ResponseS3 = {response}")
+    except Exception as e:
+        raise Exception(f"Error sending log to S3 {e}") from e
+
+
+def register_extension():
+    print(f"[{LAMBDA_EXTENSION_NAME}] Registering...", flush=True)
+    headers = {
+        'Lambda-Extension-Name': LAMBDA_EXTENSION_NAME,
+    }
+    payload = {
+        'events': [
+            'INVOKE',
+            'SHUTDOWN'
+        ],
+    }
+    response = requests.post(
+        url=f"http://{os.environ['AWS_LAMBDA_RUNTIME_API']}/2020-01-01/extension/register",
+        json=payload,
+        headers=headers
+    )
+    print(response)
+    ext_id = response.headers[LAMBDA_AGENT_IDENTIFIER_HEADER_KEY]
+    print(f"[{LAMBDA_EXTENSION_NAME}] Registered with ID: {ext_id}", flush=True)
+
+    return ext_id
+
+
+def process_events(ext_id):
+    headers = {
+        LAMBDA_AGENT_IDENTIFIER_HEADER_KEY: ext_id
+    }
+    while True:
+        print(f"[{LAMBDA_EXTENSION_NAME}] Waiting for event...", flush=True)
+        response = requests.get(
+            url=f"http://{os.environ['AWS_LAMBDA_RUNTIME_API']}/2020-01-01/extension/event/next",
+            headers=headers,
+            timeout=None
+        )
+        event = json.loads(response.text)
+        if event['eventType'] == 'SHUTDOWN':
+            print(f"[{LAMBDA_EXTENSION_NAME}] Received SHUTDOWN event. Exiting.", flush=True)
+            sys.exit(0)
+        else:
+            execute_custom_processing(event)
+
+def execute_custom_processing(event):
+    # perform custom per-event processing here
+    print(f"[{LAMBDA_EXTENSION_NAME}] Received event: {json.dumps(event)}", flush=True)
+    while not pending_queue.empty():
+        msg = pending_queue.get_nowait()
+        push_log_to_s3(msg)
+
+def subscribe_telemetry_api(ext_id):
+    print(f"Start telemetry api subscription")
+    TIMEOUT_MS = 1000 # Maximum time (in milliseconds) that a batch is buffered.
+    MAX_BYTES = 262144 # Maximum size in bytes that the logs are buffered in memory.
+    MAX_ITEMS = 10000 # Maximum number of events that are buffered in memory.
+
+    subscription_body = {
+        "schemaVersion": "2022-07-01",
+        "destination":{
+            "protocol": "HTTP",
+            "URI": f"http://{HOST_NAME}:{HOST_PORT}",
+        },
+        "types": ["platform", "function"],
+        "buffering": {
+            "timeoutMs": TIMEOUT_MS,
+            "maxBytes": MAX_BYTES,
+            "maxItems": MAX_ITEMS
+        }
+
+    }
+    endpoint =  f"http://{os.environ['AWS_LAMBDA_RUNTIME_API']}/2022-07-01/telemetry"
+    req = urllib.request.Request(endpoint)
+    req.method = 'PUT'
+    req.add_header(LAMBDA_AGENT_IDENTIFIER_HEADER_KEY, ext_id)   
+    req.add_header("Content-Type", "application/json")
+    data = json.dumps(subscription_body).encode("utf-8")
+    req.data = data
+    resp = urllib.request.urlopen(req)    
+    print(f"Subscription response code = {resp.status}")
+
+def serve(started_event, server):
+    # Notify that this thread is up and running
+    started_event.set()
+    try:
+        print(f"extension.http_listener: Running HTTP Server on {HOST_NAME}:{HOST_PORT}")
+        server.serve_forever()
+    except:
+        print(f"extension.http_listener: Error in HTTP server {sys.exc_info()[0]}", flush=True)
+    finally:
+        if server:
+            server.shutdown()
+
+def start_listener():
+    webServer = HTTPServer((HOST_NAME, HOST_PORT), TelemetryHTTPHandler)
+
+    started_event = Event()
+    server_thread = Thread(target=serve, daemon=True, args=(started_event, webServer,))
+    server_thread.start()
+    rc = started_event.wait(timeout = 9)
+    if rc is not True:
+        raise Exception("server_thread has timed out before starting")
+
+def main():
+    #Prepare S3 bucket
+    s3_bucket = (os.environ['S3_BUCKET_NAME'])
+    s3 = boto3.resource('s3')
+    #Start HTTP listener to listen to Telemetry API
+    start_listener()
+    # Register Extension API and Subscribe to Telemetry API with HTTP Listener which created previously 
+    extension_id = register_extension()
+    subscribe_telemetry_api(extension_id)
+    #While HTTP Listener listen to Teleymetry API and put log to the queue, 
+    #process events will check the queue and put the log to S3 and then send signal to Extension API for next event 
+    process_events(extension_id)
+    
+
+if __name__ == "__main__":
+    main()    

--- a/lambda-extension-telemetryapi-s3/extensionsrc/makefile
+++ b/lambda-extension-telemetryapi-s3/extensionsrc/makefile
@@ -1,0 +1,4 @@
+build-TelemetryS3ExtensionsLayer:
+	cp -R extensions "$(ARTIFACTS_DIR)"
+	mkdir -p "$(ARTIFACTS_DIR)/extensions/lib"
+	python -m pip install -r requirements.txt -t "$(ARTIFACTS_DIR)/extensions/lib"

--- a/lambda-extension-telemetryapi-s3/extensionsrc/requirements.txt
+++ b/lambda-extension-telemetryapi-s3/extensionsrc/requirements.txt
@@ -1,0 +1,3 @@
+requests==2.31.0
+urllib3==1.26.16
+boto3

--- a/lambda-extension-telemetryapi-s3/sampleappsrc/app.py
+++ b/lambda-extension-telemetryapi-s3/sampleappsrc/app.py
@@ -1,0 +1,16 @@
+import json
+
+# import requests
+
+
+def lambda_handler(event, context):
+
+
+    print("Sample App 1 Log - To show how the log is captured by the extension and send to s3")
+
+    return {
+        "statusCode": 200,
+        "body": json.dumps({
+            "message": "Sample App 1 Return",
+        }),
+    }

--- a/lambda-extension-telemetryapi-s3/sampleappsrc/requirements.txt
+++ b/lambda-extension-telemetryapi-s3/sampleappsrc/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/lambda-extension-telemetryapi-s3/template.yaml
+++ b/lambda-extension-telemetryapi-s3/template.yaml
@@ -1,0 +1,62 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  aws-extension-telemetryapi-s3-app
+
+  Sample SAM Template for aws-extension-telemetryapi-s3-app
+
+# More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
+Globals:
+  Function:
+    Timeout: 30
+
+Resources:
+  SampleFunction1:
+    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+    Properties:
+      CodeUri: sampleappsrc/
+      Handler: app.lambda_handler
+      Runtime: python3.10
+      Architectures:
+        - arm64
+      Layers: 
+        - !Ref TelemetryS3ExtensionsLayer    
+      Policies:
+        - S3WritePolicy:
+            BucketName: !Ref LogExtensionsBucket
+      Environment:
+        Variables:
+          S3_BUCKET_NAME:
+            Ref: LogExtensionsBucket                        
+  TelemetryS3ExtensionsLayer:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      Description: Layer containing extension(s)
+      ContentUri: extensionsrc/
+      CompatibleRuntimes:
+        - python3.10
+      RetentionPolicy: Delete  
+    Metadata:
+      BuildMethod: makefile     
+  LogExtensionsBucket:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      LifecycleConfiguration:
+        Rules:
+          - Id: DeleteAfterSevenDays
+            Status: "Enabled"
+            ExpirationInDays: 7
+
+Outputs:
+  SampleFunction1:
+    Description: "Hello World Lambda Function ARN"
+    Value: !GetAtt SampleFunction1.Arn
+  SampleFunction1IamRole:
+    Description: "Implicit IAM Role created for Hello World function"
+    Value: !GetAtt SampleFunction1Role.Arn
+  TelemetryS3ExtensionsLayer:
+    Description: "TelemetryS3ExtensionsLayer ARN"
+    Value: !Ref TelemetryS3ExtensionsLayer    
+  LogExtensionsBucket:
+    Description: "LogExtensionsBucket ARN"
+    Value: !Ref LogExtensionsBucket    


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add a new serverless pattern - Lambda extension using Telemetry API send Lambda log to S3 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
