### PR TITLE
adding s3-sfn-lambda-bedrock

### DIFF
--- a/s3-sfn-lambda-bedrock/example-pattern.json
+++ b/s3-sfn-lambda-bedrock/example-pattern.json
@@ -1,0 +1,73 @@
+{
+    "title": "S3 to Step Functions to Lambda to Bedrock",
+    "description": "Create a Step Functions workflow to summarize S3 objects using Amazon Bedrock.",
+    "language": "Python",
+    "level": "300",
+    "framework": "SAM",
+    "introBox": {
+      "headline": "Serverless Document Summarization with Bedrock",
+      "text": [
+        "This sample project demonstrates how to use an AWS Step Functions state machine to orchestrate S3 object summarization using Amazon Bedrock. The state machine is triggered by new file uploads to an S3 bucket and coordinates the execution of Lambda functions to process and summarize the documents.",
+        "The state machine first checks the file type (txt, pdf, or docx) and invokes the appropriate Lambda function to extract the text content. The extracted text is then passed to another Lambda function that leverages Amazon Bedrock's natural language processing capabilities to generate a concise summary.",
+        "The generated summary is stored in the original S3 bucket, providing users with a convenient way to access the key information from large documents without having to read through the entire content."
+      ]
+    },
+    "gitHub": {
+      "template": {
+        "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/sfn-bedrock-sam",
+        "templateURL": "serverless-patterns/s3-sfn-lambda-bedrock",
+        "projectFolder": "s3-sfn-lambda-bedrock",
+        "templateFile": "template.yaml"
+      }
+    },
+    "resources": {
+      "bullets": [
+        {
+          "text": "Amazon Bedrock",
+          "link": "https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html"
+        },
+        {
+          "text": "Amazon Bedrock - Inference parameters for foundation models",
+          "link": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html"
+        },
+        {
+          "text": "AWS Step Functions",
+          "link": "https://aws.amazon.com/step-functions/"
+        },
+        {
+          "text": "AWS Lambda",
+          "link": "https://aws.amazon.com/lambda/"
+        },
+        {
+          "text": "AWS Serverless Application Model (SAM)",
+          "link": "https://aws.amazon.com/serverless/sam/"
+        },
+        {
+          "text": "AWS Serverless Data Analytics Pipeline Reference Architecture",
+          "link": "https://aws.amazon.com/blogs/big-data/aws-serverless-data-analytics-pipeline-reference-architecture/"
+        },
+        {
+          "text": "AWS Serverless Data Analytics Pipeline Whitepaper",
+          "link": "https://docs.aws.amazon.com/whitepapers/latest/aws-serverless-data-analytics-pipeline/aws-serverless-data-analytics-pipeline.html"
+        }
+      ]
+    },
+    "deploy": {
+      "text": [
+        "Deploy the stack: <code>sam build && sam deploy --guided</code>"
+      ]
+    },
+    "cleanup": {
+      "text": [
+        "Delete the stack: <code>sam delete</code>"
+      ]
+    },
+    "authors": [
+      {
+        "name": "Dave Horne",
+        "image": "https://media.licdn.com/dms/image/D4E03AQF8MofRpp10sw/profile-displayphoto-shrink_400_400/0/1670374747266?e=1715817600&v=beta&t=DpsC6xY9pF6DTItgjgkdKI5eXMCOnt2ZO7I9ftYnam4",
+        "bio": "Dave is a Sr. Solutions Architect supporting Federal System Integrators at AWS. He is based in Washington, DC and has 15 years of experience building, modernizing and integrating systems for Public Sector customers. Outside of work, Dave enjoys playing with his kids and hiking.",
+        "linkedin": "davidjhorne"
+      }
+    ]
+  }

