### PR TITLE
fix: web acl association race condition

### DIFF
--- a/waf-apigw-rest/template.yaml
+++ b/waf-apigw-rest/template.yaml
@@ -48,7 +48,7 @@ Resources:
   MyWAFAssociation:
     Type: AWS::WAFv2::WebACLAssociation
     Properties: 
-      ResourceArn: !Sub arn:aws:apigateway:${AWS::Region}::/restapis/${MyApi}/stages/Prod
+      ResourceArn: !Sub arn:aws:apigateway:${AWS::Region}::/restapis/${MyApi}/stages/${MyApi.Stage}
       WebACLArn: !GetAtt MyWAFACL.Arn
 
 # Lambda function as an example micro-service behind the API Gateway REST endpoint


### PR DESCRIPTION
*Fix race condition when creating a WAF ACL Association resource:*

CloudFormation expects the api gateway stage to be created, to fix this we can Reference our Api Gateway Stage resource using ${logicalId.Stage}

This fixes an issue I got when testing the proposed template

```
AWS WAF couldn?t perform the operation because your resource doesn?t exist.
```
