### PR TITLE
New Terraform template - EventBridge Scheduler to CloudWatch Alarm

### DIFF
--- a/eventbridge-schedule-to-cloudwatch-alarm-terraform/README.md
+++ b/eventbridge-schedule-to-cloudwatch-alarm-terraform/README.md
@@ -1,0 +1,60 @@
+# AWS Service 1 to AWS Service 2
+
+This pattern << explain usage >>
+
+Learn more about this pattern at Serverless Land Patterns: << Add the live URL here >>
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ```
+    cd _patterns-model
+    ```
+1. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
+    ```
+    sam deploy --guided
+    ```
+1. During the prompts:
+    * Enter a stack name
+    * Enter the desired AWS Region
+    * Allow SAM CLI to create IAM roles with the required permissions.
+
+    Once you have run `sam deploy --guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+
+1. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## How it works
+
+Explain how the service interaction works.
+
+## Testing
+
+Provide steps to trigger the integration and show what should be observed if successful.
+
+## Cleanup
+ 
+1. Delete the stack
+    ```bash
+    aws cloudformation delete-stack --stack-name STACK_NAME
+    ```
+1. Confirm the stack has been deleted
+    ```bash
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus"
+    ```
+----
+Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/eventbridge-schedule-to-cloudwatch-alarm-terraform/README.md
+++ b/eventbridge-schedule-to-cloudwatch-alarm-terraform/README.md
@@ -1,6 +1,6 @@
-# AWS Service 1 to AWS Service 2
+# EventBridge Scheduler for CloudWatch Alarm
 
-This pattern will create two EventBridge Scheduler schedules to enable and disable the action of a CloudWatch alarm in a specific period. This example will enable the alarm at 08:00 and disable it at 17:00 in the US/Eastern timezone.
+This pattern will create two Amazon EventBridge Scheduler schedules to enable and disable the action of a Amazon CloudWatch alarm in a specific period. This example will enable the alarm at 08:00 and disable it at 17:00 in the US/Eastern timezone.
 
 Learn more about this pattern at Serverless Land Patterns: https://serverlessland.com/patterns/eventbridge-schedule-to-cloudwatch-alarm-terraform.
 
@@ -51,6 +51,6 @@ Two Amazon EventBridge Scheduler schedules will be used to enable and disable th
     ```
 
 ----
-Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 SPDX-License-Identifier: MIT-0

--- a/eventbridge-schedule-to-cloudwatch-alarm-terraform/README.md
+++ b/eventbridge-schedule-to-cloudwatch-alarm-terraform/README.md
@@ -1,4 +1,4 @@
-# EventBridge Scheduler for CloudWatch Alarm
+# Amazon EventBridge Scheduler for Amazon CloudWatch Alarm
 
 This pattern will create two Amazon EventBridge Scheduler schedules to enable and disable the action of a Amazon CloudWatch alarm in a specific period. This example will enable the alarm at 08:00 and disable it at 17:00 in the US/Eastern timezone.
 

--- a/eventbridge-schedule-to-cloudwatch-alarm-terraform/README.md
+++ b/eventbridge-schedule-to-cloudwatch-alarm-terraform/README.md
@@ -1,8 +1,8 @@
 # AWS Service 1 to AWS Service 2
 
-This pattern << explain usage >>
+This pattern will create two EventBridge Scheduler schedules to enable and disable the action of a CloudWatch alarm in a specific period. This example will enable the alarm at 08:00 and disable it at 17:00 in the US/Eastern timezone.
 
-Learn more about this pattern at Serverless Land Patterns: << Add the live URL here >>
+Learn more about this pattern at Serverless Land Patterns: https://serverlessland.com/patterns/eventbridge-schedule-to-cloudwatch-alarm-terraform.
 
 Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
 
@@ -21,39 +21,35 @@ Important: this application uses various AWS services and there are costs associ
     ```
 1. Change directory to the pattern directory:
     ```
-    cd _patterns-model
+    cd eventbridge-schedule-to-cloudwatch-alarm-terraform
     ```
-1. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
+1. From the command line, initialize terraform to download and install the providers defined in the configuration: 
     ```
-    sam deploy --guided
+    terraform init
     ```
-1. During the prompts:
-    * Enter a stack name
-    * Enter the desired AWS Region
-    * Allow SAM CLI to create IAM roles with the required permissions.
+1. From the commend line, apply the configuration in the main.tf file and follow the prompts: 
+    ```
+    terraform apply
+    ```
 
-    Once you have run `sam deploy --guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
-
-1. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
 
 ## How it works
 