--- a/s3-sfn-lambda-bedrock/functions/ingest_doc/app.py
+++ b/s3-sfn-lambda-bedrock/functions/ingest_doc/app.py
@@ -1,0 +1,46 @@
+import boto3
+import urllib.parse
+import os
+import tempfile
+from docx import Document
+
+s3 = boto3.client('s3')
+
+def lambda_handler(event, context):
+    bucket = event['detail']['bucket']['name']
+    source_key = event['detail']['object']['key']
+
+    try:
+        # Download the Word document from S3
+        response = s3.get_object(Bucket=bucket, Key=source_key)
+        word_content = response['Body'].read()
+
+        # Create a temporary file from the Word document content
+        with tempfile.TemporaryFile() as temp_file:
+            temp_file.write(word_content)
+            temp_file.seek(0)  # Move the file pointer to the beginning
+
+            # Open the temporary file using the python-docx library
+            doc = Document(temp_file)
+            text = ''
+            for para in doc.paragraphs:
+                text += para.text + "\n"
+
+        # Remove the 'raw/' prefix from the object key
+        object_name = os.path.basename(source_key)
+
+        # Write the text to a text file in the 'cleaned' prefix
+        next_key = os.path.join(os.environ['NextPrefix'], object_name + "_text.txt")
+        s3.put_object(Bucket=bucket, Key=next_key, Body=text.encode('utf-8'))
+
+        print(f"Text extracted from Word document and written to {next_key} in bucket {bucket}")
+    except Exception as e:
+        print(f"Error: {e}")
+        raise e
+
+    return {
+        'statusCode': 200,
+        'body': f'File {source_key} processed and written to {next_key}',
+        'next_key': next_key,
+        'bucket': bucket
+    }

--- a/s3-sfn-lambda-bedrock/functions/ingest_doc/requirements.txt
+++ b/s3-sfn-lambda-bedrock/functions/ingest_doc/requirements.txt
@@ -1,0 +1,1 @@
+python-docx

--- a/s3-sfn-lambda-bedrock/functions/ingest_pdf/app.py
+++ b/s3-sfn-lambda-bedrock/functions/ingest_pdf/app.py
@@ -1,0 +1,47 @@
+import boto3
+import urllib.parse
+import os
+import tempfile
+from pdf2image import convert_from_path
+from PyPDF2 import PdfReader
+
+s3 = boto3.client('s3')
+
+def lambda_handler(event, context):
+    bucket = event['detail']['bucket']['name']
+    source_key = event['detail']['object']['key']
+
+    try:
+        # Download the PDF file from S3
+        response = s3.get_object(Bucket=bucket, Key=source_key)
+        pdf_content = response['Body'].read()
+
+        # Create a temporary file from the PDF content
+        with tempfile.TemporaryFile() as temp_file:
+            temp_file.write(pdf_content)
+            temp_file.seek(0)  # Move the file pointer to the beginning
+
+            # Extract text from the PDF file
+            pdf_reader = PdfReader(temp_file)
+            text = ''
+            for page in range(len(pdf_reader.pages)):
+                text += pdf_reader.pages[page].extract_text()
+
+        # Remove the 'raw/' prefix from the object key
+        object_name = os.path.basename(source_key)
+
+        # Write the text to a text file in the 'stage' prefix
+        next_key = os.path.join(os.environ['NextPrefix'], object_name + "_text.txt")
+        s3.put_object(Bucket=bucket, Key=next_key, Body=text.encode('utf-8'))
+
+        print(f"Text extracted from PDF and written to {next_key} in bucket {bucket}")
+    except Exception as e:
+        print(f"Error: {e}")
+        raise e
+
+    return {
+        'statusCode': 200,
+        'body': f'File {source_key} processed and written to {next_key}',
+        'next_key': next_key,
+        'bucket': bucket
+    }

--- a/s3-sfn-lambda-bedrock/functions/ingest_pdf/requirements.txt
+++ b/s3-sfn-lambda-bedrock/functions/ingest_pdf/requirements.txt
@@ -1,0 +1,2 @@
+PyPDF2
+pdf2image

