### PR TITLE
Updating NodeJS version to supported runtime

### DIFF
--- a/cloudfront-lambda-edge-s3-cdk/cdk/lib/amazon-s3-upload-api-patterns-stack.ts
+++ b/cloudfront-lambda-edge-s3-cdk/cdk/lib/amazon-s3-upload-api-patterns-stack.ts
@@ -43,7 +43,7 @@ export class AmazonS3UploadApiPatternsStack extends cdk.Stack {
     });
 
     const authFunction = new NodejsFunction(this, "authFunction", {
-      runtime: Runtime.NODEJS_14_X,
+      runtime: Runtime.NODEJS_18_X,
       handler: "handler",
       entry: "./authorizer/app.js",
       timeout: cdk.Duration.seconds(5),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Bumping NodeJS Lambda runtime from 14.x to 18.x as 14.x is no longer supported and causes cdk deploy to fail.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