-Explain how the service interaction works.
+Two Amazon EventBridge Scheduler schedules will be used to enable and disable the action of a CloudWatch alarm. The Terraform template creates a VPC, an EC2 instance and two schedules that invokes the enableAlarmActions and disableAlarmActions API regularly.
 
 ## Testing
 
-Provide steps to trigger the integration and show what should be observed if successful.
+1. After the deployment, review the schedule created in the Amazon EventBridge console under Scheduler > Schedules. 
+2. Navigate to the CloudWatch console to verify the alarm graph, a period with blue color under the graph is representing the action has been disabled.
+3. Navigate to the CloudTrail console to verify the enableAlarmActions and disableAlarmActions API calls.
 
 ## Cleanup
  
-1. Delete the stack
-    ```bash
-    aws cloudformation delete-stack --stack-name STACK_NAME
+1. Delete all created resources and follow prompts:
     ```
-1. Confirm the stack has been deleted
-    ```bash
-    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus"
+    terraform destroy
     ```
+
 ----
 Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 

--- a/eventbridge-schedule-to-cloudwatch-alarm-terraform/eventbridge-schedule-to-cloudwatch-alarm-terraform.json
+++ b/eventbridge-schedule-to-cloudwatch-alarm-terraform/eventbridge-schedule-to-cloudwatch-alarm-terraform.json
@@ -1,5 +1,5 @@
 {
-    "title": "EventBridge Scheduler for CloudWatch Alarm",
+    "title": "Amazon EventBridge Scheduler for Amazon CloudWatch Alarm",
     "description": "Create two Amazon EventBridge Scheduler schedules to enable and disable the action of a CloudWatch alarm",
     "language": "YAML",
     "level": "200",

--- a/eventbridge-schedule-to-cloudwatch-alarm-terraform/eventbridge-schedule-to-cloudwatch-alarm-terraform.json
+++ b/eventbridge-schedule-to-cloudwatch-alarm-terraform/eventbridge-schedule-to-cloudwatch-alarm-terraform.json
@@ -1,0 +1,72 @@
+{
+    "title": "EventBridge Scheduler for CloudWatch Alarm",
+    "description": "Create two Amazon EventBridge Scheduler schedules to enable and disable the action of a CloudWatch alarm",
+    "language": "YAML",
+    "level": "200",
+    "framework": "Terraform",
+    "introBox": {
+        "headline": "How it works",
+        "text": [
+            "Two Amazon EventBridge Scheduler schedules will be used to enable and disable the action of a CloudWatch alarm.",
+            "This Terraform template creates a VPC, an EC2 instance and two schedules that invokes the enableAlarmActions and disableAlarmActions API regularly."
+        ]
+    },
+    "gitHub": {
+        "template": {
+            "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-schedule-to-cloudwatch-alarm-terraform",
+            "templateURL": "serverless-patterns/eventbridge-schedule-to-cloudwatch-alarm-terraform",
+            "projectFolder": "eventbridge-schedule-to-cloudwatch-alarm-terraform",
+            "templateFile": "main.tf"
+        }
+    },
+    "resources": {
+        "bullets": [
+            {
+                "text": "Using universal targets in EventBridge Scheduler",
+                "link": "https://docs.aws.amazon.com/scheduler/latest/UserGuide/managing-targets-universal.html"
+            }
+        ]
+    },
+    "deploy": {
+        "text": [
+            "See the GitHub repo for detailed deployment instructions."
+        ]
+    },
+    "testing": {
+        "text": [
+            "See the GitHub repo for detailed testing instructions."
+        ]
+    },
+    "cleanup": {
+        "text": [
+            "Delete the stack: <code>terraform destroy</code>."
+        ]
+    },
+    "authors": [
+        {
+            "name": "Edwin So",
+            "image": "https://media.licdn.com/dms/image/C5603AQGXFWV-L0nYuw/profile-displayphoto-shrink_200_200/0/1596368326454?e=1715212800&v=beta&t=-Xc2wRWeM1TiNpldpkHC7RsgjjzJJ17U0np-VQs0ij0",
+            "bio": "Cloud Support Engineer @ AWS | CloudWatch SME",
+            "linkedin": "edwin-so"
+        }
+    ],
+    "patternArch": {
+        "icon1": {
+            "x": 20,
+            "y": 50,
+            "service": "eventbridge-scheduler",
+            "label": "EventBridge Scheduler"
+        },
+        "icon2": {
+            "x": 80,
+            "y": 50,
+            "service": "cloudwatch",
+            "label": "CloudWatch alarms"
+        },
+        "line1": {
+            "from": "icon1",
+            "to": "icon2",
+            "label": "enables/disables"
+        }
+    }
+}

--- a/eventbridge-schedule-to-cloudwatch-alarm-terraform/example-pattern.json
+++ b/eventbridge-schedule-to-cloudwatch-alarm-terraform/example-pattern.json
@@ -1,5 +1,5 @@
 {
-  "title": "EventBridge Scheduler to CloudWatch Alarm",
+  "title": "EventBridge Scheduler for CloudWatch Alarm",
   "description": "Create two EventBridge Scheduler schedules to enable and disable the action of a CloudWatch alarm",
   "language": "HCL",
   "level": "200",
@@ -47,7 +47,7 @@
       "name": "Edwin So",
       "image": "https://media.licdn.com/dms/image/C5603AQGXFWV-L0nYuw/profile-displayphoto-shrink_200_200/0/1596368326454?e=1715212800&v=beta&t=-Xc2wRWeM1TiNpldpkHC7RsgjjzJJ17U0np-VQs0ij0",
       "bio": "Cloud Support Engineer @ AWS | CloudWatch SME",
-      "linkedin": "https://www.linkedin.com/in/edwin-so/"
+      "linkedin": "edwin-so"
     }
   ]
 }