--- a/s3-sfn-lambda-bedrock/functions/ingest_text/app.py
+++ b/s3-sfn-lambda-bedrock/functions/ingest_text/app.py
@@ -1,0 +1,37 @@
+import base64
+import boto3
+import chardet
+import os
+
+s3 = boto3.client('s3')
+
+def lambda_handler(event, context):
+    # Extract the S3 bucket and key from the Step Functions event
+    bucket = event['detail']['bucket']['name']
+    source_key = event['detail']['object']['key']
+
+    # Download the file from S3
+    response = s3.get_object(Bucket=bucket, Key=source_key)
+    content = response['Body'].read()
+
+    # Detect the file encoding
+    detected_encoding = chardet.detect(content)['encoding']
+
+    # Decode the content using the detected encoding
+    decoded_content = content.decode(detected_encoding or 'utf-8')
+
+    # Encode the content as UTF-8
+    encoded_content = decoded_content.encode('utf-8')
+
+    # Remove the 'raw/' prefix from the object key
+    object_name = os.path.basename(source_key)
+
+    next_key = os.path.join(os.environ['NextPrefix'], object_name + "_text.txt")
+    s3.put_object(Bucket=bucket, Key=next_key, Body=encoded_content)
+
+    return {
+        'statusCode': 200,
+        'body': f'File {source_key} processed and written to {next_key}',
+        'next_key': next_key,
+        'bucket': bucket
+    }

--- a/s3-sfn-lambda-bedrock/functions/ingest_text/requirements.txt
+++ b/s3-sfn-lambda-bedrock/functions/ingest_text/requirements.txt
@@ -1,0 +1,1 @@
+chardet

--- a/s3-sfn-lambda-bedrock/functions/summarize_text/app.py
+++ b/s3-sfn-lambda-bedrock/functions/summarize_text/app.py
@@ -1,0 +1,71 @@
+import json
+import boto3
+import os
+from urllib.parse import unquote_plus
+from datetime import datetime
+
+def getSummaryFromText(content):
+    modelId = "anthropic.claude-v2:1"
+    contentType = "application/json"
+    accept = "*/*"
+    
+    body = json.dumps({
+    "prompt": "\n\nHuman: " + os.environ['BedrockPrompt'] + " \n " +content+ "\n\nAssistant:",
+    "max_tokens_to_sample": 300,
+    "temperature": 0.1,
+    "top_p": 0.9,
+})
+
+    
+    bedrock_client = boto3.client("bedrock-runtime")
+
+    response = bedrock_client.invoke_model(
+        modelId=modelId, contentType=contentType, accept=accept, body=body
+    )
+
+    response_body = json.loads(response.get("body").read())
+    return response_body["completion"]
+
+
+def readFile(bucket, key):
+    s3_client = boto3.client("s3")
+    fileObj = s3_client.get_object(Bucket=bucket, Key=key)
+    file_content = fileObj["Body"].read().decode("utf-8")
+    return file_content
+
+
+def lambda_handler(event, context):
+    txt_response = ""
+    s3 = boto3.client("s3")
+    if event:
+        print("event", event)
+        
+        # Get the staged key and bucket name from the Step Functions event
+        source_key = event["SourceKey"]
+        
+        # Check if the 'detail' key exists in the event
+        bucketname = event["Bucket"]
+        
+        file_content = readFile(bucketname, source_key)
+        print(file_content)
+
+        txt_response = getSummaryFromText(file_content)
+        print("Response:")
+        print(txt_response)
+
+        # Write output file to S3 bucket
+        output_data = {
+            "original_content": file_content,
+            "summary": txt_response,
+            "model": "anthropic.claude-v2:1",
+            "datetime": str(datetime.now())
+        }
+
+        output_key = os.environ['NextPrefix'] + f"{source_key.split('/')[-1]}.json"
+        s3.put_object(
+            Body=json.dumps(output_data),
+            Bucket=bucketname,
+            Key=output_key
+        )
+
+    return {"statusCode": 200, "body": "File summary generated and uploaded to S3"}

--- a/s3-sfn-lambda-bedrock/functions/summarize_text/requirements.txt
+++ b/s3-sfn-lambda-bedrock/functions/summarize_text/requirements.txt
@@ -1,0 +1,2 @@
+requests
+boto3==1.28.68

