### PR TITLE
New serverless pattern: lambda-aurora-serverlessv2-postgresql

### DIFF
--- a/lambda-aurora-serverlessv2-postgresql/README.md
+++ b/lambda-aurora-serverlessv2-postgresql/README.md
@@ -1,0 +1,92 @@
+# AWS Lambda and Amazon Aurora Serverless v2
+
+This pattern creates an AWS Lambda function and an [Amazon Aurora PostgreSQL DB](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.AuroraPostgreSQL.html) in an [Aurora Serverless v2](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.html) DB cluster with [RDS Data API](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html) and a Secrets Manager secret.
+
+Learn more about this pattern at Serverless Land Patterns: https://serverlessland.com/patterns/lambda-aurora-serverlessv2-postgresql
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ```
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ```
+    cd lambda-aurora-serverlessv2-postgresql
+    ```
+1. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
+    ```
+    sam build
+    sam deploy --guided
+    ```
+1. During the prompts:
+    * Enter a stack name
+    * Enter the desired AWS Region (choose a region where the RDS Data API is available)
+    * Allow SAM CLI to create IAM roles with the required permissions.
+
+    Once you have run `sam deploy --guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam build && sam deploy` in future to use these defaults.
+
+1. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## How it works
+
+This pattern creates an AWS Lambda function and an [Amazon Aurora PostgreSQL DB](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.AuroraPostgreSQL.html) in an [Aurora Serverless v2](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.html) DB cluster with [RDS Data API](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html) and a Secrets Manager secret. The function creates an example table named "music", inserts a row with data from the event object, then returns the results of a select query.
+
+## Testing
+
+Once the application is deployed, [navigate to the Lambda function and configure a test event](https://docs.aws.amazon.com/lambda/latest/dg/testing-functions.html) using the sample event available in this repo. Alternatively, use [`sam remote invoke`](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/using-sam-cli-remote-invoke.html) including the `event-file` option, e.g:
+```
+sam remote invoke LambdaFunction --stack-name STACK_NAME --event-file src/event.json
+```
+Invoke the function to execute SQL statements against the database. Modify the test event before subsequent invocations to insert new data into the example "music" table. Review the Amazon CloudWatch Logs for details on the function invocation.
+
+Example test event:
+```
+{
+  "body": {
+    "artist": "The Beatles",
+    "album": "Abbey Road"
+  }
+}
+```
+
+Response:
+```
+{
+  "statusCode": 200,
+  "body": "[{\"id\":1,\"artist\":\"The Beatles\",\"album\":\"Abbey Road\"}]"
+}
+```
+
+## Documentation
+- [Using the Data API for Aurora Serverless](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html)
+- [Data API - ExecuteStatement](https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_ExecuteStatement.html)
+- [Data API - ExecuteStatement Response Elements](https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_ExecuteStatement.html#API_ExecuteStatement_ResponseElements)
+- [AWS Lambda - the Basics](https://docs.aws.amazon.com/whitepapers/latest/serverless-architectures-lambda/aws-lambdathe-basics.html)
+- [Lambda Function Handler](https://docs.aws.amazon.com/whitepapers/latest/serverless-architectures-lambda/the-handler.html)
+- [Function Event Object - Overview](https://docs.aws.amazon.com/whitepapers/latest/serverless-architectures-lambda/the-event-object.html)
+- [Function Environment Variables](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html)
+
+## Cleanup
+
+1. Delete the stack
+    ```bash
+    sam delete
+    ```
+1. Confirm the stack has been deleted
+    ```bash
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus"
+    ```
+----
+Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/lambda-aurora-serverlessv2-postgresql/example-pattern.json
+++ b/lambda-aurora-serverlessv2-postgresql/example-pattern.json
@@ -1,0 +1,61 @@
+{
+  "title": "AWS Lambda and Amazon Aurora Serverless v2",
+  "description": "Creates a Lambda function with access to an Amazon Aurora Serverless v2 DB cluster.",
+  "language": "Python",
+  "level": "200",
+  "framework": "SAM",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "This pattern creates an AWS Lambda function and an Amazon Aurora PostgreSQL DB in an Aurora Serverless v2 DB cluster with RDS Data API and a Secrets Manager secret.",
+      "The function creates an example table in the DB, inserts a row with data from the event object, then returns the results of a select query."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/lambda-aurora-serverlessv2-postgresql",
+      "templateURL": "serverless-patterns/lambda-aurora-serverlessv2-postgresql",
+      "projectFolder": "lambda-aurora-serverlessv2-postgresql",
+      "templateFile": "template.yaml"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "Using the Data API for Aurora Serverless",
+        "link": "https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html"
+      },
+      {
+        "text": "Data API - ExecuteStatement",
+        "link": "https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_ExecuteStatement.html"
+      },
+      {
+        "text": "Using Aurora Serverless v2",
+        "link": "https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.html"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "sam deploy"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the GitHub repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>sam delete</code>."
+    ]
+  },
+  "authors": [
+    {
+      "name": "Yusuf Mayet",
+      "image": "https://d2908q01vomqb2.cloudfront.net/9e6a55b6b4563e652a23be9d623ca5055c356940/2021/11/24/Yusuf-mayet-aws.jpg",
+      "bio": "I am a Solutions Architect at AWS, where I help customers realise that true transformation lies at the intersection of Cloud, DevOps cultural practices, Agile principles, modular and scalable architectures, and efficient team structures.",
+      "linkedin": "yusufmayet"
+    }
+  ]
+}

--- a/lambda-aurora-serverlessv2-postgresql/lambda-aurora-serverlessv2-postgresql.json
+++ b/lambda-aurora-serverlessv2-postgresql/lambda-aurora-serverlessv2-postgresql.json
@@ -1,0 +1,80 @@
+{
+    "title": "AWS Lambda and Amazon Aurora Serverless v2",
+    "description": "Creates a Lambda function with access to an Amazon Aurora Serverless v2 DB cluster.",
+    "language": "Python",
+    "level": "200",
+    "framework": "SAM",
+    "introBox": {
+        "headline": "How it works",
+        "text": [
+            "This pattern creates an AWS Lambda function and an Amazon Aurora PostgreSQL DB in an Aurora Serverless v2 DB cluster with RDS Data API and a Secrets Manager secret.",
+            "The function creates an example table in the DB, inserts a row with data from the event object, then returns the results of a select query."
+        ]
+    },
+    "gitHub": {
+        "template": {
+            "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/lambda-aurora-serverlessv2-postgresql",
+            "templateURL": "serverless-patterns/lambda-aurora-serverlessv2-postgresql",
+            "projectFolder": "lambda-aurora-serverlessv2-postgresql",
+            "templateFile": "template.yaml"
+        }
+    },
+    "resources": {
+        "bullets": [
+            {
+                "text": "Using the Data API for Aurora Serverless",
+                "link": "https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html"
+            },
+            {
+                "text": "Data API - ExecuteStatement",
+                "link": "https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_ExecuteStatement.html"
+            },
+            {
+                "text": "Using Aurora Serverless v2",
+                "link": "https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.html"
+            }
+        ]
+    },
+    "deploy": {
+        "text": [
+            "sam deploy"
+        ]
+    },
+    "testing": {
+        "text": [
+            "See the GitHub repo for detailed testing instructions."
+        ]
+    },
+    "cleanup": {
+        "text": [
+            "Delete the stack: <code>sam delete</code>."
+        ]
+    },
+    "authors": [
+        {
+            "name": "Yusuf Mayet",
+            "image": "https://d2908q01vomqb2.cloudfront.net/9e6a55b6b4563e652a23be9d623ca5055c356940/2021/11/24/Yusuf-mayet-aws.jpg",
+            "bio": "I am a Solutions Architect at AWS, where I help customers realise that true transformation lies at the intersection of Cloud, DevOps cultural practices, Agile principles, modular and scalable architectures, and efficient team structures.",
+            "linkedin": "yusufmayet"
+        }
+    ],
+    "patternArch": {
+        "icon1": {
+            "x": 20,
+            "y": 50,
+            "service": "lambda",
+            "label": "AWS Lambda"
+        },
+        "icon2": {
+            "x": 80,
+            "y": 50,
+            "service": "aurora",
+            "label": "Amazon Aurora"
+        },
+        "line1": {
+            "from": "icon1",
+            "to": "icon2",
+            "label": "using the Data API"
+        }
+    }
+}

--- a/lambda-aurora-serverlessv2-postgresql/src/app.py
+++ b/lambda-aurora-serverlessv2-postgresql/src/app.py
@@ -1,0 +1,103 @@
+#! Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: MIT-0
+#
+from boto3.session import Session 
+import os
+import json
+
+session = Session()  
+rds_data = session.client(
+    service_name='rds-data'
+)
+
+DBClusterArn = os.environ['DBClusterArn']
+DBName = os.environ['DBName']
+SecretArn = os.environ['SecretArn']
+
+def run_command(sql_statement, sql_values=None):
+    print(f"SQL statement: {sql_statement}")
+    result = ''
+    
+    if not sql_values:
+        #Use the Data API ExecuteStatement operation to run the SQL command
+        result = rds_data.execute_statement(
+            resourceArn=DBClusterArn,
+            secretArn=SecretArn,
+            database=DBName,
+            sql=sql_statement
+        )
+    else:    
+        result = rds_data.execute_statement(
+            resourceArn=DBClusterArn,
+            secretArn=SecretArn,
+            database=DBName,
+            sql=sql_statement,
+            includeResultMetadata=True,
+            parameters=[
+                {
+                    'name':'artist', 
+                    'value':{'stringValue':sql_values['artist']}
+                },
+                {
+                    'name':'album',
+                    'value':{'stringValue':sql_values['album']}
+                }
+            ] 
+        )
+
+    #print(f"SQL Result: {result}")
+    return result
+
+def lambda_handler(event, context):
+    try:
+        #Log event object and database name to CloudWatch Logs
+        print(f"Event: {event}")
+        print(f"Database Name: {DBName}")
+
+        #Get data from test event
+        if event['body']:
+            body = event['body']
+            artist = body['artist']
+            album = body['album']
+            
+    except Exception as e:
+         #Use default data if test event is not configured properly
+        artist = "The Beatles"
+        album = "Abbey Road"
+        print(f"Error: {e}")
+
+    sql_create = "CREATE TABLE IF NOT EXISTS music (id SERIAL PRIMARY KEY, artist VARCHAR(128), album VARCHAR(128));" 
+    sql_insert = "INSERT INTO music (artist, album) VALUES (:artist, :album);"
+    sql_select = "SELECT id, artist, album FROM music WHERE artist=:artist and album=:album;"
+    sql_values = {'artist': artist, 'album': album}
+
+    #Run the SQL commands one at a time
+    run_command(sql_create)
+    run_command(sql_insert, sql_values)
+    result = run_command(sql_select, sql_values)
+    
+    #get column names
+    meta = []
+    for column in result['columnMetadata']:
+        meta.append(column['name'])
+
+    #get records data, linked to column names
+    data = []
+    for record in result['records']:
+        data.append({
+            meta[0]: record[0]['longValue'],
+            meta[1]: record[1]['stringValue'],
+            meta[2]: record[2]['stringValue']
+        })
+
+    return {
+        "statusCode": 200,
+        "body": json.dumps(data),
+    }
+
+
+
+
+    
+
+  

--- a/lambda-aurora-serverlessv2-postgresql/src/event.json
+++ b/lambda-aurora-serverlessv2-postgresql/src/event.json
@@ -1,0 +1,6 @@
+{
+  "body": {
+    "artist": "The Beatles",
+    "album": "Abbey Road"
+  }
+}

--- a/lambda-aurora-serverlessv2-postgresql/template.yaml
+++ b/lambda-aurora-serverlessv2-postgresql/template.yaml
@@ -78,6 +78,7 @@ Resources:
       Engine: aurora-postgresql
       DBInstanceClass: db.serverless
       DBClusterIdentifier: !Ref AuroraCluster
+      PubliclyAccessible: false
   # Lambda Function - uses Globals to define additional configuration values
   LambdaFunction:
     Type: 'AWS::Serverless::Function'

--- a/lambda-aurora-serverlessv2-postgresql/template.yaml
+++ b/lambda-aurora-serverlessv2-postgresql/template.yaml
@@ -1,0 +1,117 @@
+AWSTemplateFormatVersion: 2010-09-09
+Transform: 'AWS::Serverless-2016-10-31'
+Description: An AWS Lambda function and an Amazon Aurora PostgreSQL DB in an Aurora Serverless v2 DB cluster with RDS Data API and a Secrets Manager secret.
+
+# Global values that are applied to all applicable resources in this template
+Globals:
+  Function:
+    CodeUri: ./src
+    Runtime: python3.12
+    MemorySize: 128
+    Timeout: 10
+    LoggingConfig:
+      LogFormat: JSON
+    Architectures:
+      - arm64
+    Tags:
+      project: "lambda-aurora-serverlessv2-postgresql"  
+
+Parameters:
+  DBClusterName:
+    Description: Aurora DB cluster name.
+    Type: String
+    Default: aurora-test-cluster
+  DatabaseName:
+    Description: Aurora database name.
+    Type: String
+    Default: aurora_test_db
+    AllowedPattern: '[a-zA-Z][a-zA-Z0-9_]*'
+    ConstraintDescription: Must begin with a letter and only contain alphanumeric characters.
+  DBAdminUserName:
+    Description: The admin user name.
+    Type: String
+    Default: admin_user
+    MinLength: '2'
+    MaxLength: '16'
+    AllowedPattern: '[a-zA-Z0-9_]+'
+    ConstraintDescription: Must be between 2 to 16 alphanumeric characters.
+
+Resources:
+  # Secrets Manager secret
+  DBSecret:
+    Type: 'AWS::SecretsManager::Secret'
+    Properties:
+      Name: !Sub '${DBClusterName}-AuroraUserSecret'
+      Description: RDS database auto-generated user password
+      Tags:
+        [{"Key":"project","Value":"lambda-aurora-serverlessv2-postgresql"}]  
+      GenerateSecretString:
+        SecretStringTemplate: !Sub '{"username": "${DBAdminUserName}"}'
+        GenerateStringKey: password
+        PasswordLength: 30
+        ExcludeCharacters: '"@/\'
+  # Aurora Serverless v2 DB Cluster with Data API
+  AuroraCluster:
+    Type: 'AWS::RDS::DBCluster'
+    Properties:
+      Tags:
+        - Key: project
+          Value: lambda-aurora-serverlessv2-postgresql
+      DBClusterIdentifier: !Ref DBClusterName
+      MasterUsername: !Sub '{{resolve:secretsmanager:${DBSecret}:SecretString:username}}'
+      MasterUserPassword: !Sub '{{resolve:secretsmanager:${DBSecret}:SecretString:password}}'
+      DatabaseName: !Ref DatabaseName
+      Engine: aurora-postgresql
+      EngineMode: provisioned
+      StorageEncrypted: true
+      # Enable the Data API for Aurora Serverless
+      EnableHttpEndpoint: true
+      ServerlessV2ScalingConfiguration:
+        MinCapacity: 0.5
+        MaxCapacity: 1
+  AuroraInstance:
+    Type: 'AWS::RDS::DBInstance'
+    Properties:
+      Tags:
+        - Key: project
+          Value: lambda-aurora-serverlessv2-postgresql
+      Engine: aurora-postgresql
+      DBInstanceClass: db.serverless
+      DBClusterIdentifier: !Ref AuroraCluster
+  # Lambda Function - uses Globals to define additional configuration values
+  LambdaFunction:
+    Type: 'AWS::Serverless::Function'
+    Properties:
+      FunctionName: !Sub '${DBClusterName}-function'
+      Handler: app.lambda_handler
+      # Function environment variables
+      Environment:
+        Variables:
+          DBClusterArn: !Sub 'arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:${DBClusterName}'
+          DBName: !Ref DatabaseName
+          SecretArn: !Ref DBSecret
+      # Creates an IAM Role that defines the services the function can access and which actions the function can perform
+      Policies:
+        - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Ref DBSecret
+        - Statement:
+          - Effect: Allow
+            Action: 'rds-data:ExecuteStatement'
+            Resource: !Sub 'arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:${DBClusterName}'
+
+Outputs:
+  DBClusterArn:
+    Description: Aurora DB Cluster Resource ARN
+    Value: !Sub 'arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:${DBClusterName}'
+  DBClusterEndpoint:
+    Description: Aurora DB Cluster Endpoint Address
+    Value: !GetAtt AuroraCluster.Endpoint.Address
+  DBName:
+    Description: Aurora Database Name
+    Value: !Ref DatabaseName
+  DBAdminUserName:
+    Description: Aurora Database Admin User
+    Value: !Ref DBAdminUserName
+  SecretArn:
+    Description: Secrets Manager Secret ARN
+    Value: !Ref DBSecret


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently, [lambda-aurora-serverless](https://github.com/aws-samples/serverless-patterns/tree/main/lambda-aurora-serverless) creates an Aurora Serverless v1 cluster. Now that the [Data API is available for Aurora Serverless v2, but PostgreSQL only](https://aws.amazon.com/about-aws/whats-new/2023/12/amazon-aurora-postgresql-rds-data-api/), this new pattern creates a PostgreSQL Aurora Serverless v2 cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
