### PR TITLE
feat: Add API Destinations idempotency pattern

### DIFF
--- a/eventbridge-api-destinations-idempotency-cdk/README.md
+++ b/eventbridge-api-destinations-idempotency-cdk/README.md
@@ -1,0 +1,130 @@
+# Idempotent HTTP requests with Amazon EventBridge API Destinations
+
+This pattern describe how to use EventBridge API Destinations with the IETF HTTP `Idempotency-Key`
+[header](https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/) to invoke HTTP APIs supporting
+idempotent API operations. Using API destinations, you can route events between AWS services, integrated software as a
+service (SaaS) applications, and your applications outside of AWS by using API calls.
+
+> Idempotence is the property of certain operations in mathematics and computer science whereby they can be applied
+> multiple times without changing the result beyond the initial application.  It does not matter if the operation is
+> called only once, or 10s of times over. Idempotency is important in building a fault-tolerant HTTP API. An HTTP
+> request method is considered idempotent if the intended effect on the server of multiple identical requests with that
+> method is the same as the effect for a single such request.
+
+Source: https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/
+
+Learn more about this pattern at Serverless Land Patterns:
+https://serverlessland.com/patterns/eventbridge-api-destinations-idempotency-cdk.
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free
+Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any
+AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already
+  have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls
+  and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [Node and NPM](https://nodejs.org/en/download/) installed
+* [AWS Cloud Development Kit](https://docs.aws.amazon.com/cdk/latest/guide/cli.html) (AWS CDK) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ```
+    cd eventbridge-api-destinations-idempotency-cdk/src
+    ```
+1. Install dependencies:
+
+    ```
+    npm install
+    ```
+    
+1. In the file `lib/eb-api-destination-stack.ts` change the variable `webhookUrl` to match your desired HTTP API target. For example, you can generate a unique webhook URL for testing using https://webhook.site.
+    
+1. From the command line, configure AWS CDK (unless already done):
+
+   ```
+   # cdk bootstrap <ACCOUNT-NUMBER/REGION>
+   cdk bootstrap 1111111111/us-east-1
+   ```
+
+1. From the command line, use AWS CDK to deploy the AWS resources for the pattern:
+   
+    ```
+    cdk deploy 
+    ```
+
+1. Note down the event bus ARN from the output value of `EbApiDestinationStack.busArn` which is used for testing in
+   later steps.
+
+## How it works
+
+This pattern creates a custom event bus with an event filtering rule matching all events sent from the same account.
+These events are then sent to an API Destination, i.e., the HTTP target you configured during the above steps. Each
+event is sent as a JSON request to the HTTP target. If event delivery fails, i.e., after 3 retries in this sample,
+events are sent to an Amazon SQS dead-letter queue (DLQ).
+
+EventBridge allows developers to create dynamic mappings from event fields to HTTP headers. A custom client-controlled
+field value from the event body e.g., `customID` in `events.json` file in this sample, is used as the IETF HTTP
+`Idempotency-Key` [header](https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/) value. The HTTP
+target can then use the IETF standardized `Idempotency-Key` in the HTTP request to detect duplicate requests.  The
+reason for using a specific field from the event body as the `Idempotency-Key` is to give the developer (event producer)
+control over the value used in that header. EventBridge generates a unique event ID per request, which could be used in
+this example as the header value. However, this ID can also change and thus might not be stable, for example when a
+client needs to retry sending an event to EventBridge after a failed or timed out `PutEvents` call. 
+
+The header key name and value, i.e., event field reference, can be changed based on your needs and event schema. See
+`headerParameters` in the target configuration in `src/lib/eb-api-destination-stack.ts` (and make sure to change the
+event sample in `src/events.json` accordingly).
+
+## Testing
+
+After the CDK stack is deployed send a test event to EventBridge. In `src/events.json` replace the `EventBusName`
+placeholder value with the ARN you copied from the deployment step above. Also change this file if you made other
+changes to the stack configuration e.g., using a different header key or event field reference.
+
+```
+# from within the src/ folder
+aws events put-events --entries file://events.json
+```
+
+Your output shoud look like:
+
+```
+{
+    "FailedEntryCount": 0,
+    "Entries": [
+        {
+            "EventId": "3c3f6b7d-9ef1-d718-5d10-c5427beb6c40"
+        }
+    ]
+}
+```
+
+In your HTTP API e.g., https://webhook.site/, you should see a new event (HTTP request) with the `Idempotency-Key`
+header value from the sample event used in the `put-events` call e.g., `idempotency-key:
+e9bf3c4d-638c-4fb3-898b-1ac6c1988000`. The value is different from the `EventID` seen in the above `put-events` response
+because we are using a client-controlled event ID as described above. If you want to use the EventBridge event ID as the
+header value, change `headerParameters` in `src/lib/eb-api-destination-stack.ts` to `'Idempotency-Key': '$.id'`. 
+
+Note that HTTP headers are case-insensitive when transferred over the network.
+
+## Cleanup
+
+Delete the stack:
+
+```
+cdk destroy
+```
+
+----
+Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/eventbridge-api-destinations-idempotency-cdk/example-pattern.json
+++ b/eventbridge-api-destinations-idempotency-cdk/example-pattern.json
@@ -7,7 +7,7 @@
   "introBox": {
     "headline": "How it works",
     "text": [
-      "This pattern describe how to use EventBridge API Destinations with the IETF HTTP Idempotency-Key header to invoke HTTP APIs supporting idempotent API operations.",
+      "This pattern describes how to use EventBridge API Destinations with the IETF HTTP Idempotency-Key header to invoke HTTP APIs supporting idempotent API operations.",
       "Using API destinations, you can route events between AWS services, integrated software as a service (SaaS) applications, and your applications outside of AWS by using API calls."
     ]
   },

--- a/eventbridge-api-destinations-idempotency-cdk/example-pattern.json
+++ b/eventbridge-api-destinations-idempotency-cdk/example-pattern.json
@@ -1,0 +1,66 @@
+{
+  "title": "Idempotent HTTP requests with Amazon EventBridge API Destinations",
+  "description": "Create an EventBridge event bus and API Destination to reliably send events to HTTP APIs.",
+  "language": "TypeScript",
+  "level": "200",
+  "framework": "CDK",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "This pattern describe how to use EventBridge API Destinations with the IETF HTTP Idempotency-Key header to invoke HTTP APIs supporting idempotent API operations.",
+      "Using API destinations, you can route events between AWS services, integrated software as a service (SaaS) applications, and your applications outside of AWS by using API calls."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-api-destinations-idempotency-cdk",
+      "templateURL": "serverless-patterns/eventbridge-api-destinations-idempotency-cdk",
+      "projectFolder": "eventbridge-api-destinations-idempotency-cdk",
+      "templateFile": "src/lib/eb-api-destination-stack.ts"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "The Idempotency-Key HTTP Header Field",
+        "link": "https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/"
+      },
+      {
+        "text": "Amazon EventBridge - A Serverless Event Bus",
+        "link": "https://aws.amazon.com/eventbridge"
+      },
+      {
+        "text": "Amazon EventBridge - User Guide",
+        "link": "https://docs.aws.amazon.com/eventbridge/"
+      },
+      {
+        "text": "Amazon EventBridge - API Destinations",
+        "link": "https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-api-destinations.html"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "Deploy the stack: <code>cdk deploy</code>"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the GitHub repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>cdk destroy</code>."
+    ]
+  },
+  "authors": [
+    {
+      "name": "Michael Gasch",
+      "image": "https://serverlessland.com/assets/images/resources/Michael%20Gasch.jpeg",
+      "bio": "Senior Product Manager Technical for Amazon EventBridge.",
+      "linkedin": "michael-gasch-10603298",
+      "twitter": "https://twitter.com/embano1"
+    }
+  ]
+}

--- a/eventbridge-api-destinations-idempotency-cdk/example-pattern.json
+++ b/eventbridge-api-destinations-idempotency-cdk/example-pattern.json
@@ -60,7 +60,7 @@
       "image": "https://serverlessland.com/assets/images/resources/Michael%20Gasch.jpeg",
       "bio": "Senior Product Manager Technical for Amazon EventBridge.",
       "linkedin": "michael-gasch-10603298",
-      "twitter": "https://twitter.com/embano1"
+      "twitter": "embano1"
     }
   ]
 }

--- a/eventbridge-api-destinations-idempotency-cdk/src/.gitignore
+++ b/eventbridge-api-destinations-idempotency-cdk/src/.gitignore
@@ -1,0 +1,8 @@
+*.js
+!jest.config.js
+*.d.ts
+node_modules
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/eventbridge-api-destinations-idempotency-cdk/src/.npmignore
+++ b/eventbridge-api-destinations-idempotency-cdk/src/.npmignore
@@ -1,0 +1,6 @@
+*.ts
+!*.d.ts
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/eventbridge-api-destinations-idempotency-cdk/src/README.md
+++ b/eventbridge-api-destinations-idempotency-cdk/src/README.md
@@ -1,0 +1,14 @@
+# Welcome to your CDK TypeScript project
+
+This is a blank project for CDK development with TypeScript.
+
+The `cdk.json` file tells the CDK Toolkit how to execute your app.
+
+## Useful commands
+
+* `npm run build`   compile typescript to js
+* `npm run watch`   watch for changes and compile
+* `npm run test`    perform the jest unit tests
+* `npx cdk deploy`  deploy this stack to your default AWS account/region
+* `npx cdk diff`    compare deployed stack with current state
+* `npx cdk synth`   emits the synthesized CloudFormation template

--- a/eventbridge-api-destinations-idempotency-cdk/src/bin/eb-api-destination.ts
+++ b/eventbridge-api-destinations-idempotency-cdk/src/bin/eb-api-destination.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import 'source-map-support/register';
+import * as cdk from 'aws-cdk-lib';
+import { EbApiDestinationStack } from '../lib/eb-api-destination-stack';
+
+const app = new cdk.App();
+new EbApiDestinationStack(app, 'EbApiDestinationStack', {
+  /* If you don't specify 'env', this stack will be environment-agnostic.
+   * Account/Region-dependent features and context lookups will not work,
+   * but a single synthesized template can be deployed anywhere. */
+
+  /* Uncomment the next line to specialize this stack for the AWS Account
+   * and Region that are implied by the current CLI configuration. */
+  // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
+
+  /* Uncomment the next line if you know exactly what Account and Region you
+   * want to deploy the stack to. */
+  // env: { account: '123456789012', region: 'us-east-1' },
+
+  /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
+});

--- a/eventbridge-api-destinations-idempotency-cdk/src/cdk.json
+++ b/eventbridge-api-destinations-idempotency-cdk/src/cdk.json
@@ -1,0 +1,64 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/eb-api-destination.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ],
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+    "@aws-cdk/core:enablePartitionLiterals": true,
+    "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
+    "@aws-cdk/aws-iam:standardizedServicePrincipals": true,
+    "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
+    "@aws-cdk/aws-iam:importedRoleStackSafeDefaultPolicyName": true,
+    "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
+    "@aws-cdk/aws-route53-patters:useCertificate": true,
+    "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
+    "@aws-cdk/aws-rds:databaseProxyUniqueResourceName": true,
+    "@aws-cdk/aws-codedeploy:removeAlarmsFromDeploymentGroup": true,
+    "@aws-cdk/aws-apigateway:authorizerChangeDeploymentLogicalId": true,
+    "@aws-cdk/aws-ec2:launchTemplateDefaultUserData": true,
+    "@aws-cdk/aws-secretsmanager:useAttachedSecretResourcePolicyForSecretTargetAttachments": true,
+    "@aws-cdk/aws-redshift:columnId": true,
+    "@aws-cdk/aws-stepfunctions-tasks:enableEmrServicePolicyV2": true,
+    "@aws-cdk/aws-ec2:restrictDefaultSecurityGroup": true,
+    "@aws-cdk/aws-apigateway:requestValidatorUniqueId": true,
+    "@aws-cdk/aws-kms:aliasNameRef": true,
+    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true,
+    "@aws-cdk/core:includePrefixInUniqueNameGeneration": true,
+    "@aws-cdk/aws-efs:denyAnonymousAccess": true,
+    "@aws-cdk/aws-opensearchservice:enableOpensearchMultiAzWithStandby": true,
+    "@aws-cdk/aws-lambda-nodejs:useLatestRuntimeVersion": true,
+    "@aws-cdk/aws-efs:mountTargetOrderInsensitiveLogicalId": true,
+    "@aws-cdk/aws-rds:auroraClusterChangeScopeOfInstanceParameterGroupWithEachParameters": true,
+    "@aws-cdk/aws-appsync:useArnForSourceApiAssociationIdentifier": true,
+    "@aws-cdk/aws-rds:preventRenderingDeprecatedCredentials": true,
+    "@aws-cdk/aws-codepipeline-actions:useNewDefaultBranchForCodeCommitSource": true
+  }
+}

--- a/eventbridge-api-destinations-idempotency-cdk/src/events.json
+++ b/eventbridge-api-destinations-idempotency-cdk/src/events.json
@@ -1,0 +1,8 @@
+[
+  {
+    "Source": "http.idempotency.demo.app",
+    "Detail": "{\"customID\":\"e9bf3c4d-638c-4fb3-898b-1ac6c1988000\",\"message\":\"hello world!\"}",
+    "DetailType": "http.idempotency.demo.event.v0",
+    "EventBusName": "<INSERT ARN OR NAME FROM CDK DEPLOYMENT>"
+  }
+]

--- a/eventbridge-api-destinations-idempotency-cdk/src/jest.config.js
+++ b/eventbridge-api-destinations-idempotency-cdk/src/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  testEnvironment: 'node',
+  roots: ['<rootDir>/test'],
+  testMatch: ['**/*.test.ts'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest'
+  }
+};

--- a/eventbridge-api-destinations-idempotency-cdk/src/lib/eb-api-destination-stack.ts
+++ b/eventbridge-api-destinations-idempotency-cdk/src/lib/eb-api-destination-stack.ts
@@ -1,0 +1,50 @@
+import * as cdk from 'aws-cdk-lib';
+import { ApiDestination, Authorization, Connection,Rule,EventBus } from 'aws-cdk-lib/aws-events';
+import * as targets from 'aws-cdk-lib/aws-events-targets';
+import {Queue} from 'aws-cdk-lib/aws-sqs';
+import { Construct } from 'constructs';
+
+export class EbApiDestinationStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+
+    // dummy value here because target has no auth but connection requires this parameter
+    // ignore or replace with a secure password/token if needed
+    const apisecret = cdk.SecretValue.unsafePlainText("notused")
+    const conn = new Connection(this, "connection", {
+      authorization: Authorization.apiKey("notused", apisecret)
+    }
+    )
+
+    const webhookUrl = '<INSERT_VALUE>'
+    const apiDestination = new ApiDestination(this, "apidestination",
+      {
+        connection: conn,
+        endpoint: webhookUrl,
+        rateLimitPerSecond: 1,
+      }
+    )
+
+    const dlq = new Queue(this, 'dlq')
+    const bus = new EventBus(this, 'bus')
+    const target = new targets.ApiDestination(apiDestination, {
+      deadLetterQueue: dlq,
+      retryAttempts: 3,
+      headerParameters: {
+        // https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/
+        'Idempotency-Key': '$.detail.customID' // replace with desired field from your event
+      }
+    })
+    const rule = new Rule(this, 'rule', {
+      eventBus: bus,
+      eventPattern: { account: [this.account] },
+      targets: [target]
+    })
+
+    new cdk.CfnOutput(this, 'busArn', { value: bus.eventBusArn })
+    new cdk.CfnOutput(this, 'ruleArn', { value: rule.ruleArn })
+    new cdk.CfnOutput(this, 'dlqArn', { value: dlq.queueArn })
+    new cdk.CfnOutput(this, 'apiDestinationArn', { value: apiDestination.apiDestinationArn })
+  }
+}

--- a/eventbridge-api-destinations-idempotency-cdk/src/package.json
+++ b/eventbridge-api-destinations-idempotency-cdk/src/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "eb-api-destination",
+  "version": "0.1.0",
+  "bin": {
+    "eb-api-destination": "bin/eb-api-destination.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "test": "jest",
+    "cdk": "cdk"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.8",
+    "@types/node": "20.9.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "aws-cdk": "2.110.0",
+    "ts-node": "^10.9.1",
+    "typescript": "~5.2.2"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "2.110.0",
+    "constructs": "^10.0.0",
+    "source-map-support": "^0.5.21"
+  }
+}

--- a/eventbridge-api-destinations-idempotency-cdk/src/test/eb-api-destination.test.ts
+++ b/eventbridge-api-destinations-idempotency-cdk/src/test/eb-api-destination.test.ts
@@ -1,0 +1,17 @@
+// import * as cdk from 'aws-cdk-lib';
+// import { Template } from 'aws-cdk-lib/assertions';
+// import * as EbApiDestination from '../lib/eb-api-destination-stack';
+
+// example test. To run these tests, uncomment this file along with the
+// example resource in lib/eb-api-destination-stack.ts
+test('SQS Queue Created', () => {
+//   const app = new cdk.App();
+//     // WHEN
+//   const stack = new EbApiDestination.EbApiDestinationStack(app, 'MyTestStack');
+//     // THEN
+//   const template = Template.fromStack(stack);
+
+//   template.hasResourceProperties('AWS::SQS::Queue', {
+//     VisibilityTimeout: 300
+//   });
+});

--- a/eventbridge-api-destinations-idempotency-cdk/src/tsconfig.json
+++ b/eventbridge-api-destinations-idempotency-cdk/src/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": [
+      "es2020",
+      "dom"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": [
+      "./node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "cdk.out"
+  ]
+}


### PR DESCRIPTION
*Issue #, if available:* #1952

*Description of changes:* This pattern describe how to use EventBridge API Destinations with the IETF HTTP `Idempotency-Key` [header](https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/) to invoke HTTP APIs supporting idempotent API operations.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
