### PR TITLE
New serverless pattern - sns-sqs-fanout-cdk-java 

### DIFF
--- a/sns-sqs-fanout-cdk-java/README.md
+++ b/sns-sqs-fanout-cdk-java/README.md
@@ -1,4 +1,4 @@
-# SNS to SQS fanout pattern
+# Amazon SNS to Amazon SQS fanout pattern
 
 This pattern demonstrates fanning out SNS messages to SQS with the CDK in Java.
 
@@ -17,7 +17,7 @@ Important: this application uses various AWS services and there are costs associ
 - [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
 - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
 - [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-- [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+- [AWS CDK](https://docs.aws.amazon.com/cdk/v2/guide/cli.html) installed and configured
 
 ## Deployment Instructions
 

--- a/sns-sqs-fanout-cdk-java/README.md
+++ b/sns-sqs-fanout-cdk-java/README.md
@@ -32,7 +32,7 @@ Important: this application uses various AWS services and there are costs associ
 
 3. From the command line, configure AWS CDK:
 
-The cdk bootstrap command only need to be run if the account and region hasn't been bootstrapped before. This sets up the necessary resources for deploying CDK apps in the specified AWS account and region.
+The cdk bootstrap command only needs to be run if the account and region hasn't been bootstrapped before. This sets up the necessary resources for deploying CDK apps in the specified AWS account and region.
    ```bash
    cdk bootstrap ACCOUNT-NUMBER/REGION # e.g.
    cdk bootstrap 1111111111/us-east-1

--- a/sns-sqs-fanout-cdk-java/README.md
+++ b/sns-sqs-fanout-cdk-java/README.md
@@ -1,14 +1,14 @@
-# Amazon SNS to Amazon SQS fanout pattern
+# Amazon SNS to Amazon SQS fanout with filtering
 
 This pattern demonstrates fanning out SNS messages to SQS with the CDK in Java.
 
 In this example, we create an SNS Topic named `my-topic`. We also create three SQS Queues named `queue1`, `queue2`, and `queue3`.
 
-Then, we subscribe each queue to the SNS Topic using `topic.addSubscription()`. For `queue1`, we simply subscribe it to the topic without any filters, so it will receive all messages published to the topic.
+Then, we subscribe each queue to the SNS topic using `topic.addSubscription()`. For `queue1`, we simply subscribe it to the topic without any filters, so it will receive all messages published to the topic.
 
 For `queue2`, we use a subscription filter to only receive messages with the attribute `event` set to `order_placed`. Similarly, for `queue3`, we use a subscription filter to only receive messages with the attribute `event` set to `order_shipped`.
 
-This demonstrates the fan-out pattern, where a single message published to the SNS Topic can be delivered to multiple SQS Queues based on the subscription filters. For example, if you publish a message with the attribute `{ "event": "order_placed" }`, it will be delivered to `queue1` and `queue2`. If you publish a message with the attribute `{ "event": "order_shipped" }`, it will be delivered to `queue1` and `queue3`.
+This demonstrates the fanout pattern, where a single message published to the SNS topic can be delivered to multiple SQS queues based on the subscription filters. For example, if you publish a message with the attribute `{ "event": "order_placed" }`, it will be delivered to `queue1` and `queue2`. If you publish a message with the attribute `{ "event": "order_shipped" }`, it will be delivered to `queue1` and `queue3`.
 
 Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
 
@@ -67,6 +67,6 @@ cdk destroy
 
 ---
 
-Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 SPDX-License-Identifier: MIT-0

--- a/sns-sqs-fanout-cdk-java/README.md
+++ b/sns-sqs-fanout-cdk-java/README.md
@@ -1,0 +1,72 @@
+# SNS to SQS fanout pattern
+
+This pattern demonstrates fanning out SNS messages to SQS with the CDK in Java.
+
+In this example, we create an SNS Topic named `my-topic`. We also create three SQS Queues named `queue1`, `queue2`, and `queue3`.
+
+Then, we subscribe each queue to the SNS Topic using `topic.addSubscription()`. For `queue1`, we simply subscribe it to the topic without any filters, so it will receive all messages published to the topic.
+
+For `queue2`, we use a subscription filter to only receive messages with the attribute `event` set to `order_placed`. Similarly, for `queue3`, we use a subscription filter to only receive messages with the attribute `event` set to `order_shipped`.
+
+This demonstrates the fan-out pattern, where a single message published to the SNS Topic can be delivered to multiple SQS Queues based on the subscription filters. For example, if you publish a message with the attribute `{ "event": "order_placed" }`, it will be delivered to `queue1` and `queue2`. If you publish a message with the attribute `{ "event": "order_shipped" }`, it will be delivered to `queue1` and `queue3`.
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+- [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+- [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+- [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+   ```bash
+   git clone https://github.com/aws-samples/serverless-patterns
+   ```
+2. Change directory to the pattern directory:
+   ```bash
+   cd serverless-patterns/sns-sqs-fanout-cdk-java
+   ```
+
+3. From the command line, configure AWS CDK:
+   ```bash
+   cdk bootstrap ACCOUNT-NUMBER/REGION # e.g.
+   cdk bootstrap 1111111111/us-east-1
+   cdk bootstrap --profile test 1111111111/us-east-1
+   ```
+4. From the command line, use AWS CDK to deploy the AWS resources for the pattern as specified in the `lib/cdk-stack.ts` file:
+   ```bash
+   cdk deploy
+   ```
+
+## How it works
+
+After deploying the stack, you can publish messages to the SNS topic using the AWS CLI or any other tool of your choice. The messages will be delivered to the appropriate SQS queues based on the subscription filters.
+
+Example:
+
+```
+aws sns publish --topic-arn <YOUR_SNS_TOPIC_ARN> --message '{"event": "order_placed", "order_id": 123}'
+```
+
+This message will be delivered to `queue1` and `queue2`.
+
+```
+aws sns publish --topic-arn <YOUR_SNS_TOPIC_ARN> --message '{"event": "order_shipped", "order_id": 456}'
+```
+
+This message will be delivered to `queue1` and `queue3`.
+
+## Delete stack
+
+```bash
+cdk destroy
+```
+
+---
+
+Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/sns-sqs-fanout-cdk-java/README.md
+++ b/sns-sqs-fanout-cdk-java/README.md
@@ -31,6 +31,8 @@ Important: this application uses various AWS services and there are costs associ
    ```
 
 3. From the command line, configure AWS CDK:
+
+The cdk bootstrap command only need to be run if the account and region hasn't been bootstrapped before. This sets up the necessary resources for deploying CDK apps in the specified AWS account and region.
    ```bash
    cdk bootstrap ACCOUNT-NUMBER/REGION # e.g.
    cdk bootstrap 1111111111/us-east-1
@@ -45,7 +47,7 @@ Important: this application uses various AWS services and there are costs associ
 
 After deploying the stack, you can publish messages to the SNS topic using the AWS CLI or any other tool of your choice. The messages will be delivered to the appropriate SQS queues based on the subscription filters.
 
-Example:
+### Example 1
 
 ```
 aws sns publish --topic-arn <YOUR_SNS_TOPIC_ARN> --message '{"event": "order_placed", "order_id": 123}'
@@ -53,11 +55,27 @@ aws sns publish --topic-arn <YOUR_SNS_TOPIC_ARN> --message '{"event": "order_pla
 
 This message will be delivered to `queue1` and `queue2`.
 
+You can verify that the messages were successfully received by the queues using the AWS Management Console or AWS CLI.
+
+```
+aws sqs receive-message --queue-url <QUEUE_1_URL> --max-number-of-messages=2
+aws sqs receive-message --queue-url <QUEUE_2_URL> --max-number-of-messages=2
+```
+
+### Example 2:
+
 ```
 aws sns publish --topic-arn <YOUR_SNS_TOPIC_ARN> --message '{"event": "order_shipped", "order_id": 456}'
 ```
 
 This message will be delivered to `queue1` and `queue3`.
+
+You can verify that the messages were successfully received by the queues using the AWS Management Console or AWS CLI.
+
+```
+aws sqs receive-message --queue-url <QUEUE_1_URL> --max-number-of-messages=2
+aws sqs receive-message --queue-url <QUEUE_3_URL> --max-number-of-messages=2
+```
 
 ## Delete stack
 

--- a/sns-sqs-fanout-cdk-java/cdk.json
+++ b/sns-sqs-fanout-cdk-java/cdk.json
@@ -1,0 +1,63 @@
+{
+  "app": "mvn -e -q compile exec:java",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "target",
+      "pom.xml",
+      "src/test"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ],
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+    "@aws-cdk/core:enablePartitionLiterals": true,
+    "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
+    "@aws-cdk/aws-iam:standardizedServicePrincipals": true,
+    "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
+    "@aws-cdk/aws-iam:importedRoleStackSafeDefaultPolicyName": true,
+    "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
+    "@aws-cdk/aws-route53-patters:useCertificate": true,
+    "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
+    "@aws-cdk/aws-rds:databaseProxyUniqueResourceName": true,
+    "@aws-cdk/aws-codedeploy:removeAlarmsFromDeploymentGroup": true,
+    "@aws-cdk/aws-apigateway:authorizerChangeDeploymentLogicalId": true,
+    "@aws-cdk/aws-ec2:launchTemplateDefaultUserData": true,
+    "@aws-cdk/aws-secretsmanager:useAttachedSecretResourcePolicyForSecretTargetAttachments": true,
+    "@aws-cdk/aws-redshift:columnId": true,
+    "@aws-cdk/aws-stepfunctions-tasks:enableEmrServicePolicyV2": true,
+    "@aws-cdk/aws-ec2:restrictDefaultSecurityGroup": true,
+    "@aws-cdk/aws-apigateway:requestValidatorUniqueId": true,
+    "@aws-cdk/aws-kms:aliasNameRef": true,
+    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true,
+    "@aws-cdk/core:includePrefixInUniqueNameGeneration": true,
+    "@aws-cdk/aws-efs:denyAnonymousAccess": true,
+    "@aws-cdk/aws-opensearchservice:enableOpensearchMultiAzWithStandby": true,
+    "@aws-cdk/aws-lambda-nodejs:useLatestRuntimeVersion": true,
+    "@aws-cdk/aws-efs:mountTargetOrderInsensitiveLogicalId": true,
+    "@aws-cdk/aws-rds:auroraClusterChangeScopeOfInstanceParameterGroupWithEachParameters": true,
+    "@aws-cdk/aws-appsync:useArnForSourceApiAssociationIdentifier": true,
+    "@aws-cdk/aws-rds:preventRenderingDeprecatedCredentials": true,
+    "@aws-cdk/aws-codepipeline-actions:useNewDefaultBranchForCodeCommitSource": true,
+    "@aws-cdk/aws-cloudwatch-actions:changeLambdaPermissionLogicalIdForLambdaAction": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeysDefaultValueToFalse": true,
+    "@aws-cdk/aws-codepipeline:defaultPipelineTypeToV2": true
+  }
+}

--- a/sns-sqs-fanout-cdk-java/example-pattern.json
+++ b/sns-sqs-fanout-cdk-java/example-pattern.json
@@ -1,5 +1,5 @@
 {
-	"title": "Fan-out pattern using SNS-SQS filters",
+	"title": "SNS to SQS fanout with filtering",
 	"description": "Creates SNS topic and SQS queues with message body based and attribute based filter using configuration file (appSettings.json)",
 	"language": "Java",
 	"level": "200",
@@ -7,7 +7,7 @@
 	"introBox": {
 		"headline": "How it works",
 		"text": [
-			"This CDK application demonstrates how to create fan-out pattern using sns topic and sqs queues using subscription filters. ",
+			"This CDK application demonstrates how to create fanout pattern using a SNS topic and SQS queues with subscription filters.",
 			"Number of queues required and type of filter (Message attribute based or message body based) can be defined in appSettings.json (Sample json is provided, replace queue names and filter by conditions as needed)."
 		]
 	},

--- a/sns-sqs-fanout-cdk-java/example-pattern.json
+++ b/sns-sqs-fanout-cdk-java/example-pattern.json
@@ -1,0 +1,50 @@
+{
+	"title": "Fan-out pattern using SNS-SQS filters",
+	"description": "Creates SNS topic and Sqs queues with message body based and attribute based filter using configuration file (appSettings.json)",
+	"language": "Java",
+	"level": "200",
+	"framework": "CDK",
+	"introBox": {
+		"headline": "How it works",
+		"text": [
+			"This CDK application demonstrates how to create fan-out pattern using sns topic and sqs queues using subscription filters. ",
+			"Number of queues required and type of filter (Message attribute based or message body based) can be defined in appSettings.json (Sample json is provided, replace queue names and filter by conditions as needed)."
+		]
+	},
+	"gitHub": {
+		"template": {
+			"repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/sns-sqs-fanout-cdk-java",
+			"projectFolder": "sns-sqs-fanout-cdk-java",
+			"templateFile": "src/main/java/com/myorg/SnsToSqsFanOutStack.java.java",
+			"templateURL": "serverless-patterns/sns-sqs-fanout-cdk-java"
+		}
+	},
+	"resources": {
+		"bullets": [
+		]
+	},
+	"deploy": {
+		"text": [
+			"cdk deploy"
+		]
+	},
+	"testing": {
+		"text": [
+			"See the GitHub repo for detailed testing instructions."
+		]
+	},
+	"cleanup": {
+		"text": [
+			"Delete the stack: <code>cdk delete</code>."
+		]
+	},
+	"authors": [
+		{
+			"name": "Matt Ridehalgh",
+			"image": "https://avatars.githubusercontent.com/u/9155962",
+			"bio": "Matt Ridehalgh is a Solutions Architect at AWS.",
+			"linkedin": "matthew-ridehalgh",
+			"twitter": "mrideh"
+		}
+	]
+}

--- a/sns-sqs-fanout-cdk-java/example-pattern.json
+++ b/sns-sqs-fanout-cdk-java/example-pattern.json
@@ -21,6 +21,22 @@
 	},
 	"resources": {
 		"bullets": [
+			{
+				"text": "Fanout to Amazon SQS queues",
+                		"link": "https://docs.aws.amazon.com/sns/latest/dg/sns-sqs-as-subscriber.html"
+            		},
+			{
+				"text": "Amazon SNS message filtering",
+                		"link": "https://docs.aws.amazon.com/sns/latest/dg/sns-message-filtering.html"
+            		},
+			{
+				"text": "Message driven",
+                		"link": "https://docs.aws.amazon.com/whitepapers/latest/reactive-systems-on-aws/message-driven.html"
+            		},
+			{
+				"text": "Introducing payload-based message filtering for Amazon SNS",
+                		"link": "https://aws.amazon.com/blogs/compute/introducing-payload-based-message-filtering-for-amazon-sns/"
+            		}
 		]
 	},
 	"deploy": {

--- a/sns-sqs-fanout-cdk-java/example-pattern.json
+++ b/sns-sqs-fanout-cdk-java/example-pattern.json
@@ -1,6 +1,6 @@
 {
 	"title": "Fan-out pattern using SNS-SQS filters",
-	"description": "Creates SNS topic and Sqs queues with message body based and attribute based filter using configuration file (appSettings.json)",
+	"description": "Creates SNS topic and SQS queues with message body based and attribute based filter using configuration file (appSettings.json)",
 	"language": "Java",
 	"level": "200",
 	"framework": "CDK",

--- a/sns-sqs-fanout-cdk-java/pom.xml
+++ b/sns-sqs-fanout-cdk-java/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.myorg</groupId>
+    <artifactId>apigw-http-sfn</artifactId>
+    <version>0.1</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <cdk.version>2.133.0</cdk.version>
+        <constructs.version>[10.0.0,11.0.0)</constructs.version>
+        <junit.version>5.7.1</junit.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <release>17</release>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <mainClass>com.myorg.SnsToSqsFanOutApp</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <!-- AWS Cloud Development Kit -->
+        <dependency>
+            <groupId>software.amazon.awscdk</groupId>
+            <artifactId>aws-cdk-lib</artifactId>
+            <version>${cdk.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>software.constructs</groupId>
+            <artifactId>constructs</artifactId>
+            <version>${constructs.version}</version>
+        </dependency>
+
+        <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter</artifactId>
+          <version>${junit.version}</version>
+          <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/sns-sqs-fanout-cdk-java/sns-sqs-fanout-cdk-java.json
+++ b/sns-sqs-fanout-cdk-java/sns-sqs-fanout-cdk-java.json
@@ -1,0 +1,96 @@
+{
+    "title": "SNS to SQS fanout with filtering",
+    "description": "Creates SNS topic and SQS queues with message body based and attribute based filter using configuration file (appSettings.json)",
+    "language": "Java",
+    "level": "200",
+    "framework": "CDK",
+    "introBox": {
+        "headline": "How it works",
+        "text": [
+            "This CDK application demonstrates how to create fanout pattern using a SNS topic and SQS queues with subscription filters.",
+            "Number of queues required and type of filter (Message attribute based or message body based) can be defined in appSettings.json (Sample json is provided, replace queue names and filter by conditions as needed)."
+        ]
+    },
+    "gitHub": {
+        "template": {
+            "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/sns-sqs-fanout-cdk-java",
+            "projectFolder": "sns-sqs-fanout-cdk-java",
+            "templateFile": "src/main/java/com/myorg/SnsToSqsFanOutStack.java",
+            "templateURL": "serverless-patterns/sns-sqs-fanout-cdk-java"
+        }
+    },
+    "resources": {
+        "bullets": [
+            {
+                "text": "Fanout to Amazon SQS queues",
+                "link": "https://docs.aws.amazon.com/sns/latest/dg/sns-sqs-as-subscriber.html"
+            },
+            {
+                "text": "Amazon SNS message filtering",
+                "link": "https://docs.aws.amazon.com/sns/latest/dg/sns-message-filtering.html"
+            },
+            {
+                "text": "Message driven",
+                "link": "https://docs.aws.amazon.com/whitepapers/latest/reactive-systems-on-aws/message-driven.html"
+            },
+            {
+                "text": "Introducing payload-based message filtering for Amazon SNS",
+                "link": "https://aws.amazon.com/blogs/compute/introducing-payload-based-message-filtering-for-amazon-sns/"
+            }
+        ]
+    },
+    "deploy": {
+        "text": [
+            "cdk deploy"
+        ]
+    },
+    "testing": {
+        "text": [
+            "See the GitHub repo for detailed testing instructions."
+        ]
+    },
+    "cleanup": {
+        "text": [
+            "Delete the stack: <code>cdk delete</code>."
+        ]
+    },
+    "authors": [
+        {
+            "name": "Matt Ridehalgh",
+            "image": "https://avatars.githubusercontent.com/u/9155962",
+            "bio": "Matt Ridehalgh is a Solutions Architect at AWS.",
+            "linkedin": "matthew-ridehalgh",
+            "twitter": "mrideh"
+        }
+    ],
+    "patternArch": {
+        "icon1": {
+            "x": 30,
+            "y": 50,
+            "service": "sns",
+            "label": "SNS topic"
+        },
+        "icon2": {
+            "x": 70,
+            "y": 30,
+            "service": "sqs",
+            "label": "SQS queue 1"
+        },
+        "icon3": {
+            "x": 70,
+            "y": 70,
+            "service": "sqs",
+            "label": "SQS queue 2"
+        },
+        "line1": {
+            "from": "icon1",
+            "to": "icon2",
+            "label": "filtering"
+        },
+        "line2": {
+            "from": "icon1",
+            "to": "icon3",
+            "label": "filtering"
+        }
+    }
+}

--- a/sns-sqs-fanout-cdk-java/src/main/java/com/myorg/SnsToSqsFanOutApp.java
+++ b/sns-sqs-fanout-cdk-java/src/main/java/com/myorg/SnsToSqsFanOutApp.java
@@ -1,0 +1,39 @@
+package com.myorg;
+
+import software.amazon.awscdk.App;
+import software.amazon.awscdk.StackProps;
+
+public class SnsToSqsFanOutApp {
+    public static void main(final String[] args) {
+        App app = new App();
+
+        new SnsToSqsFanOutStack(app, "SnsToSqsFanOutStack", StackProps.builder()
+                // If you don't specify 'env', this stack will be environment-agnostic.
+                // Account/Region-dependent features and context lookups will not work,
+                // but a single synthesized template can be deployed anywhere.
+
+                // Uncomment the next block to specialize this stack for the AWS Account
+                // and Region that are implied by the current CLI configuration.
+                /*
+                .env(Environment.builder()
+                        .account(System.getenv("CDK_DEFAULT_ACCOUNT"))
+                        .region(System.getenv("CDK_DEFAULT_REGION"))
+                        .build())
+                */
+
+                // Uncomment the next block if you know exactly what Account and Region you
+                // want to deploy the stack to.
+                /*
+                .env(Environment.builder()
+                        .account("123456789012")
+                        .region("us-east-1")
+                        .build())
+                */
+
+                // For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html
+                .build());
+
+        app.synth();
+    }
+}
+

--- a/sns-sqs-fanout-cdk-java/src/main/java/com/myorg/SnsToSqsFanOutStack.java
+++ b/sns-sqs-fanout-cdk-java/src/main/java/com/myorg/SnsToSqsFanOutStack.java
@@ -1,0 +1,66 @@
+package com.myorg;
+
+import software.amazon.awscdk.CfnOutput;
+import software.amazon.awscdk.Stack;
+import software.amazon.awscdk.StackProps;
+import software.amazon.awscdk.services.sns.Filter;
+import software.amazon.awscdk.services.sns.StringConditions;
+import software.amazon.awscdk.services.sns.SubscriptionFilter;
+import software.amazon.awscdk.services.sns.Topic;
+import software.amazon.awscdk.services.sns.subscriptions.SqsSubscription;
+import software.amazon.awscdk.services.sns.subscriptions.SqsSubscriptionProps;
+import software.amazon.awscdk.services.sqs.Queue;
+import software.constructs.Construct;
+
+import java.util.List;
+import java.util.Map;
+
+public class SnsToSqsFanOutStack extends Stack {
+    public SnsToSqsFanOutStack(final Construct scope, final String id) {
+        this(scope, id, null);
+    }
+
+    public SnsToSqsFanOutStack(final Construct scope, final String id, final StackProps props) {
+        super(scope, id, props);
+
+        // Create an SNS Topic
+        Topic topic = Topic.Builder.create(this, "MyTopic")
+                .topicName("my-topic")
+                .build();
+
+        // Create SQS Queues
+        Queue queue1 = Queue.Builder.create(this, "Queue1")
+                .queueName("queue1")
+                .build();
+
+        Queue queue2 = Queue.Builder.create(this, "Queue2")
+                .queueName("queue2")
+                .build();
+
+        Queue queue3 = Queue.Builder.create(this, "Queue3")
+                .queueName("queue3")
+                .build();
+
+        filterByEventType("order_placed");
+
+        // Subscribe queues to the SNS Topic with subscription filters
+        topic.addSubscription(new SqsSubscription(queue1));
+        topic.addSubscription(new SqsSubscription(queue2, filterByEventType("order_placed")));
+        topic.addSubscription(new SqsSubscription(queue3, filterByEventType("order_shipped")));
+
+        CfnOutput.Builder.create(this, "SnsArn")
+                .key("SnsArn")
+                .value(topic.getTopicArn())
+                .build();
+    }
+
+    private static SqsSubscriptionProps filterByEventType(String type) {
+        return SqsSubscriptionProps.builder()
+                .filterPolicyWithMessageBody(Map.of(
+                        "event", Filter.filter(SubscriptionFilter.stringFilter(StringConditions.builder()
+                                .allowlist(List.of(type))
+                                .build()))
+                )).build();
+
+    }
+}

--- a/sns-sqs-fanout-cdk-java/src/main/java/com/myorg/SnsToSqsFanOutStack.java
+++ b/sns-sqs-fanout-cdk-java/src/main/java/com/myorg/SnsToSqsFanOutStack.java
@@ -23,12 +23,10 @@ public class SnsToSqsFanOutStack extends Stack {
     public SnsToSqsFanOutStack(final Construct scope, final String id, final StackProps props) {
         super(scope, id, props);
 
-        // Create an SNS Topic
         Topic topic = Topic.Builder.create(this, "MyTopic")
                 .topicName("my-topic")
                 .build();
 
-        // Create SQS Queues
         Queue queue1 = Queue.Builder.create(this, "Queue1")
                 .queueName("queue1")
                 .build();
@@ -43,7 +41,6 @@ public class SnsToSqsFanOutStack extends Stack {
 
         filterByEventType("order_placed");
 
-        // Subscribe queues to the SNS Topic with subscription filters
         topic.addSubscription(new SqsSubscription(queue1));
         topic.addSubscription(new SqsSubscription(queue2, filterByEventType("order_placed")));
         topic.addSubscription(new SqsSubscription(queue3, filterByEventType("order_shipped")));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added fanout pattern using SNS and SQS with CDK (Java). Subscription filters are used to route SNS topics to the the correct SQS queue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