--- a/eventbridge-schedule-to-cloudwatch-alarm-terraform/example-pattern.json
+++ b/eventbridge-schedule-to-cloudwatch-alarm-terraform/example-pattern.json
@@ -1,0 +1,59 @@
+{
+  "title": "Step Functions to Athena",
+  "description": "Create a Step Functions workflow to query Amazon Athena.",
+  "language": "Python",
+  "level": "200",
+  "framework": "CDK",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "This sample project demonstrates how to use an AWS Step Functions state machine to query Athena and get the results. This pattern is leveraging the native integration between these 2 services which means only JSON-based, structured language is used to define the implementation.",
+      "With Amazon Athena you can get up to 1000 results per invocation of the GetQueryResults method and this is the reason why the Step Function has a loop to get more results. The results are sent to a Map which can be configured to handle (the DoSomething state) the items in parallel or one by one by modifying the max_concurrency parameter.",
+      "This pattern deploys one Step Functions, two S3 Buckets, one Glue table and one Glue database."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/sfn-athena-cdk-python",
+      "templateURL": "serverless-patterns/sfn-athena-cdk-python",
+      "projectFolder": "sfn-athena-cdk-python",
+      "templateFile": "sfn_athena_cdk_python_stack.py"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "Call Athena with Step Functions",
+        "link": "https://docs.aws.amazon.com/step-functions/latest/dg/connect-athena.html"
+      },
+      {
+        "text": "Amazon Athena - Serverless Interactive Query Service",
+        "link": "https://aws.amazon.com/athena/"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "sam deploy"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the GitHub repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>cdk delete</code>."
+    ]
+  },
+  "authors": [
+    {
+      "name": "Your name",
+      "image": "link-to-your-photo.jpg",
+      "bio": "Your bio.",
+      "linkedin": "linked-in-ID",
+      "twitter": "twitter-handle"
+    }
+  ]
+}

