### PR TITLE
New serverless pattern - Amazon EventBridge Scheduler to Amazon SNS (Terraform)

### DIFF
--- a/eventbridge-schedule-to-sns-tf/README.md
+++ b/eventbridge-schedule-to-sns-tf/README.md
@@ -1,0 +1,73 @@
+# Amazon EventBridge Scheduler to Amazon SNS
+
+This pattern will create an EventBridge schedule to send a message to an Amazon SNS topic every 5 minutes.
+
+Learn more about this pattern at Serverless Land Patterns: https://serverlessland.com/patterns/eventbridge-schedule-to-sns-tf
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli?in=terraform/aws-get-started) installed
+
+## Deployment Instructions
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+
+1. Change the working directory to this pattern's directory
+
+   ```sh
+   cd serverless-patterns/eventbridge-schedule-to-sns-tf
+   ```
+
+1. From the command line, initialize terraform to  to downloads and installs the providers defined in the configuration:
+    ```
+    terraform init
+    ```
+1. From the command line, apply the configuration in the main.tf file:
+    ```
+    terraform apply
+    ```
+1. During the prompts:
+    * Enter yes
+
+1. Note the outputs from the deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## How it works
+
+An EventBridge Scheduler schedule is created that sends a message to an Amazon SNS topic every 5 minutes. Along with a schedule and topic, template creates an IAM role and policy for EventBridge Scheduler to assume and send messages. 
+
+## Testing
+
+After the resources has been deployed, you can verify EventBridge is successfully publishing to the topic by viewing the topics "NumberOfMessagesPublished" metric in CloudWatch and verifying positive data points. 
+
+You can also add a subscription to the SNS topic such as an email address or phone number to verify messages are being published successfully.
+
+## Cleanup
+
+1. Change directory to the pattern directory:
+    ```
+    cd eventbridge-schedule-to-sns-tf
+    ```
+1. Delete all created resources by terraform
+    ```bash
+    terraform destroy
+    ```
+1. During the prompts:
+    * Enter yes
+1. Confirm all created resources has been deleted
+    ```bash
+    terraform show
+    ```
+----
+Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/eventbridge-schedule-to-sns-tf/example-pattern.json
+++ b/eventbridge-schedule-to-sns-tf/example-pattern.json
@@ -1,0 +1,60 @@
+{
+  "title": "Amazon EventBridge Scheduler to Amazon SNS",
+  "description": "Send a message to an Amazon SNS topic every 5 minutes using EventBridge Scheduler",
+  "language": "YAML",
+  "level": "200",
+  "framework": "Terraform",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "An EventBridge Scheduler schedule is created which sends a message to an Amazon SNS topic every 5 minutes.", 
+      "Along with a schedule and topic, the template creates an IAM role and policy for EventBridge Scheduler to assume and send messages."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-schedule-to-sns-tf",
+      "templateURL": "serverless-patterns/eventbridge-schedule-to-sns-tf",
+      "projectFolder": "eventbridge-schedule-to-sns-tf",
+      "templateFile": "main.tf"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "Getting started with EventBridge Scheduler",
+        "link": "https://docs.aws.amazon.com/scheduler/latest/UserGuide/getting-started.html"
+      },
+            {
+        "text": "Getting started with Amazon SNS",
+        "link": "https://docs.aws.amazon.com/sns/latest/dg/sns-getting-started.html"
+      }
+    ]
+  },
+	"deploy": {
+		"text": [
+		          "terraform init",
+		          "terraform apply"
+		        ]
+	},
+	"testing": {
+		"text": [
+		"See the Github repo for detailed testing instructions."
+		]
+	},
+	"cleanup": {
+		"text": [
+		          "terraform destroy",
+		          "terraform show"
+		        ]
+	},
+	"authors": [
+		{
+			"name": "Makendran G",
+			"image": "https://drive.google.com/file/d/1mUObnbmn52UWL-Zn39EpgpneiBNv3LCN/view?usp=sharing",
+			"bio": "Cloud Support Engineer @ AWS",
+			"linkedin": "makendran",
+			"twitter": "@MakendranG"
+		}
+	]
+}

--- a/eventbridge-schedule-to-sns-tf/main.tf
+++ b/eventbridge-schedule-to-sns-tf/main.tf
@@ -1,0 +1,94 @@
+provider "aws" {
+  region = "us-east-1"  # Change to your desired region
+}
+
+resource "aws_iam_policy" "eventbridge_scheduler_policy" {
+  name        = "EventBridgeSchedulerPolicy"
+  description = "IAM policy for EventBridge Scheduler"
+  
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action   = "sns:Publish",
+        Effect   = "Allow",
+        Resource = aws_sns_topic.aws_logins.arn,
+      },
+    ],
+  })
+}
+
+resource "aws_iam_role" "eventbridge_scheduler_role" {
+  name = "EventBridgeSchedulerRole"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = "events.amazonaws.com",
+        },
+      },
+    ],
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "eventbridge_scheduler_attachment" {
+  policy_arn = aws_iam_policy.eventbridge_scheduler_policy.arn
+  role       = aws_iam_role.eventbridge_scheduler_role.name
+}
+
+resource "aws_sns_topic" "aws_logins" {
+  name = "MySNSTopic"
+}
+
+resource "aws_sns_topic_policy" "default" {
+  arn    = aws_sns_topic.aws_logins.arn
+  policy = data.aws_iam_policy_document.sns_topic_policy.json
+}
+
+data "aws_iam_policy_document" "sns_topic_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["SNS:Publish"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+
+    resources = [aws_sns_topic.aws_logins.arn]
+  }
+}  
+
+resource "aws_cloudwatch_event_rule" "eventbridge_scheduler" {
+  name                = "EventBridgeScheduler"
+  description         = "EventBridge Scheduler Rule"
+  schedule_expression = "rate(5 minutes)"
+  
+  event_pattern = jsonencode({
+    source = ["aws.events"],
+  })
+}  
+  
+resource "aws_cloudwatch_event_target" "sns" {
+  rule      = aws_cloudwatch_event_rule.eventbridge_scheduler.name
+  target_id = "SendToSNS"
+  arn       =  aws_sns_topic.aws_logins.arn
+  }
+
+
+output "sns_topic_arn" {
+  value = aws_sns_topic.aws_logins.arn
+}
+
+output "iam_role_arn" {
+  value = aws_iam_role.eventbridge_scheduler_role.arn
+}
+
+output "cloudwatch_event_rule_name" {
+  value = aws_cloudwatch_event_rule.eventbridge_scheduler.name
+}
+


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-samples/serverless-patterns/issues/1917

*Description of changes:* This pattern will create an EventBridge schedule to send a message to an Amazon SNS topic every 5 minutes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