--- a/s3-sfn-lambda-bedrock/statemachine/statemachine.asl.json
+++ b/s3-sfn-lambda-bedrock/statemachine/statemachine.asl.json
@@ -1,0 +1,56 @@
+{
+	"Comment": "A state machine that summarizes different types of files",
+	"StartAt": "CheckFileType",
+	"States": {
+		"CheckFileType": {
+			"Type": "Choice",
+			"Choices": [
+				{
+					"Variable": "$.detail.object.key",
+					"StringMatches": "*txt",
+					"Next": "IngestTextFile"
+				},
+				{
+					"Variable": "$.detail.object.key",
+					"StringMatches": "*pdf",
+					"Next": "IngestPDFFile"
+				},
+				{
+					"Variable": "$.detail.object.key",
+					"StringMatches": "*docx",
+					"Next": "IngestDocFile"
+				}
+			],
+			"Default": "UnsupportedFileType"
+		},
+		"IngestTextFile": {
+			"Type": "Task",
+			"Resource": "${IngestTextFunction}",
+			"Next": "SummarizeTextFile"
+		},
+		"IngestPDFFile": {
+			"Type": "Task",
+			"Resource": "${IngestPDFFunction}",
+			"Next": "SummarizeTextFile"
+		},
+		"IngestDocFile": {
+			"Type": "Task",
+			"Resource": "${IngestDocFunction}",
+			"Next": "SummarizeTextFile"
+		},
+		"UnsupportedFileType": {
+			"Type": "Fail",
+			"Error": "UnsupportedFileType",
+			"Cause": "Unsupported file type"
+		},
+		"SummarizeTextFile": {
+			"Type": "Task",
+			"Resource": "${SummarizeTextFileFunction}",
+			"Parameters": {
+				"SourceKey.$": "$.next_key",
+				"Bucket.$": "$.bucket"
+			},
+			"End": true
+		}
+	}
+}