--- a/eventbridge-schedule-to-cloudwatch-alarm-terraform/example-pattern.json
+++ b/eventbridge-schedule-to-cloudwatch-alarm-terraform/example-pattern.json
@@ -1,40 +1,35 @@
 {
-  "title": "Step Functions to Athena",
-  "description": "Create a Step Functions workflow to query Amazon Athena.",
-  "language": "Python",
+  "title": "EventBridge Scheduler to CloudWatch Alarm",
+  "description": "Create two EventBridge Scheduler schedules to enable and disable the action of a CloudWatch alarm",
+  "language": "HCL",
   "level": "200",
-  "framework": "CDK",
+  "framework": "Terraform",
   "introBox": {
     "headline": "How it works",
     "text": [
-      "This sample project demonstrates how to use an AWS Step Functions state machine to query Athena and get the results. This pattern is leveraging the native integration between these 2 services which means only JSON-based, structured language is used to define the implementation.",
-      "With Amazon Athena you can get up to 1000 results per invocation of the GetQueryResults method and this is the reason why the Step Function has a loop to get more results. The results are sent to a Map which can be configured to handle (the DoSomething state) the items in parallel or one by one by modifying the max_concurrency parameter.",
-      "This pattern deploys one Step Functions, two S3 Buckets, one Glue table and one Glue database."
+      "Two Amazon EventBridge Scheduler schedules will be used to enable and disable the action of a CloudWatch alarm.",
+      "This Terraform template creates a VPC, an EC2 instance and two schedules that invokes the enableAlarmActions and disableAlarmActions API regularly."
     ]
   },
   "gitHub": {
     "template": {
-      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/sfn-athena-cdk-python",
-      "templateURL": "serverless-patterns/sfn-athena-cdk-python",
-      "projectFolder": "sfn-athena-cdk-python",
-      "templateFile": "sfn_athena_cdk_python_stack.py"
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-schedule-to-cloudwatch-alarm-terraform",
+      "templateURL": "serverless-patterns/eventbridge-schedule-to-cloudwatch-alarm-terraform",
+      "projectFolder": "eventbridge-schedule-to-cloudwatch-alarm-terraform",
+      "templateFile": "main.tf"
     }
   },
   "resources": {
     "bullets": [
       {
-        "text": "Call Athena with Step Functions",
-        "link": "https://docs.aws.amazon.com/step-functions/latest/dg/connect-athena.html"
-      },
-      {
-        "text": "Amazon Athena - Serverless Interactive Query Service",
-        "link": "https://aws.amazon.com/athena/"
+        "text": "Using universal targets in EventBridge Scheduler",
+        "link": "https://docs.aws.amazon.com/scheduler/latest/UserGuide/managing-targets-universal.html"
       }
     ]
   },
   "deploy": {
     "text": [
-      "sam deploy"
+      "See the GitHub repo for detailed deployment instructions."
     ]
   },
   "testing": {
@@ -44,16 +39,15 @@
   },
   "cleanup": {
     "text": [
-      "Delete the stack: <code>cdk delete</code>."
+      "Delete the stack: <code>terraform destroy</code>."
     ]
   },
   "authors": [
     {
-      "name": "Your name",
-      "image": "link-to-your-photo.jpg",
-      "bio": "Your bio.",
-      "linkedin": "linked-in-ID",
-      "twitter": "twitter-handle"
+      "name": "Edwin So",
+      "image": "https://media.licdn.com/dms/image/C5603AQGXFWV-L0nYuw/profile-displayphoto-shrink_200_200/0/1596368326454?e=1715212800&v=beta&t=-Xc2wRWeM1TiNpldpkHC7RsgjjzJJ17U0np-VQs0ij0",
+      "bio": "Cloud Support Engineer @ AWS | CloudWatch SME",
+      "linkedin": "https://www.linkedin.com/in/edwin-so/"
     }
   ]
 }

