### PR TITLE
Modified the aws sqs send-message command to properly close the value…

### DIFF
--- a/eventbridge-pipes-sqs-to-stepfunctions-cdk-python/README.md
+++ b/eventbridge-pipes-sqs-to-stepfunctions-cdk-python/README.md
@@ -54,7 +54,7 @@ Send SQS message that will trigger step function execution as below:
 ```sh
  aws sqs send-message \
  --queue-url=SQS_URL \
- --message-body '{"orderId":"125a2e1e-d420-482e-8008-5a606f4b2076, "customerId": "a48516db-66aa-4dbc-bb66-a7f058c5ec24", "type": "NEW"}'
+ --message-body '{"orderId":"125a2e1e-d420-482e-8008-5a606f4b2076", "customerId": "a48516db-66aa-4dbc-bb66-a7f058c5ec24", "type": "NEW"}'
 ```
 
 ## Delete stack


### PR DESCRIPTION
… in the json paramter

*Issue #, if available:*
#2080 

*Description of changes:*
The `aws sqs send-message` command to test the pattern has an invalid json as value for the `message-body` parameter. This fixes that by adding a double quote

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