--- a/s3-sfn-lambda-bedrock/template.yaml
+++ b/s3-sfn-lambda-bedrock/template.yaml
@@ -1,0 +1,201 @@
+Transform: AWS::Serverless-2016-10-31
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Step Functions workflow to summarize documents using Amazon Bedrock
+Parameters:
+  RawPrefix:
+    Type: String
+    Default: raw/
+  CleanedPrefix:
+    Type: String
+    Default: cleaned/
+  CuratedPrefix:
+    Type: String
+    Default: curated/
+  BedrockPrompt:
+    Type: String
+    Default: 'You are a business analyst.  Review the following content and produce a concise summary for an executive.  Also, generate tags that can be used to find the content in a search or word cloud: '
+Resources:
+  ContentBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub ${AWS::StackName}-contentbu-${AWS::AccountId}
+      NotificationConfiguration:
+        EventBridgeConfiguration:
+          EventBridgeEnabled: true
+  SummarizeContent:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      DefinitionSubstitutions:
+        IngestTextFunction: !GetAtt IngestTextFunction.Arn
+        IngestPDFFunction: !GetAtt IngestPDFFunction.Arn
+        IngestDocFunction: !GetAtt IngestDocFunction.Arn
+        SummarizeTextFileFunction: !GetAtt SummarizeTextFileFunction.Arn
+      Logging:
+        Level: ALL
+        IncludeExecutionData: true
+        Destinations:
+          - CloudWatchLogsLogGroup:
+              LogGroupArn: !GetAtt StateMachineLogGroup.Arn
+      Role: !GetAtt StateMachineRole.Arn
+      Tracing:
+        Enabled: true
+      Type: EXPRESS
+      Events:
+        RawFileTrigger:
+          Type: EventBridgeRule
+          Properties:
+            EventBusName: default
+            Pattern:
+              source:
+                - aws.s3
+              detail-type:
+                - Object Created
+              detail:
+                bucket:
+                  name:
+                    - !Ref ContentBucket
+                object:
+                  key:
+                    - prefix: !Ref RawPrefix
+      DefinitionUri: statemachine/statemachine.asl.json
+    DependsOn:
+      - IngestTextFunction
+      - IngestPDFFunction
+      - IngestDocFunction
+      - SummarizeTextFileFunction
+  StateMachineLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub
+        - /aws/vendedlogs/states/${AWS::StackName}-${ResourceId}-Logs
+        - ResourceId: StateMachineLG
+  StateMachineRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: states.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: InvokeLambdaPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - lambda:InvokeFunction
+                Resource:
+                  - !GetAtt IngestTextFunction.Arn
+                  - !GetAtt IngestPDFFunction.Arn
+                  - !GetAtt IngestDocFunction.Arn
+                  - !GetAtt SummarizeTextFileFunction.Arn
+        - PolicyName: CloudWatchLogsPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogDelivery
+                  - logs:GetLogDelivery
+                  - logs:UpdateLogDelivery
+                  - logs:DeleteLogDelivery
+                  - logs:ListLogDeliveries
+                  - logs:PutResourcePolicy
+                  - logs:DescribeResourcePolicies
+                  - logs:DescribeLogGroups
+                Resource: '*'
+  IngestTextFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: functions/ingest_text/
+      Handler: app.lambda_handler
+      Runtime: python3.9
+      Timeout: 300
+      MemorySize: 128
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Environment:
+        Variables:
+          NextPrefix: !Ref CleanedPrefix
+      Description: This Lambda function is responsible for ingesting text files from S3 into an Amazon S3 bucket. It takes the S3 object key and content type, and stores the content in an S3 bucket with a specified prefix in utf-8 encoding.
+  IngestPDFFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: functions/ingest_pdf/
+      Handler: app.lambda_handler
+      Runtime: python3.9
+      Timeout: 300
+      MemorySize: 128
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Environment:
+        Variables:
+          NextPrefix: !Ref CleanedPrefix
+      Description: This Lambda function is responsible for ingesting PDF files from S3 into an Amazon S3 bucket. It takes the S3 object key and content type, and stores the content in an S3 bucket with a specified prefix.
+  IngestDocFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: functions/ingest_doc/
+      Handler: app.lambda_handler
+      Runtime: python3.9
+      Timeout: 300
+      MemorySize: 128
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Environment:
+        Variables:
+          NextPrefix: !Ref CleanedPrefix
+      Description: This Lambda function is responsible for ingesting word documents from S3 into an Amazon S3 bucket. It takes the S3 object key and content type, and stores the content in an S3 bucket with a specified prefix.
+  SummarizeTextFileFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: functions/summarize_text/
+      Handler: app.lambda_handler
+      Runtime: python3.9
+      Timeout: 900
+      MemorySize: 128
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Environment:
+        Variables:
+          NextPrefix: !Ref CuratedPrefix
+          BedrockPrompt: !Ref BedrockPrompt
+      Description: This Lambda function is summarizes text files using the Amazon Bedrock AI service. It takes the text content from an S3 object and generates a concise summary. The summarized content is then stored in an S3 bucket with a specified prefix.
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: CustomPolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObjectAcl
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:ListAllMyBuckets
+                  - s3:ListBucketVersions
+                  - s3:GetObjectAttributes
+                  - s3:ListBucket
+                Resource:
+                  - !Sub arn:aws:s3:::${ContentBucket}/*
+                  - !Sub arn:aws:s3:::${ContentBucket}
+              - Effect: Allow
+                Action:
+                  - bedrock:InvokeModel
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: '*'


### PR DESCRIPTION
*Issue #, if available:*
    "introBox": {
      "headline": "Serverless Document Summarization with Bedrock",
      "text": [
        "This sample project demonstrates how to use an AWS Step Functions state machine to orchestrate S3 object summarization using Amazon Bedrock. The state machine is triggered by new file uploads to an S3 bucket and coordinates the execution of Lambda functions to process and summarize the documents.",
        "The state machine first checks the file type (txt, pdf, or docx) and invokes the appropriate Lambda function to extract the text content. The extracted text is then passed to another Lambda function that leverages Amazon Bedrock's natural language processing capabilities to generate a concise summary.",
        "The generated summary is stored in the original S3 bucket, providing users with a convenient way to access the key information from large documents without having to read through the entire content."
      ]
    },

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
