### PR TITLE
database engine aurora mysql v1 is EOL, so we need to switch to auror…

### DIFF
--- a/lambda-aurora-serverless/README.md
+++ b/lambda-aurora-serverless/README.md
@@ -1,6 +1,6 @@
 # AWS Lambda and Amazon Aurora Serverless
 
-This pattern creates an AWS Lambda function and an Amazon Aurora Serverless DB cluster with Data API and a Secrets Manager secret.
+This pattern creates an AWS Lambda function and an [Amazon Aurora MySQL version 2 (with MySQL 5.7 compatibility)](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraMySQLReleaseNotes/AuroraMySQL.Updates.20Updates.html) in an [Aurora Serverless version 1](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.html) DB cluster with Data API and a Secrets Manager secret.
 
 Learn more about this pattern at Serverless Land Patterns: https://serverlessland.com/patterns/lambda-aurora
 
@@ -38,7 +38,7 @@ Important: this application uses various AWS services and there are costs associ
 
 ## How it works
 
-This pattern creates an AWS Lambda function and an Amazon Aurora Serverless DB cluster with Data API and a Secrets Manager secret. The function creates an example table named "music", inserts a row with data from the event object, then returns the results of a select query.
+This pattern creates an AWS Lambda function and an [Amazon Aurora MySQL version 2 (with MySQL 5.7 compatibility)](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraMySQLReleaseNotes/AuroraMySQL.Updates.20Updates.html) in an [Aurora Serverless version 1](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.html) DB cluster with Data API and a Secrets Manager secret. The function creates an example table named "music", inserts a row with data from the event object, then returns the results of a select query.
 
 ## Testing
 

--- a/lambda-aurora-serverless/template.yml
+++ b/lambda-aurora-serverless/template.yml
@@ -50,7 +50,7 @@ Resources:
       MasterUsername: !Sub '{{resolve:secretsmanager:${DBSecret}:SecretString:username}}'
       MasterUserPassword: !Sub '{{resolve:secretsmanager:${DBSecret}:SecretString:password}}'
       DatabaseName: !Ref DatabaseName
-      Engine: aurora
+      Engine: aurora-mysql
       EngineMode: serverless
       # Enable the Data API for Aurora Serverless
       EnableHttpEndpoint: true

--- a/lambda-aurora-serverless/template.yml
+++ b/lambda-aurora-serverless/template.yml
@@ -52,6 +52,7 @@ Resources:
       DatabaseName: !Ref DatabaseName
       Engine: aurora-mysql
       EngineMode: serverless
+      StorageEncrypted: true
       # Enable the Data API for Aurora Serverless
       EnableHttpEndpoint: true
       ScalingConfiguration:


### PR DESCRIPTION
…a mysql v2: 'Engine: aurora-mysql'

*Issue #, if available: database engine [aurora mysql v1 is EOL](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.MySQL56.EOL.html), so we need to switch to aurora mysql v2

*Description of changes:* in template.yml, update Engine: aurora-mysql


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
