### PR TITLE
New serverless pattern - s3 - lambda - bedrock

### DIFF
--- a/s3-lambda-bedrock/.gitignore
+++ b/s3-lambda-bedrock/.gitignore
@@ -1,0 +1,5 @@
+samconfig.toml
+/.vscode
+/.aws-sam
+.vscode
+.aws-sam

--- a/s3-lambda-bedrock/README.md
+++ b/s3-lambda-bedrock/README.md
@@ -1,0 +1,56 @@
+# AWS Service 1 to AWS Service 2
+
+This pattern explains how to deploy a SAM application with Amazon S3, AWS Lambda and Amazon Bedrock.
+
+This pattern is useful for LLM RAG Usecases in getting vector embeddings of the documents uploaded to S3 via S3 event notification. Once the files are placed in S3, AWS Lambda picks up the files via event notification and post the content to Amazon Bedrock embedding model and gets the vector embedding of the content as response. 
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ```
+    cd s3-lambda-bedrock
+    ```
+1. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
+    ```
+    sam build
+    sam deploy --guided
+    ```
+1. During the prompts:
+    * Enter a stack name
+    * Enter the desired AWS Region
+    * Allow SAM CLI to create IAM roles with the required permissions.
+
+    Once you have run `sam deploy --guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+
+1. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## How it works
+
+Explain how the service interaction works.
+
+## Testing
+
+Create a text document with some content and upload it to the S3 bucket (bucket details in sam deploy output). You will be able to validate the lambda response in Cloudwatch Logs LogGroup.
+
+## Cleanup
+ 
+1. Delete the stack
+    sam delete
+
+----
+Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/s3-lambda-bedrock/README.md
+++ b/s3-lambda-bedrock/README.md
@@ -1,4 +1,4 @@
-# AWS Service 1 to AWS Service 2
+# S3 to Lambda to Bedrock Embeddings
 
 This pattern explains how to deploy a SAM application with Amazon S3, AWS Lambda and Amazon Bedrock.
 

--- a/s3-lambda-bedrock/README.md
+++ b/s3-lambda-bedrock/README.md
@@ -31,6 +31,7 @@ Important: this application uses various AWS services and there are costs associ
 1. During the prompts:
     * Enter a stack name
     * Enter the desired AWS Region
+    * Enter the ContentBucketName - Provide a n ame for a new S3 bucket which will be created
     * Allow SAM CLI to create IAM roles with the required permissions.
 
     Once you have run `sam deploy --guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
@@ -39,11 +40,23 @@ Important: this application uses various AWS services and there are costs associ
 
 ## How it works
 
-Explain how the service interaction works.
+The Amazon S3 event notification listens for a putobject api operation and when a new object is uploaded to the bucket,  Amazon S3 invokes your function asynchronously with an event that contains details about the object. With the object details in the event Lambda reads the content of the object and call Amazon Bedrock Titan Embedding service to get the vector embeddings of the object content.
+
 
 ## Testing
 
 Create a text document with some content and upload it to the S3 bucket (bucket details in sam deploy output). You will be able to validate the lambda response in Cloudwatch Logs LogGroup.
+
+1. Tail to the Lambda function log to get the logs
+aws logs tail "/aws/lambda/BedrockEmb" --follow --format json 
+
+2. Upload the sample file to S3 using below command. Please note the file needs to uploaded to a directory named "content". Refer below for example
+aws s3 cp sampletext.txt s3://bdbedrockembedding3/content/sampletext.txt
+
+Sample Output:
+You should be able to get the output in the log tails windows in the embedding format similar to below. This is the vector embedding of the content of the file we uploaded to S3. 
+
+{'embedding': [-0.26367188, 0.12011719, 0.34375, 0.23144531, 0.042236328, 0.24316406, -0.34570312, 3.9815903e-05, 0.04711914, -0.3828125, 0.19921875, 0.12011719, 0.20019531, 0.2109375, -0.375, 0.076660156, -0.067871094, 0.5078125, 0.0009765625, -0.076660156, -0.26953125, 0.09277344, -0.23632812, -0.07421875, 0.42578125, -0.11279297, -0.3671875, 0.22265625, 0.055664062, 0.2578125, -0.75390625, -0.7421875, 0.48242188, 0.064941406, -0.095214844, -0.047607422, 0.032226562, 0.20019531, 0.16796875, 0.16015625, 0.56640625, -0.859375, -0.053955078, -0.55078125, 0.08496094, 0.1953125, 0.16796875, 0.515625, 0.43945312, -0.15625, -0.08154297, -0.072265625, -0.36328125, -0.029785156, 0.42578125, 0.2109375, -0.40429688, 0.055908203, -0.3984375, 0.19628906, 0.2890625, 0.31445312, -0.21777344, -0.26367188, -0.25195312, -0.13183594, 0.24902344, -0.46484375, 0.12597656, 0.18261719, -0.43359375, 0.05908203, 0.390625, -0.25976562, 0.53515625, 0.5234375, -0.43554688, 0.06738281, 0.25585938, -0.29492188, -0.072753906, 0.10253906, 0.23535156, 0.375, 0.30273438, 0.58203125, -0.30664062, 0.22363281, 0.00012302399, -0.52734375, -0.3359375, 0.04272461, 0.296875, 0.42382812]}
 
 ## Cleanup
  

