### PR TITLE
feat(apigw-http-api-sqs-lambda-sls): Modernize the example

### DIFF
--- a/apigw-http-api-sqs-lambda-sls/package.json
+++ b/apigw-http-api-sqs-lambda-sls/package.json
@@ -4,8 +4,8 @@
   "license": "MIT-0",
   "type": "module",
   "devDependencies": {
-    "@types/aws-lambda": "^8.10.93",
-    "serverless-plugin-typescript": "^2.1.1",
-    "typescript": "^4.6.3"
+    "@types/aws-lambda": "^8.10.130",
+    "serverless-plugin-typescript": "^2.1.5",
+    "typescript": "^4.9.5"
   }
 }

--- a/apigw-http-api-sqs-lambda-sls/serverless.yml
+++ b/apigw-http-api-sqs-lambda-sls/serverless.yml
@@ -8,11 +8,8 @@ provider:
   name: aws
 
   # common configuration for all Lambda functions in this stack
-  runtime: nodejs14.x
+  runtime: nodejs20.x
   architecture: arm64 # use Graviton for running all Lambda functions
-
-  # use --region option value or the default - us-east-1
-  region: ${opt:region, "us-east-1"}
 
   # override the default stage (dev), although we are not using it in the script below
   stage: ${opt:stage, "prod"}
@@ -20,11 +17,13 @@ provider:
   # optional, Lambda function's memory size in MB, default is 1024
   memorySize: 256
 
+  # optional, switches to direct CloudFormation stack update to speed up deployment
+  deploymentMethod: direct
+
 # Lambda function triggered with events from the default EventBridge topic
 functions:
   logEvent:
     handler: src/handler.logEvent
-    memorySize: 256 # optional, in MB, default is 1024
     events:
       - sqs:
           arn: !GetAtt MySqsQueue.Arn
@@ -46,7 +45,7 @@ resources:
 
     # Create the default stage and configure it to automatically deploy
     MyHttpApiStage:
-      Type: AWS::ApiGatewayV2::Stage    
+      Type: AWS::ApiGatewayV2::Stage
       Properties:
         ApiId: !Ref MyHttpApi
         # we use default stage, instead of the stage name for simplicity.
@@ -64,7 +63,7 @@ resources:
             - Effect: "Allow"
               Principal:
                 Service: "apigateway.amazonaws.com"
-              Action: 
+              Action:
                 - "sts:AssumeRole"
         Policies:
           - PolicyName: ApiDirectWriteEventBridge


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

When browsing examples on Serverless Patterns website, I've noticed that some of them could be slightly simplified or improved. This PR includes changes for `apigw-http-api-sqs-lambda-sls` pattern such as:

- Update of runtime to `nodejs20.x`. Current `nodejs14.x`-based example is not deployable
- Remove unnecessary override of `provider.region` as the provided override configuration is the same as the default
- Added `deploymentMethod` to make the deployment faster by using direct CloudFormation `updateStack` instead of going through changesets which are slower
- Removed unnecessary `memorySize` on function level as it's already set on `provider`

Please let me know what do you think 🙇 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
