### PR TITLE
New serverless pattern - lambda-canary-monitoring-cdk

### DIFF
--- a/lambda-canary-monitoring-cdk/README.md
+++ b/lambda-canary-monitoring-cdk/README.md
@@ -1,6 +1,6 @@
 # AWS Service 1 to AWS Service 2
 
-This pattern << explain usage >>
+This pattern demonstrates how to deploy a Lambda Function with CodeDeploy canary deployments through CDK. It also creates a CloudWatch Dashboard through CodeDeploys BeforeAllowTraffic Hook to monitor the traffic-shift during a canary deployment.
 
 Learn more about this pattern at Serverless Land Patterns: << Add the live URL here >>
 
@@ -37,22 +37,36 @@ Important: this application uses various AWS services and there are costs associ
 
 ## How it works
 
-TODO: Explain basics, Explain subsequent deployments with change of version number
+After you have finished the initial deployment of the CDK application, you can increase the version Number in `cdk/bin/cdk.ts` for your next deployment. This is just a mechanism to make it easier for you to distinguish between the two versions when calling the API, or looking at the logs. However it is not necessary, since a new version will be created whenever you make changes to your Function Code.
+
+When you do your first deployment you can go to your AWS Console, to monitor the Deployment in CodeDeploy and on the CloudWatch Dashboard.
+It is recommended to run a small load test during the deployment against this Lambda function, to see the traffic gradually shift over in the CloudWatch Dashboard.
+
+You can adjust the Deployment Strategy in `cdk/lib/lambda-canary-stack.ts`, by changing `deploymentConfig` of the `LambdaDeploymentGroup`
+
+```
+    const deploymentGroup = new codedeploy.LambdaDeploymentGroup(this,
+      'LambdaCanaryMonitoringDeploymentGroup',
+      {
+        application: application,
+        alias: aliasBusinessLambda,
+        deploymentConfig: codedeploy.LambdaDeploymentConfig.CANARY_10PERCENT_5MINUTES,
+        preHook: dashboardLambda,
+      }
+    );
+```
 
 ## Testing
 
-Provide steps to trigger the integration and show what should be observed if successful.
+After the initial deployment you will get an HTTPS Endpoint from the Function URL of the Lambda function. You can send simple GET requests to this endpoint to get a response with the configured Version number of the Lambda Function.
 
 ## Cleanup
  
-1. Delete the stack
-    ```bash
-    aws cloudformation delete-stack --stack-name STACK_NAME
-    ```
-1. Confirm the stack has been deleted
-    ```bash
-    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus"
-    ```
+1. From the command line run this AWS CDK command to delete the Serverless application stack
+
+```node
+   cdk destroy
+```
 ----
 Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 

--- a/lambda-canary-monitoring-cdk/README.md
+++ b/lambda-canary-monitoring-cdk/README.md
@@ -1,4 +1,4 @@
-# AWS Service 1 to AWS Service 2
+# Canary Deployments with Lambda and CodeDeploy with Monitoring
 
 This pattern demonstrates how to deploy a Lambda Function with CodeDeploy canary deployments through CDK. It also creates a CloudWatch Dashboard through CodeDeploys BeforeAllowTraffic Hook to monitor the traffic-shift during a canary deployment.
 

