### PR TITLE
feat(eventbridge-lambda-sls): Modernize the example

### DIFF
--- a/eventbridge-lambda-sls/package.json
+++ b/eventbridge-lambda-sls/package.json
@@ -4,8 +4,8 @@
   "license": "MIT-0",
   "type": "module",
   "devDependencies": {
-    "@types/aws-lambda": "^8.10.93",
-    "serverless-plugin-typescript": "^2.1.1",
-    "typescript": "^4.6.3"
+    "@types/aws-lambda": "^8.10.130",
+    "serverless-plugin-typescript": "^2.1.5",
+    "typescript": "^4.9.5"
   }
 }

--- a/eventbridge-lambda-sls/serverless.yml
+++ b/eventbridge-lambda-sls/serverless.yml
@@ -8,17 +8,17 @@ provider:
   name: aws
 
   # common configuration for all Lambda functions in this stack
-  runtime: nodejs14.x
+  runtime: nodejs20.x
   architecture: arm64 # use Graviton for running all Lambda functions
-
-  # use --region option value or the default - us-east-1
-  region: ${opt:region, "us-east-1"}
 
   # override the default stage (dev)
   stage: ${opt:stage, "prod"}
 
   # optional, Lambda function's memory size in MB, default is 1024
   memorySize: 256
+
+  # optional, switches to direct CloudFormation stack update to speed up deployment
+  deploymentMethod: direct
 
   apiGateway:
     description: API Gateway for this stack
@@ -42,5 +42,3 @@ functions:
 resources:
   # Override the default description
   Description: EventBridge rule invoking a Lambda function (Serverless Framework).
-
-    


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

When browsing examples on Serverless Patterns website, I've noticed that some of them could be slightly simplified or improved. This PR includes changes for `eventbridge-lambda-sls` pattern such as:

- Update of runtime to `nodejs20.x`. Current `nodejs14.x`-based example is not deployable
- Remove unnecessary override of `provider.region` as the provided override configuration is the same as the default
- Added `deploymentMethod` to make the deployment faster by using direct CloudFormation `updateStack` instead of going through changesets which are slower
- Bump versions of dependencies

Please let me know what do you think 🙇 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
