### PR TITLE
New Serverless Pattern. bedrock streaming inference integration with lambda streaming function

### DIFF
--- a/lambda-streaming-ttfb-write-sam-with-bedrock-streaming/README.md
+++ b/lambda-streaming-ttfb-write-sam-with-bedrock-streaming/README.md
@@ -1,0 +1,72 @@
+# Lambda Response streaming: time-to-first-byte using write() method
+
+This pattern shows how to use Lambda response streaming ability and bedrock LLM streaming inference api to improve time-to-first byte using the write() method and `InvokeModelWithResponseStreamCommand`. For more information on the feature, see the [launch blog post](https://aws.amazon.com/blogs/compute/introducing-aws-lambda-response-streaming/).
+
+Learn more about this pattern at Serverless Land Patterns: [lambda-streaming-ttfb-write-sam](https://github.com/aws-samples/serverless-patterns/tree/main/lambda-streaming-ttfb-write-sam)
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+
+```
+git clone https://github.com/aws-samples/serverless-patterns
+```
+
+1. Change directory to the pattern directory:
+
+    ```
+    cd lambda-streaming-ttfb-write-sam-with-bedrock-streaming
+    ```
+
+1. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
+
+    ```
+    sam deploy -g --stack-name lambda-streaming-ttfb-write-sam-with-bredrock-streaming
+    ```
+
+1. During the prompts:
+    * Enter a stack name
+    * Enter the desired AWS Region - AWS CLI default region is recommended if you are planning to run the test (test.sh) script
+    * Allow SAM CLI to create IAM roles with the required permissions.
+
+1. Once you have run `sam deploy --guided` mode once and saved arguments to a configuration file `samconfig.toml`, you can use `sam deploy` in future to use these defaults.
+
+AWS SAM deploys a Lambda function with streaming support and a function URL
+
+![AWS SAM deploy --g](https://d2908q01vomqb2.cloudfront.net/1b6453892473a467d07372d45eb05abc2031647a/2023/03/31/AWS-SAM-deploy-g.png)
+
+The AWS SAM output returns a Lambda function URL.
+
+![AWS SAM resources](https://d2908q01vomqb2.cloudfront.net/1b6453892473a467d07372d45eb05abc2031647a/2023/03/31/AWS-SAM-resources.png)
+
+## Testing
+
+1.	Use curl with your AWS credentials to view the streaming response as the url uses AWS Identity and Access Management (IAM) for authorization. Replace the URL and Region parameters for your deployment.
+
+    ```
+    curl --request GET https://<url>.lambda-url.<Region>.on.aws/ --user AKIAIOSFODNN7EXAMPLE:wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY --aws-sigv4 'aws:amz:<Region>:lambda' -d '{"prompt": "hello! how are you?"}'
+    ```
+
+You can see the gradual display of the streamed response.
+
+![Using curl to stream response from write() function](https://d2908q01vomqb2.cloudfront.net/1b6453892473a467d07372d45eb05abc2031647a/2023/03/31/Using-curl-to-stream-response-from-write-function.png)
+
+## Cleanup
+ 
+1. Delete the stack, Enter `Y` to confirm deleting the stack and folder.
+    ```
+    sam delete
+    ```
+----
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/lambda-streaming-ttfb-write-sam-with-bedrock-streaming/example-pattern.json
+++ b/lambda-streaming-ttfb-write-sam-with-bedrock-streaming/example-pattern.json
@@ -1,0 +1,53 @@
+{
+  "title": "Streaming Response With Bedrock and Lambda Function URL",
+  "description": "Create a LLM Streaming Response API with Lambda Function URL Streaming write",
+  "language": "nodejs",
+  "level": "200",
+  "framework": "SAM",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "This sample project demonstrates how to use an Lambda Function URL streaming ability and Bedrock runtime `InvokeModelWithResponseStreamCommand` to build a LLM response streaming API",
+      "This pattern deploys One Lambda Function. Since Bedrock access is limited to certain regions, user need to set BEDROCK_AWS_ACCESS_KEY_ID and BEDROCK_AWS_SECRET_ACCESS_KEY environment variables to Lambda Function to allow request across regions."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/lambda-streaming-ttfb-write-sam-with-bedrock-streaming",
+      "templateURL": "serverless-patterns/lambda-streaming-ttfb-write-sam-with-bedrock-streaming",
+      "projectFolder": "lambda-streaming-ttfb-write-sam-with-bedrock-streaming",
+      "templateFile": "lambda-streaming-ttfb-write-sam-with-bedrock-streaming/src/index.js"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "Configure Lambda Function Response Streaming",
+        "link": "https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "sam deploy"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the GitHub repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>sam delete</code>."
+    ]
+  },
+  "authors": [
+    {
+      "name": "Ian Chenyang Zhao",
+      "image": "https://media.licdn.com/media/AAYQAQSOAAgAAQAAAAAAAB-zrMZEDXI2T62PSuT6kpB6qg.png",
+      "bio": "https://github.com/randomradio",
+      "linkedin": "https://www.linkedin.com/in/ianchenyangzhao/"
+    }
+  ]
+}

--- a/lambda-streaming-ttfb-write-sam-with-bedrock-streaming/src/index.js
+++ b/lambda-streaming-ttfb-write-sam-with-bedrock-streaming/src/index.js
@@ -1,0 +1,86 @@
+exports.handler = awslambda.streamifyResponse(
+    async (event, responseStream, context) => {
+        const lambdaRequestBody = JSON.parse(event.body);
+        const prompt = lambdaRequestBody.prompt || '';
+        if (prompt == '') {
+            responseStream.write("No prompt provided.");
+            responseStream.end();
+        }
+
+        const httpResponseMetadata = {
+            statusCode: 200,
+            headers: {
+                "Content-Type": "text/html",
+                "X-Custom-Header": "Example-Custom-Header"
+            }
+        };
+
+        const
+            maxTokens = 2500,
+            temperature = .7,
+            topP = 1,
+            stopSequences = ["\n\nHuman:"],
+            anthropicVersion = "bedrock-2023-05-31",
+            modelId = 'anthropic.claude-v2',
+            contentType = 'application/json',
+            accept = '*/*';
+
+        const formattedPrompt = f`Human: ${prompt}\n\nAssistant:`
+
+        try {
+            responseStream = awslambda.HttpResponseStream.from(responseStream, httpResponseMetadata);
+
+            const bedrockruntime = new BedrockRuntimeClient({
+                region: 'us-west-2',
+                apiVersion: '2023-09-30',
+                credentials: {
+                    accessKeyId: process.env.BEDROCK_AWS_ACCESS_KEY_ID, // setting this in template file
+                    secretAccessKey: process.env.BEDROCK_AWS_SECRET_ACCESS_KEY
+                }
+            });
+
+            const llmRequestBody = {
+                prompt: formattedPrompt,
+                max_tokens_to_sample: maxTokens,
+                temperature,
+                top_p: topP,
+                stop_sequences: stopSequences,
+                anthropic_version: anthropicVersion
+            };
+
+            const params = {
+                body: Buffer.from(JSON.stringify(llmRequestBody)),
+                modelId,
+                contentType,
+                accept
+            };
+
+            const command = new InvokeModelWithResponseStreamCommand(params);
+            // streaming response
+            const data = await bedrockruntime.send(command);
+            const actualStream = data.body.options.messageStream;
+            // parse actual stream to send response
+            responseStream = awslambda.HttpResponseStream.from(responseStream, httpResponseMetadata);
+            const chunks = []
+            for await (const value of actualStream) {
+                const jsonString = new TextDecoder().decode(value.body); // body is a Uint8Array. jsonString->'{"bytes":"eyJjb21wbGV0aW9uIjoiIEkiLCJzdG9wX3JlYXNvbiI6bnVsbH0="}'
+                const base64encoded = JSON.parse(jsonString).bytes; // base64 encoded string. 
+                const decodedString = base64ToUtf8(base64encoded);
+                try {
+                    const streamingCompletion = JSON.parse(decodedString).completion;
+                    chunks.push(streamingCompletion)
+                    responseStream.write(streamingCompletion)
+                } catch (error) {
+                    console.error(error);
+                    responseStream.write(null);
+                    responseStream.end()
+                }
+            }
+            console.log("stream ended: ", chunks.join(''))
+            responseStream.end();
+        } catch (error) {
+            console.error(error);
+            throw error;
+        }
+    }
+);

--- a/lambda-streaming-ttfb-write-sam-with-bedrock-streaming/template.yaml
+++ b/lambda-streaming-ttfb-write-sam-with-bedrock-streaming/template.yaml
@@ -1,0 +1,39 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  StreamingFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: index.handler
+      Runtime: nodejs16.x
+      Timeout: 300
+      MemorySize: 512
+      AutoPublishAlias: live
+      FunctionUrlConfig:
+        AuthType: AWS_IAM
+        InvokeMode: RESPONSE_STREAM
+      Events:
+        GenerateApi:
+          Type: Api
+          Properties:
+            Path: /generate
+            Method: post
+      Environment:
+        Variables:
+          BEDROCK_AWS_ACCESS_KEY_ID: 
+          BEDROCK_AWS_SECRET_ACCESS_KEY: 
+  MyFunctionUrl:
+    Type: AWS::Lambda::Url
+    Properties:
+      TargetFunctionArn: !Ref StreamingFunction
+      AuthType: AWS_IAM
+      InvokeMode: RESPONSE_STREAM       
+Outputs:
+  StreamingFunction:
+    Description: "Streaming Lambda Function ARN"
+    Value: !GetAtt StreamingFunction.Arn
+  StreamingFunctionURL:
+    Description: "Streaming Lambda Function URL"
+    Value: !GetAtt MyFunctionUrl.FunctionUrl
+


### PR DESCRIPTION
add example to demonstrate how to read data properly from bedrock streaming inference api with AWS JS SDK v3, along with streaming LLM response with lambda streaming ability using write()

*Issue #, if available:*

*Description of changes:*

1. Example code to demonstrate how to read from `InvokeModelWithResponseStreamCommand` inference streaming response with javascript SDK v3.
2. Demonstrate how to streaming inference response with lambda function, to support a streaming experience with llarge language model.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