--- a/lambda-canary-monitoring-cdk/README.md
+++ b/lambda-canary-monitoring-cdk/README.md
@@ -1,0 +1,59 @@
+# AWS Service 1 to AWS Service 2
+
+This pattern << explain usage >>
+
+Learn more about this pattern at Serverless Land Patterns: << Add the live URL here >>
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS CDK Toolkit](https://docs.aws.amazon.com/cdk/latest/guide/cli.html) installed and configured
+* [Node 18+](https://nodejs.org/en/download/current) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ```
+    cd lambda-canary-monitoring-cdk/cdk
+    ```
+1. From the command line, install the required dependencies:
+    ```
+    npm install
+    ```
+1. From the command line, use AWS CDK to deploy the AWS resources for the pattern as specified in the cdk/bin/cdk.ts file:
+    ```
+    cdk deploy --all
+    ```
+1. During the prompts:
+    * You have to confirm IAM related changes with y during deployment.
+
+## How it works
+
+TODO: Explain basics, Explain subsequent deployments with change of version number
+
+## Testing
+
+Provide steps to trigger the integration and show what should be observed if successful.
+
+## Cleanup
+ 
+1. Delete the stack
+    ```bash
+    aws cloudformation delete-stack --stack-name STACK_NAME
+    ```
+1. Confirm the stack has been deleted
+    ```bash
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus"
+    ```
+----
+Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/lambda-canary-monitoring-cdk/cdk/.gitignore
+++ b/lambda-canary-monitoring-cdk/cdk/.gitignore
@@ -1,0 +1,8 @@
+*.js
+!jest.config.js
+*.d.ts
+node_modules
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/lambda-canary-monitoring-cdk/cdk/.npmignore
+++ b/lambda-canary-monitoring-cdk/cdk/.npmignore
@@ -1,0 +1,6 @@
+*.ts
+!*.d.ts
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/lambda-canary-monitoring-cdk/cdk/bin/cdk.ts
+++ b/lambda-canary-monitoring-cdk/cdk/bin/cdk.ts
@@ -9,6 +9,6 @@ const app = new cdk.App();
 const monitoring = new MonitoringStack(app, 'MonitoringStack');
 
 new LambdaCanaryMonitoringStack(app, 'LambdaCanaryStack', {
-  VERSION_NUMBER: '6',
+  VERSION_NUMBER: '1',
   monitoring,
 });

--- a/lambda-canary-monitoring-cdk/cdk/bin/cdk.ts
+++ b/lambda-canary-monitoring-cdk/cdk/bin/cdk.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+import 'source-map-support/register';
+import * as cdk from 'aws-cdk-lib';
+import { LambdaCanaryMonitoringStack } from '../lib/lambda-canary-stack';
+import { MonitoringStack } from '../lib/monitoring-stack';
+
+const app = new cdk.App();
+
+const monitoring = new MonitoringStack(app, 'MonitoringStack');
+
+new LambdaCanaryMonitoringStack(app, 'LambdaCanaryStack', {
+  VERSION_NUMBER: '6',
+  monitoring,
+});

--- a/lambda-canary-monitoring-cdk/cdk/cdk.json
+++ b/lambda-canary-monitoring-cdk/cdk/cdk.json
@@ -1,0 +1,65 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/cdk.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ],
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+    "@aws-cdk/core:enablePartitionLiterals": true,
+    "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
+    "@aws-cdk/aws-iam:standardizedServicePrincipals": true,
+    "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
+    "@aws-cdk/aws-iam:importedRoleStackSafeDefaultPolicyName": true,
+    "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
+    "@aws-cdk/aws-route53-patters:useCertificate": true,
+    "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
+    "@aws-cdk/aws-rds:databaseProxyUniqueResourceName": true,
+    "@aws-cdk/aws-codedeploy:removeAlarmsFromDeploymentGroup": true,
+    "@aws-cdk/aws-apigateway:authorizerChangeDeploymentLogicalId": true,
+    "@aws-cdk/aws-ec2:launchTemplateDefaultUserData": true,
+    "@aws-cdk/aws-secretsmanager:useAttachedSecretResourcePolicyForSecretTargetAttachments": true,
+    "@aws-cdk/aws-redshift:columnId": true,
+    "@aws-cdk/aws-stepfunctions-tasks:enableEmrServicePolicyV2": true,
+    "@aws-cdk/aws-ec2:restrictDefaultSecurityGroup": true,
+    "@aws-cdk/aws-apigateway:requestValidatorUniqueId": true,
+    "@aws-cdk/aws-kms:aliasNameRef": true,
+    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true,
+    "@aws-cdk/core:includePrefixInUniqueNameGeneration": true,
+    "@aws-cdk/aws-efs:denyAnonymousAccess": true,
+    "@aws-cdk/aws-opensearchservice:enableOpensearchMultiAzWithStandby": true,
+    "@aws-cdk/aws-lambda-nodejs:useLatestRuntimeVersion": true,
+    "@aws-cdk/aws-efs:mountTargetOrderInsensitiveLogicalId": true,
+    "@aws-cdk/aws-rds:auroraClusterChangeScopeOfInstanceParameterGroupWithEachParameters": true,
+    "@aws-cdk/aws-appsync:useArnForSourceApiAssociationIdentifier": true,
+    "@aws-cdk/aws-rds:preventRenderingDeprecatedCredentials": true,
+    "@aws-cdk/aws-codepipeline-actions:useNewDefaultBranchForCodeCommitSource": true,
+    "@aws-cdk/aws-cloudwatch-actions:changeLambdaPermissionLogicalIdForLambdaAction": true
+  }
+}

--- a/lambda-canary-monitoring-cdk/cdk/jest.config.js
+++ b/lambda-canary-monitoring-cdk/cdk/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  testEnvironment: 'node',
+  roots: ['<rootDir>/test'],
+  testMatch: ['**/*.test.ts'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest'
+  }
+};

--- a/lambda-canary-monitoring-cdk/cdk/lambda-code/app.ts
+++ b/lambda-canary-monitoring-cdk/cdk/lambda-code/app.ts
@@ -1,0 +1,21 @@
+'use strict';
+import { Handler, LambdaFunctionURLEvent, LambdaFunctionURLResult} from 'aws-lambda';
+
+const SLEEP_SEC = parseInt(process.env['SLEEP_SEC'] || '0');
+const VERSION = process.env['VERSION'];
+
+export const handler: Handler = async (event:LambdaFunctionURLEvent, context: any):Promise<LambdaFunctionURLResult> => {
+    
+    await sleep(SLEEP_SEC*1000);
+    console.log('version_'+VERSION);
+
+    const response:LambdaFunctionURLResult = {
+        'statusCode': 200,
+        'body': JSON.stringify({'event': event, 'version': VERSION})
+    }
+    return response
+};
+
+function sleep(milliseconds:number) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}

--- a/lambda-canary-monitoring-cdk/cdk/lambda-code/dashboard-lambda.ts
+++ b/lambda-canary-monitoring-cdk/cdk/lambda-code/dashboard-lambda.ts
@@ -1,0 +1,227 @@
+'use strict';
+import {
+  CodeDeploy,
+  GetDeploymentOutput,
+  GetApplicationRevisionOutput,
+  RevisionLocation,
+  PutLifecycleEventHookExecutionStatusInput,
+} from '@aws-sdk/client-codedeploy';
+import { CloudWatch } from '@aws-sdk/client-cloudwatch';
+import { Handler } from 'aws-lambda';
+const codedeploy = new CodeDeploy({ apiVersion: '2014-10-06' });
+const cloudwatch = new CloudWatch();
+const DASHBOARD_NAME = process.env.DASHBOARD_NAME || '';
+const METRIC_REGION = process.env.AWS_REGION || '';
+
+/**
+ * This Lambda Function can be configured as a BeforeAllowTestTraffic Hook in a CodeDeploy Deployment of a Lambda Function
+ * The function will read the information about the Deployed Lambda Version and will create metrics on a pre-created CloudWatch Dashboard.
+ * It will create metrics for the currently running Version of the Lambda Function and for the to-be-deployed function.
+ * This allows you to monitor traffic shift to your new version.
+ * Currently the metrics focus on monitoring Provisioned Concurrency related metrics, however this can be adjusted.
+ */
+export const handler: Handler = async (event: any, _context: any) => {
+  const validationTestResult = performTrafficValidationTests();
+
+  const revisionDetails: RevisionLocation = await getRevisionDetails(
+    event.DeploymentId
+  );
+
+  const { lambdaName, currentVersion, targetVersion, lambdaAlias } =
+    getLambdaDetailsFromRevision(revisionDetails);
+
+  await createMetricGraphs(
+    currentVersion,
+    targetVersion,
+    lambdaName,
+    lambdaAlias,
+    METRIC_REGION
+  );
+
+  const params: PutLifecycleEventHookExecutionStatusInput = {
+    deploymentId: event.DeploymentId,
+    lifecycleEventHookExecutionId: event.LifecycleEventHookExecutionId,
+    status: validationTestResult, // status can be 'Succeeded' or 'Failed'
+  };
+  // Sends Status to CodeDeploy, so the Deployment can continue or rollback
+  await codedeploy.putLifecycleEventHookExecutionStatus(params);
+};
+
+function performTrafficValidationTests() {
+  console.log('This is where AfterAllowTestTraffic validation tests happen.');
+  if (true) {
+    return 'Succeeded';
+  }
+  return 'Failed';
+}
+
+async function getRevisionDetails(
+  deploymentId: string
+): Promise<RevisionLocation> {
+  // Read the DeploymentId and LifecycleEventHookExecutionId from the event payload
+
+  const deploymentData: GetDeploymentOutput = await codedeploy
+    .getDeployment({ deploymentId: deploymentId });
+
+  const appName = deploymentData.deploymentInfo?.applicationName || '';
+
+  const revision: GetApplicationRevisionOutput = await codedeploy
+    .getApplicationRevision({
+      applicationName: appName,
+      revision: deploymentData.deploymentInfo?.revision || {},
+    });
+
+  return revision.revision || {};
+}
+
+function getLambdaDetailsFromRevision(revisionLocation: RevisionLocation): {
+  lambdaName: string;
+  currentVersion: string;
+  targetVersion: string;
+  lambdaAlias: string;
+} {
+  //   const sampleRevisionDetails = {
+  //   version: '0.0',
+  //   Resources: [
+  //     {
+  //       '<NameOfDeployedLambda>': {
+  //         Type: 'AWS::Lambda::Function',
+  //         Properties: {
+  //           Name: '<NameOfDeployedLambda>',
+  //           Alias: 'prod',
+  //           CurrentVersion: '18',
+  //           TargetVersion: '19',
+  //         },
+  //       },
+  //     },
+  //   ],
+  //   Hooks: [
+  //     {
+  //       BeforeAllowTraffic:
+  //         '<NameOfHookLambda>',
+  //     },
+  //   ],
+  // };
+
+  const revisionDetails = JSON.parse(revisionLocation.string?.content || '');
+  const lambdaName = Object.keys(revisionDetails.Resources[0])[0];
+  const lambdaData = revisionDetails.Resources[0][lambdaName].Properties;
+
+  const currentVersion = lambdaData.CurrentVersion;
+  const targetVersion = lambdaData.TargetVersion;
+  const lambdaAlias = lambdaData.Alias;
+
+  return { lambdaName, currentVersion, targetVersion, lambdaAlias };
+}
+
+async function createMetricGraphs(
+  currentVersion: string,
+  targetVersion: string,
+  lambdaName: string,
+  lambdaAlias: string,
+  metricRegion: string
+) {
+  const metricData = generateWidgetsForFunctions(
+    lambdaName,
+    [currentVersion, targetVersion],
+    lambdaAlias,
+    metricRegion
+  );
+  const dashboardBody = { widgets: metricData };
+  await cloudwatch
+    .putDashboard({
+      DashboardName: DASHBOARD_NAME,
+      DashboardBody: JSON.stringify(dashboardBody),
+    });
+}
+
+/**
+ * Generates JSON that can be pushed to the Dashboard. One row of metrics per function.
+ * @param functionName
+ * @param versions
+ * @param lambdaAlias
+ * @returns
+ */
+function generateWidgetsForFunctions(
+  functionName: string,
+  versions: string[],
+  lambdaAlias: string,
+  metricRegion: string
+) {
+  
+  const metrics = [
+    {
+      metricName: 'ProvisionedConcurrentExecutions',
+      stat: 'Maximum',
+      period: 60,
+    },
+    {
+      metricName: 'ProvisionedConcurrencySpilloverInvocations',
+      stat: 'Sum',
+      period: 60,
+    },
+    {
+      metricName: 'ProvisionedConcurrencyInvocations',
+      stat: 'Sum',
+      period: 60,
+    },
+    {
+      metricName: 'Throttles',
+      stat: 'Sum',
+      period: 60,
+    },
+    {
+      metricName: 'Invocations',
+      stat: 'Sum',
+      period: 60,
+    },
+  ];
+  // Max width of Dashboard is 24
+  const metricWidth = Math.floor(24/metrics.length);
+  const metricHeight = 6;
+  //Alternates between these two colors for the metric graphs
+  const colorOrange = '#f89256';
+  const colorBlue = '#08aad2';
+  const output = [];
+  let yPosition = 0;
+  let counter = 0;
+  for (let version of versions) {
+    let xPosition = 0;
+    for (let metric of metrics) {
+      let singleMetricElement = {
+        type: 'metric',
+        x: xPosition,
+        y: yPosition,
+        width: metricWidth,
+        height: metricHeight,
+        properties: {
+          metrics: [
+            [
+              'AWS/Lambda',
+              metric.metricName,
+              'FunctionName',
+              functionName,
+              'ExecutedVersion',
+              `${version}`,
+              'Resource',
+              `${functionName}:${lambdaAlias}`,
+            ],
+          ],
+          view: 'timeSeries',
+          stacked: false,
+          region: metricRegion,
+          color: counter % 2 ? colorBlue : colorOrange,
+          label: `v${version}`,
+          stat: metric.stat,
+          period: metric.period,
+          title: `v${version}-${metric.metricName}`,
+        },
+      };
+      output.push(singleMetricElement);
+      xPosition += metricWidth;
+    }
+    yPosition += metricHeight;
+    counter++;
+  }
+  return output;
+}

--- a/lambda-canary-monitoring-cdk/cdk/lib/lambda-canary-stack.ts
+++ b/lambda-canary-monitoring-cdk/cdk/lib/lambda-canary-stack.ts
@@ -66,7 +66,7 @@ export class LambdaCanaryMonitoringStack extends Stack {
       {
         application: application,
         alias: aliasBusinessLambda,
-        deploymentConfig: codedeploy.LambdaDeploymentConfig.ALL_AT_ONCE,
+        deploymentConfig: codedeploy.LambdaDeploymentConfig.CANARY_10PERCENT_5MINUTES,
         preHook: dashboardLambda,
       }
     );

--- a/lambda-canary-monitoring-cdk/cdk/lib/lambda-canary-stack.ts
+++ b/lambda-canary-monitoring-cdk/cdk/lib/lambda-canary-stack.ts
@@ -1,0 +1,119 @@
+import { Duration, RemovalPolicy, Stack, StackProps } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as path from 'path';
+import * as codedeploy from 'aws-cdk-lib/aws-codedeploy';
+import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
+import { IMonitoring } from './monitoring-stack';
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
+
+
+interface LambdaCanaryMonitoringStackProps extends StackProps {
+  readonly VERSION_NUMBER: string;
+  readonly monitoring: IMonitoring;
+}
+
+
+export class LambdaCanaryMonitoringStack extends Stack {
+  constructor(
+    scope: Construct,
+    id: string,
+    props: LambdaCanaryMonitoringStackProps
+  ) {
+    super(scope, id, props);
+
+    const dashboardLambda = this.createDashboardLambda(props.monitoring.dashboard);
+    const businessLambda = this.createBusinessLambda(props.VERSION_NUMBER);
+    const deploymentGroup = this.deployBusinessLambda(businessLambda, dashboardLambda);
+    this.assignIAMPolicyToDashboardLambda(dashboardLambda, props.monitoring.dashboard, deploymentGroup);
+  }
+
+  private createBusinessLambda(versionNumber:string): lambda.Function{
+    return new NodejsFunction(this, 'Business-Lambda', {
+      currentVersionOptions: {
+        removalPolicy: RemovalPolicy.RETAIN,
+      },
+      runtime: lambda.Runtime.NODEJS_18_X,
+      handler: 'handler',
+      entry: path.join(__dirname, '../lambda-code/app.ts'),
+      timeout: Duration.seconds(25),
+      environment: {
+        SLEEP_SEC: '2',
+        VERSION: versionNumber,
+      },
+    });
+  }
+
+  private deployBusinessLambda(handler: lambda.Function, dashboardLambda: lambda.Function):codedeploy.LambdaDeploymentGroup {
+    const application = new codedeploy.LambdaApplication(
+      this,
+      'CodeDeployApplication',
+      {
+        applicationName: 'LambdaCanaryMonitoringApplication',
+      }
+    );
+    
+    const aliasBusinessLambda = new lambda.Alias(this, 'alias', {
+      aliasName: 'prod',
+      version: handler.currentVersion,
+      // provisionedConcurrentExecutions: 100, //commented this line to reduce accidental costs. Comment in, to test provisioned concurrency traffic shift
+    });
+    
+
+    const deploymentGroup = new codedeploy.LambdaDeploymentGroup(this,
+      'LambdaCanaryMonitoringDeploymentGroup',
+      {
+        application: application,
+        alias: aliasBusinessLambda,
+        deploymentConfig: codedeploy.LambdaDeploymentConfig.ALL_AT_ONCE,
+        preHook: dashboardLambda,
+      }
+    );
+
+    // Can be used to run a load test during traffic shift
+    aliasBusinessLambda.addFunctionUrl({
+      authType: lambda.FunctionUrlAuthType.NONE,
+    });
+    return deploymentGroup;
+  }
+
+  /**
+   * Creates the Lambda Function that will be called in the CodeDeploy preHook and changes the given CloudWatch Dashboard
+   * @param dashboard Name of the dashboard where the metrics should be added
+   */
+  private createDashboardLambda(dashboard: cloudwatch.Dashboard): lambda.Function {
+    return new NodejsFunction(this, 'Dashboard-Lambda', {
+      runtime: lambda.Runtime.NODEJS_18_X,
+      handler: 'handler',
+      entry: path.join(__dirname, '../lambda-code/dashboard-lambda.ts'),
+      environment: { DASHBOARD_NAME: dashboard.dashboardName },
+      timeout: Duration.seconds(10),
+      bundling: {
+        externalModules: ['aws-sdk'],
+        sourceMap: true,
+      },
+    });
+  }
+
+  private assignIAMPolicyToDashboardLambda(dashboardLambda: lambda.Function, dashboard: cloudwatch.Dashboard, deploymentGroup: codedeploy.LambdaDeploymentGroup){
+    /**
+     * IAM Policies for the Lambda to read from CodeDeploy and create the CloudWatch Dashboard
+     */
+    const policyCodeDeployApplication = new PolicyStatement();
+    policyCodeDeployApplication.addResources(deploymentGroup.application.applicationArn);
+    policyCodeDeployApplication.addActions('codedeploy:GetApplicationRevision');
+    
+    const policyCodeDeployDeploymentGroup = new PolicyStatement();
+    policyCodeDeployDeploymentGroup.addResources(deploymentGroup.deploymentGroupArn);
+    policyCodeDeployDeploymentGroup.addActions('codedeploy:GetDeployment');
+        
+    const policyCloudwatch = new PolicyStatement();
+    policyCloudwatch.addResources(dashboard.dashboardArn+dashboard.dashboardName);
+    policyCloudwatch.addActions('cloudwatch:PutDashboard');
+    
+    dashboardLambda.addToRolePolicy(policyCodeDeployApplication);
+    dashboardLambda.addToRolePolicy(policyCodeDeployDeploymentGroup);
+    dashboardLambda.addToRolePolicy(policyCloudwatch);
+  }
+}

--- a/lambda-canary-monitoring-cdk/cdk/lib/monitoring-stack.ts
+++ b/lambda-canary-monitoring-cdk/cdk/lib/monitoring-stack.ts
@@ -1,0 +1,16 @@
+import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+
+export interface IMonitoring {
+  dashboard: cloudwatch.Dashboard;
+}
+
+export class MonitoringStack extends cdk.Stack implements IMonitoring {
+  public readonly dashboard: cloudwatch.Dashboard;
+
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    this.dashboard = new cloudwatch.Dashboard(this, 'Dashboard');
+  }
+}

--- a/lambda-canary-monitoring-cdk/cdk/package.json
+++ b/lambda-canary-monitoring-cdk/cdk/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "cdk",
+  "version": "0.1.0",
+  "bin": {
+    "cdk": "bin/cdk.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "test": "jest",
+    "cdk": "cdk"
+  },
+  "devDependencies": {
+    "@aws-sdk/client-cloudwatch": "^3.507.0",
+    "@aws-sdk/client-codedeploy": "^3.507.0",
+    "@types/aws-lambda": "^8.10.133",
+    "@types/jest": "^29.5.11",
+    "@types/node": "20.11.14",
+    "aws-cdk": "2.126.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.2",
+    "ts-node": "^10.9.2",
+    "typescript": "~5.3.3"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "2.126.0",
+    "constructs": "^10.0.0",
+    "source-map-support": "^0.5.21"
+  }
+}

--- a/lambda-canary-monitoring-cdk/cdk/tsconfig.json
+++ b/lambda-canary-monitoring-cdk/cdk/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": [
+      "es2020",
+      "dom"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": [
+      "./node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "cdk.out"
+  ]
+}

--- a/lambda-canary-monitoring-cdk/example-pattern.json
+++ b/lambda-canary-monitoring-cdk/example-pattern.json
@@ -1,0 +1,57 @@
+{
+  "title": "AWS Lambda Canary Deployment with Monitoring",
+  "description": "Creates a Canary Deployment for a Lambda function and creates a CloudWatch Dashboard for Monitoring",
+  "language": "Typescript",
+  "level": "200",
+  "framework": "CDK",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "This sample projects demonstrates how to deploy a Lambda Function with CodeDeploy through CDK. It also creates a CloudWatch Dashboard through CodeDeploys BeforeAllowTraffic Hook to monitor the traffic-shift during a canary deployment."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/sfn-athena-cdk-python",
+      "templateURL": "serverless-patterns/lambda-canary-monitoring-cdk",
+      "projectFolder": "lambda-canary-monitoring-cdk",
+      "templateFile": "cdk/bin/cdk.ts"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "Lambda Alias Configuration",
+        "link": "https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html"
+      },
+      {
+        "text": "Practical experience with a serverless-first strategy at Capital One (SVS311)",
+        "link": "https://www.youtube.com/watch?v=NZVNAEK6shc"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "npm i",
+      "cdk deploy --all"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the GitHub repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>cdk delete</code>."
+    ]
+  },
+  "authors": [
+    {
+      "name": "Julian Lang",
+      "image": "https://avatars.githubusercontent.com/u/56228802?v=4",
+      "bio": "Solutions Architect at Amazon Web Services",
+      "linkedin": "langjulian"
+    }
+  ]
+}

--- a/lambda-canary-monitoring-cdk/example-pattern.json
+++ b/lambda-canary-monitoring-cdk/example-pattern.json
@@ -12,7 +12,7 @@
   },
   "gitHub": {
     "template": {
-      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/sfn-athena-cdk-python",
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/lambda-canary-monitoring-cdk",
       "templateURL": "serverless-patterns/lambda-canary-monitoring-cdk",
       "projectFolder": "lambda-canary-monitoring-cdk",
       "templateFile": "cdk/bin/cdk.ts"

--- a/lambda-canary-monitoring-cdk/example-pattern.json
+++ b/lambda-canary-monitoring-cdk/example-pattern.json
@@ -7,7 +7,7 @@
   "introBox": {
     "headline": "How it works",
     "text": [
-      "This sample projects demonstrates how to deploy a Lambda Function with CodeDeploy through CDK. It also creates a CloudWatch Dashboard through CodeDeploys BeforeAllowTraffic Hook to monitor the traffic-shift during a canary deployment."
+      "This sample project demonstrates how to deploy a Lambda Function with CodeDeploy canary deployments through CDK. It also creates a CloudWatch Dashboard through CodeDeploys BeforeAllowTraffic Hook to monitor the traffic-shift during a canary deployment."
     ]
   },
   "gitHub": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added new pattern showing how to implement Canary Deployments with CodeDeploy and Lambda including automated monitoring of the deployment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