--- a/s3-lambda-bedrock/example-pattern.json
+++ b/s3-lambda-bedrock/example-pattern.json
@@ -1,0 +1,56 @@
+{
+  "title": "S3 to Lambda to Bedrock",
+  "description": "Generate vector embeddings for the documents uploaded to S3",
+  "language": "Python",
+  "level": "200",
+  "framework": "SAM",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "A new S3 bucket is created that has event notification set to call a Lambda function. Lambda function is integrated with Bedrock Titan Embedding Model",
+      "The S3 put request creates an event to Lambda function which extracts the content from the object and call Bedrock Titan Embedding model",
+      "The Lambda function return the Vector embeddings of the document as JSON"
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/s3-lambda-bedrock",
+      "templateURL": "serverless-patterns/s3-lambda-bedrock",
+      "projectFolder": "s3-lambda-bedrock",
+      "templateFile": "template.yaml"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "Amazon Bedrock",
+        "link": "https://aws.amazon.com/blogs/aws/amazon-bedrock-is-now-generally-available-build-and-scale-generative-ai-applications-with-foundation-models/"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "sam build",
+      "sam deploy --guided"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the GitHub repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>cdk delete</code>."
+    ]
+  },
+  "authors": [
+    {
+      "name": "Abdul Waheed",
+      "image": "https://avatars.githubusercontent.com/u/15647692?v=4",
+      "bio": "Solutions Architect @ AWS",
+      "linkedin": "linked-in-ID",
+      "twitter": "waheed2"
+    }
+  ]
+}

--- a/s3-lambda-bedrock/sampletext.txt
+++ b/s3-lambda-bedrock/sampletext.txt
@@ -1,0 +1,3 @@
+Text embeddings represent meaningful vector representations of unstructured text such as documents, paragraphs, and sentences. You input a body of text and the output is a (1 x n) vector. You can use embedding vectors for a wide variety of applications.
+Bedrock supports one model for text embeddings, the Titan Embeddings G1 - Text model (amazon.titan-embed-text-v1). This model supports text retrieval, semantic similarity, and clustering. The maximum input text is 8K tokens and the maximum output vector length is 1536.
+To use a text embeddings model, use the InvokeModel API operation with amazon.titan-embed-text-v1 as the modelId and retrieve the embedding object in the response.

