### PR TITLE
Upgrade deprecated runtime nodejs12.x

### DIFF
--- a/apigw-sqs-lambda/.vscode/launch.json
+++ b/apigw-sqs-lambda/.vscode/launch.json
@@ -3,25 +3,25 @@
         {
             "type": "aws-sam",
             "request": "direct-invoke",
-            "name": "lambda-nodejs12.x:HelloWorldFunction (nodejs12.x)",
+            "name": "lambda-nodejs16.x:HelloWorldFunction (nodejs16.x)",
             "invokeTarget": {
                 "target": "template",
-                "templatePath": "${workspaceFolder}/lambda-nodejs12.x/template.yaml",
+                "templatePath": "${workspaceFolder}/lambda-nodejs16.x/template.yaml",
                 "logicalId": "HelloWorldFunction"
             },
             "lambda": {
                 "payload": {},
                 "environmentVariables": {},
-                "runtime": "nodejs12.x"
+                "runtime": "nodejs16.x"
             }
         },
         {
             "type": "aws-sam",
             "request": "direct-invoke",
-            "name": "API lambda-nodejs12.x:HelloWorldFunction (nodejs12.x)",
+            "name": "API lambda-nodejs16.x:HelloWorldFunction (nodejs16.x)",
             "invokeTarget": {
                 "target": "api",
-                "templatePath": "${workspaceFolder}/lambda-nodejs12.x/template.yaml",
+                "templatePath": "${workspaceFolder}/lambda-nodejs16.x/template.yaml",
                 "logicalId": "HelloWorldFunction"
             },
             "api": {
@@ -32,7 +32,7 @@
                 }
             },
             "lambda": {
-                "runtime": "nodejs12.x"
+                "runtime": "nodejs16.x"
             }
         },
         {

--- a/appsync-notify-subscribers-of-database-updates/3-lambda/template.yml
+++ b/appsync-notify-subscribers-of-database-updates/3-lambda/template.yml
@@ -5,7 +5,7 @@ Description: Notify subscribers of database updates
 Globals:
   Function:
     CodeUri: src/
-    Runtime: nodejs12.x
+    Runtime: nodejs16.x
     Timeout: 10
     MemorySize: 128
     Layers:
@@ -39,7 +39,7 @@ Resources:
       # delete old version of layer
       RetentionPolicy: Delete
     Metadata:
-      BuildMethod: nodejs12.x
+      BuildMethod: nodejs16.x
 
   AppSyncLambdaUseIAM:
     Type: 'AWS::Serverless::Function'

--- a/eventbridge-lambda/template.yaml
+++ b/eventbridge-lambda/template.yaml
@@ -10,7 +10,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Timeout: 3
       Events:
         Trigger:

--- a/kinesis-lambda-efo/template.yaml
+++ b/kinesis-lambda-efo/template.yaml
@@ -21,7 +21,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: src/
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Handler: app.lambdaHandler
       Tracing: Active
       Events:

--- a/kinesis-lambda/template.yaml
+++ b/kinesis-lambda/template.yaml
@@ -14,7 +14,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: src/
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Handler: app.lambdaHandler
       Tracing: Active
       Events:

--- a/lambda-dynamodb/template.yaml
+++ b/lambda-dynamodb/template.yaml
@@ -11,7 +11,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Timeout: 3
       Environment:
         Variables:

--- a/lambda-lambda/template.yaml
+++ b/lambda-lambda/template.yaml
@@ -9,7 +9,7 @@ Resources:
     Properties:
       CodeUri: ProducerFunction/
       Handler: app.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Timeout: 3
       EventInvokeConfig:
         DestinationConfig:
@@ -25,7 +25,7 @@ Resources:
     Properties:
       CodeUri: OnFailureFunction/
       Handler: app.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Timeout: 3
   OnSuccessFunction:
     Type: AWS::Serverless::Function
@@ -33,7 +33,7 @@ Resources:
     Properties:
       CodeUri: OnSuccessFunction/
       Handler: app.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Timeout: 3
 Outputs:
   ProducerFunctionName:

--- a/lambda-rekognition/template.yaml
+++ b/lambda-rekognition/template.yaml
@@ -77,7 +77,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Description: Lambda function that will recieve CloudWatch events and will trigger
         CodeBuild build job.
       FunctionName: 'TextRecognitionLambdaFunction'

--- a/lambda-s3-sfn/template.yaml
+++ b/lambda-s3-sfn/template.yaml
@@ -5,7 +5,7 @@ Description: >
 
 Globals:
   Function:
-    Runtime: nodejs12.x
+    Runtime: nodejs16.x
     Timeout: 10  
     Environment:
         Variables:

--- a/lambda-sfn/template.yaml
+++ b/lambda-sfn/template.yaml
@@ -11,7 +11,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Timeout: 3
       Policies:
         - StepFunctionsExecutionPolicy:

--- a/lambda-sns-sms/template.yaml
+++ b/lambda-sns-sms/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Timeout: 3
       MemorySize: 128
       Environment:

--- a/lambda-sns/template.yaml
+++ b/lambda-sns/template.yaml
@@ -13,7 +13,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Timeout: 3
       MemorySize: 128
       Environment:

--- a/lambda-sqs/template.yaml
+++ b/lambda-sqs/template.yaml
@@ -13,7 +13,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Timeout: 3
       MemorySize: 128
       Environment:

--- a/msk-lambda/template.yaml
+++ b/msk-lambda/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.lambdaHandler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Events:
         MSKEvent:
           Type: MSK

--- a/s3-object-lambda/template.yaml
+++ b/s3-object-lambda/template.yaml
@@ -66,7 +66,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       MemorySize: 2048
       # The function needs permission to call back to the S3 Object Lambda Access Point with the WriteGetObjectResponse.
       Policies:

--- a/s3-sqs-lambda/template.yaml
+++ b/s3-sqs-lambda/template.yaml
@@ -68,7 +68,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       MemorySize: 2048
       Layers:
         - !Sub 'arn:aws:lambda:${AWS::Region}:175033217214:layer:graphicsmagick:2'

--- a/sfn-apigw/template.yaml
+++ b/sfn-apigw/template.yaml
@@ -31,7 +31,7 @@ Resources:
     Properties:
       CodeUri: src
       Handler: app.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Events:
         Api:
           Type: Api

--- a/sfn-lambda-dynamodb/template.yml
+++ b/sfn-lambda-dynamodb/template.yml
@@ -33,7 +33,7 @@ Resources:
         - CloudWatchLogsFullAccess
         - DynamoDBCrudPolicy:
             TableName: !Ref DynamoDBTable
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Timeout: 30
       Tracing: Active
     Type: AWS::Serverless::Function

--- a/sfn-lambda/template.yaml
+++ b/sfn-lambda/template.yaml
@@ -32,7 +32,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Timeout: 3
       Policies: 
         - CloudWatchPutMetricPolicy: {}

--- a/sns-lambda/template.yaml
+++ b/sns-lambda/template.yaml
@@ -25,7 +25,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Timeout: 3
       MemorySize: 128
 

--- a/terraform-s3-object-lambda/main.tf
+++ b/terraform-s3-object-lambda/main.tf
@@ -19,7 +19,7 @@ module "lambda_function" {
   function_name = "${random_pet.this.id}-lambda"
   description   = "My awesome lambda function"
   handler       = "app.handler"
-  runtime       = "nodejs12.x"
+  runtime       = "nodejs16.x"
   publish       = true
 
   architectures = ["arm64"] # Set to "arm64" if you are running this from ARM, else use "x86_64"


### PR DESCRIPTION
CloudFormation templates in serverless-patterns have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs12.x). The affected templates have been updated to a supported runtime (nodejs16.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.