### PR TITLE
Update templateFile in example-pattern.json

### DIFF
--- a/_pattern-model/example-pattern.json
+++ b/_pattern-model/example-pattern.json
@@ -17,7 +17,7 @@
       "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/sfn-athena-cdk-python",
       "templateURL": "serverless-patterns/sfn-athena-cdk-python",
       "projectFolder": "sfn-athena-cdk-python",
-      "templateFile": "sfn_athena_cdk_python/sfn_athena_cdk_python_stack.py"
+      "templateFile": "sfn_athena_cdk_python_stack.py"
     }
   },
   "resources": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The current format of `gitHub.template.templateFile` expects just the file name. However, the `example-pattern.json` still shows the full path including the folder which leads to validation errors.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
