### PR TITLE
Update lambda esm node

### DIFF
--- a/lambda-node-esm-cdk/cdk/node-esm-stack.ts
+++ b/lambda-node-esm-cdk/cdk/node-esm-stack.ts
@@ -1,12 +1,12 @@
-import { dirname, join } from 'path';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as cdk from 'aws-cdk-lib';
 import { Architecture, Runtime, Tracing } from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction, OutputFormat } from 'aws-cdk-lib/aws-lambda-nodejs';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
-import { HttpApi, HttpMethod} from '@aws-cdk/aws-apigatewayv2-alpha';
-import { HttpLambdaIntegration} from '@aws-cdk/aws-apigatewayv2-integrations-alpha';
+import { HttpApi, HttpMethod} from 'aws-cdk-lib/aws-apigatewayv2';
+import { HttpLambdaIntegration} from 'aws-cdk-lib/aws-apigatewayv2-integrations';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/lambda-node-esm-cdk/package.json
+++ b/lambda-node-esm-cdk/package.json
@@ -13,20 +13,20 @@
     "analyse": "esbuild --bundle ./src/hello-world.ts --external:@aws-sdk --outfile=out.js --target=es2020 --tree-shaking=true --platform=node --minify --analyze"
   },
   "devDependencies": {
-    "@aws-cdk/aws-apigatewayv2-alpha": "^2.110.0-alpha.0",
-    "@aws-cdk/aws-apigatewayv2-integrations-alpha": "^2.110.0-alpha.0",
+    "@aws-cdk/aws-apigatewayv2-alpha": "^2.114.1-alpha.0",
+    "@aws-cdk/aws-apigatewayv2-integrations-alpha": "^2.114.1-alpha.0",
+    "@types/aws-lambda": "^8.10.131",
     "@types/jest": "^29.5.8",
     "@types/node": "20.9.0",
-    "aws-cdk": "^2.110.0",
-    "aws-cdk-lib": "^2.110.0",
-    "esbuild": "^0.19.3",
+    "aws-cdk": "^2.118.0",
+    "aws-cdk-lib": "^2.118.0",
+    "esbuild": "^0.19.11",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-lambda": "^1.0.7",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.21"
   }

--- a/lambda-node-esm-cdk/package.json
+++ b/lambda-node-esm-cdk/package.json
@@ -13,8 +13,6 @@
     "analyse": "esbuild --bundle ./src/hello-world.ts --external:@aws-sdk --outfile=out.js --target=es2020 --tree-shaking=true --platform=node --minify --analyze"
   },
   "devDependencies": {
-    "@aws-cdk/aws-apigatewayv2-alpha": "^2.114.1-alpha.0",
-    "@aws-cdk/aws-apigatewayv2-integrations-alpha": "^2.114.1-alpha.0",
     "@types/aws-lambda": "^8.10.131",
     "@types/jest": "^29.5.8",
     "@types/node": "20.9.0",

--- a/lambda-node-esm-cdk/package.json
+++ b/lambda-node-esm-cdk/package.json
@@ -10,7 +10,7 @@
     "watch": "tsc -w",
     "test": "jest",
     "cdk": "cdk",
-    "analyse": "esbuild --bundle ./src/hello-world.ts --external:@aws-sdk --outfile=out.js --target=es2020 --tree-shaking=true --platform=node --minify --analyze"
+    "analyse": "esbuild --bundle ./src/hello-world.ts --outfile=out.js --target=es2020 --tree-shaking=true --platform=node --minify --analyze"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.131",


### PR DESCRIPTION
…version like in previous release

*Issue #, if available:*

*Description of changes:*
I've updated the dependencies in the package.json, specifically:
- new version of CDK and CDK lib
- removed the unused dependencies like the alpha packages of HTTP API in favour of the stable versions in aws-cdk-lib
- update the analyse script in the package.json
- added the ```@types/aws-lambda``` and removed the wrong package ```aws-lambda```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
