### PR TITLE
Minor: Consistent `node:` prefix in imports for `lambda-node-esm-cdk`

### DIFF
--- a/lambda-node-esm-cdk/cdk/node-esm-stack.ts
+++ b/lambda-node-esm-cdk/cdk/node-esm-stack.ts
@@ -1,4 +1,4 @@
-import { dirname, join } from 'path';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as cdk from 'aws-cdk-lib';
 import { Architecture, Runtime, Tracing } from 'aws-cdk-lib/aws-lambda';


### PR DESCRIPTION
*Description of changes:*

Uses the `node:` prefix also for the `path` import


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


PS: thanks for the awesome example, @lucamezzalira! ❤️ 