--- a/eventbridge-schedule-to-cloudwatch-alarm-terraform/example-pattern.json
+++ b/eventbridge-schedule-to-cloudwatch-alarm-terraform/example-pattern.json
@@ -1,5 +1,5 @@
 {
-  "title": "EventBridge Scheduler for CloudWatch Alarm",
+  "title": "Amazon EventBridge Scheduler for Amazon CloudWatch Alarm",
   "description": "Create two EventBridge Scheduler schedules to enable and disable the action of a CloudWatch alarm",
   "language": "HCL",
   "level": "200",

--- a/eventbridge-schedule-to-cloudwatch-alarm-terraform/main.tf
+++ b/eventbridge-schedule-to-cloudwatch-alarm-terraform/main.tf
@@ -1,0 +1,168 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+    account_id = data.aws_caller_identity.current.account_id
+}
+
+# This section creates the VPC and subnet for the Amazon EC2 instance
+
+resource "aws_vpc" "vpc" {
+  cidr_block  = var.vpc_cidr
+}
+
+resource "aws_subnet" "subnet" {
+  vpc_id      = aws_vpc.vpc.id
+  cidr_block  = var.subnet_cidr
+  tags        = {
+    Name = "my-private-subnet-1"
+  }
+}
+
+# This section creates an Amazon EC2 instance using the latest Amazon Linux 2 AMI
+
+data "aws_ami" "amazon-linux-2" {
+  most_recent = true
+
+  filter {
+    name = "owner-alias"
+    values = ["amazon"]
+  }
+  
+  filter {
+    name = "name"
+    values = ["amzn2-ami-hvm*"]
+  }
+}
+
+resource "aws_instance" "example-ec2" {
+  ami           = "${data.aws_ami.amazon-linux-2.id}"
+  instance_type = "t2.micro"
+  subnet_id     = aws_subnet.subnet.id
+  tags = {
+    Name = "example-ec2"
+  }
+}
+
+# This section creates an Amazon CloudWatch alarm of the CPUUtilization metric
+
+resource "aws_cloudwatch_metric_alarm" "example-ec2-cpu-alarm" {
+  alarm_name          = "example-ec2-cpu-alarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "80"
+  alarm_description   = "This alarm is monitoring the CPUUtilization metric of an EC2 instance"
+  alarm_actions       = []
+  dimensions = {
+    InstanceId = "${aws_instance.example-ec2.id}"
+  }
+}
+
+
+# This section creates the cron schedules using Amazon EventBridge Scheduler
+
+resource "aws_scheduler_schedule" "enable-ec2-alarm" {
+  name = "enable-ec2-alarm"
+  
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  schedule_expression = "cron(0 8 ? * MON-FRI *)" # Scheduled EnableAlarmActions at 8am EST Mon-Fri
+  schedule_expression_timezone = "US/Eastern" # Default is UTC
+  description = "Enable the CloudWatch alarm for EC2 CPU monitoring"
+
+  target {
+    arn = "arn:aws:scheduler:::aws-sdk:cloudwatch:enableAlarmActions"
+    role_arn = aws_iam_role.scheduler-alarm-role.arn
+  
+    input = jsonencode({
+      "AlarmNames": [
+        "example-ec2-cpu-alarm"
+      ]
+    })
+  }
+}
+
+resource "aws_scheduler_schedule" "disable-ec2-alarm" {
+  name = "disable-ec2-alarm"
+  
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  schedule_expression = "cron(0 17 ? * MON-FRI *)" # Scheduled DisableAlarmActions at 5pm EST Mon-Fri
+  schedule_expression_timezone = "US/Eastern" # Default is UTC
+  description = "Disable the CloudWatch alarm for EC2 CPU monitoring"
+
+  target {
+    arn = "arn:aws:scheduler:::aws-sdk:cloudwatch:disableAlarmActions"
+    role_arn = aws_iam_role.scheduler-alarm-role.arn
+  
+    input = jsonencode({
+      "AlarmNames": [
+        "example-ec2-cpu-alarm"
+      ]
+    })
+  }
+}
+
+# This section creates the required IAM policy and role to interact with CloudWatch alarm
+
+resource "aws_iam_policy" "scheduler_alarm_policy" {
+  name = "scheduler_alarm_policy"
+
+  policy = jsonencode(
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "VisualEditor0",
+                "Effect": "Allow",
+                "Action": [
+                    "cloudwatch:EnableAlarmActions",
+                    "cloudwatch:DisableAlarmActions"
+                ],
+                "Resource": [
+                  "arn:aws:cloudwatch:${var.region}:${local.account_id}:alarm:example-ec2-cpu-alarm"
+                ],
+            }
+        ]
+    }
+  )
+}
+
+resource "aws_iam_role" "scheduler-alarm-role" {
+  name = "scheduler-alarm-role"
+  managed_policy_arns = [aws_iam_policy.scheduler_alarm_policy.arn]
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "scheduler.amazonaws.com"
+        }
+      },
+    ]
+  })
+}

--- a/eventbridge-schedule-to-cloudwatch-alarm-terraform/variable.tf
+++ b/eventbridge-schedule-to-cloudwatch-alarm-terraform/variable.tf
@@ -1,0 +1,23 @@
+variable "region" {
+    type=string
+    description = "AWS Region where deploying resources"
+    default = "us-west-1"
+}
+
+variable "aws_profile_name" {
+    type=string
+    description = "AWS CLI credentials profile name"
+    default="default"
+}
+
+variable "vpc_cidr" {
+    type=string
+    description = "CIDR block for VPC"
+    default = "10.0.0.0/16"
+}
+
+variable "subnet_cidr" {
+    type=string
+    description = "CIDR block for the subnet"
+    default = "10.0.0.0/24"
+}


### PR DESCRIPTION
*Issue #2172, if available:*

*Description of changes:*
New Terraform template that creates two EventBridge Scheduler schedules to enable and disable the action of a CloudWatch alarm

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