--- a/s3-lambda-bedrock/src/app.py
+++ b/s3-lambda-bedrock/src/app.py
@@ -1,0 +1,59 @@
+import json
+import boto3
+from urllib.parse import unquote_plus
+
+# import requests
+
+
+def getTitanEmbeddingFromText(content):
+    modelId = "amazon.titan-embed-text-v1"
+    contentType = "application/json"
+    accept = "*/*"
+    body = json.dumps({"inputText": json.dumps(content)})
+    bedrock_client = boto3.client("bedrock-runtime")
+
+    response = bedrock_client.invoke_model(
+        modelId=modelId, contentType=contentType, accept=accept, body=body
+    )
+
+    # print(response)
+    response_body = json.loads(response.get("body").read())
+    # print(response_body)
+    return response_body
+
+
+# def main():
+
+#    text = 'sample text'
+#    txt_response = getTitanEmbeddingFromText(text)
+
+
+# if __name__ == "__main__":
+#    main()
+
+
+def readFile(bucket, key):
+    s3_client = boto3.client("s3")
+    fileObj = s3_client.get_object(Bucket=bucket, Key=key)
+    file_content = fileObj["Body"].read().decode("utf-8")
+    return file_content
+
+
+def lambda_handler(event, context):
+    txt_response = ""
+    s3 = boto3.client("s3")
+    if event:
+        print("event", event)
+        file_obj = event["Records"][0]
+        bucketname = str(file_obj["s3"]["bucket"]["name"])
+        filename = unquote_plus(str(file_obj["s3"]["object"]["key"]))
+        print("Filename: ", filename)
+
+        file_content = readFile(bucketname, filename)
+        print(file_content)
+
+        txt_response = getTitanEmbeddingFromText(file_content)
+        print("Response:")
+        print(txt_response)
+
+    return {"statusCode": 200, "body": json.dumps(txt_response)}

--- a/s3-lambda-bedrock/src/requirements.txt
+++ b/s3-lambda-bedrock/src/requirements.txt
@@ -1,0 +1,2 @@
+requests
+boto3==1.28.68

--- a/s3-lambda-bedrock/template.yaml
+++ b/s3-lambda-bedrock/template.yaml
@@ -61,7 +61,12 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  - s3:*
+                  - s3:GetObjectAcl
+                  - s3:GetObject
+                  - s3:ListAllMyBuckets
+                  - s3:ListBucketVersions
+                  - s3:GetObjectAttributes
+                  - s3:ListBucket
                 Resource:
                   - !Sub "arn:aws:s3:::${ContentBucketName}/*"
                   - !Sub "arn:aws:s3:::${ContentBucketName}"

--- a/s3-lambda-bedrock/template.yaml
+++ b/s3-lambda-bedrock/template.yaml
@@ -1,0 +1,83 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: A rest endpoint hosted by an API Gateway which invokes Kinesis data stream, consumed by lambda function and persisted in a dynamoDB table.
+
+Parameters:
+  ContentBucketName:
+    Type: String
+
+Resources:
+  ContentBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Ref ContentBucketName
+
+  ##########################################################################
+  #   Lambda Functions                                                     #
+  ##########################################################################
+  bedrockemb:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: app.lambda_handler
+      FunctionName: BedrockEmb
+      Description: Lambda to get bedrock embedding for indexing
+      Runtime: python3.9
+      Timeout: 10
+      MemorySize: 128
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Events:
+        FileUpload:
+          Type: S3
+          Properties:
+            Bucket: !Ref ContentBucket
+            Events: s3:ObjectCreated:*
+            Filter:
+              S3Key:
+                Rules:
+                  - Name: prefix
+                    Value: "content/"
+
+  ##########################################################################
+  #   Roles                                                                #
+  ##########################################################################
+
+  LambdaExecutionRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - "sts:AssumeRole"
+      Policies:
+        - PolicyName: CustomPolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:*
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - bedrock:*
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - "logs:CreateLogGroup"
+                  - "logs:CreateLogStream"
+                  - "logs:PutLogEvents"
+                Resource: "*"
+
+Outputs:
+  ContentBucket:
+    Description: "S3 bucket name"
+    Value: !Ref ContentBucket
+  LambdaFuncton:
+    Value: !Ref bedrockemb
+    Description: Lambda Function ARN

--- a/s3-lambda-bedrock/template.yaml
+++ b/s3-lambda-bedrock/template.yaml
@@ -62,10 +62,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - s3:*
-                Resource: "*"
+                Resource:
+                  - !Sub "arn:aws:s3:::${ContentBucketName}/*"
+                  - !Sub "arn:aws:s3:::${ContentBucketName}"
               - Effect: Allow
                 Action:
-                  - bedrock:*
+                  - bedrock:InvokeModel
                 Resource: "*"
               - Effect: Allow
                 Action:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is a new pattern to integrate S3 to Lambda to Bedrock. This pattern is useful for LLM RAG Usecases in getting vector embeddings of the documents uploaded to S3 via S3 event notification. Once the files are placed in S3, AWS Lambda picks up the files via event notification and post the content to Amazon Bedrock embedding model and gets the vector embedding of the content as response.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
