### PR TITLE
eventbridge-schedule-remove-onetime-cdk-pthon-serverless-pattern - folder name correction

### DIFF
--- a/eventbridge-schedule-remove-one-time-schedules-cdk-python/example-pattern.json
+++ b/eventbridge-schedule-remove-one-time-schedules-cdk-python/example-pattern.json
@@ -14,8 +14,8 @@
     },
     "gitHub": {
         "template": {
-            "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-schedule-remove-onetime-schedule-to-sns-cdk-python",
-            "templateURL": "serverless-patterns/eventbridge-schedule-remove-one-time-schedule-to-sns-cdk-python",
+            "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-schedule-remove-one-time-schedules-cdk-python",
+            "templateURL": "serverless-patterns/eventbridge-schedule-remove-one-time-schedules-cdk-python",
             "projectFolder": "eventbridge-schedule-remove-one-time-schedules-cdk-python",
             "templateFile": "eventbridge_schedule_remove_onetime_schedules_cdk_python/eventbridge_schedule_remove_onetime_schedules_cdk_python_stack.py"
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
this is a correction to earlier pull request : 
https://github.com/aws-samples/serverless-patterns/pull/1992
https://serverlessland.com/patterns/eventbridge-schedule-remove-one-time-schedules-cdk-python

i see the project merged successfully. but the github project folder name not accessible from serverlessland and  need to be corrected as below.  

Incorrect path used :
https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-schedule-remove-onetime-schedule-to-sns-cdk-python

Correct path to be used :
https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-schedule-remove-one-time-schedules-cdk-python


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
