### PR TITLE
New serverless pattern - eventbridge-cloudwatch-cdk-java

### DIFF
--- a/eventbridge-cloudwatch-cdk-java/README.md
+++ b/eventbridge-cloudwatch-cdk-java/README.md
@@ -53,7 +53,7 @@ Use the [AWS CLI](https://aws.amazon.com/cli/) to send a test event to EventBrid
 aws events put-events --entries file://event.json
 ```
 
-2. Check the CloudWatch Logs, referencing the log group name from the Outputs section of the deployed Stack, to see an event matching this example:
+2. Check CloudWatch Logs, referencing the log group name from the stack's Outputs section, to see an event matching this example:
 ```json
 {
     "Version": "0",

--- a/eventbridge-cloudwatch-cdk-java/README.md
+++ b/eventbridge-cloudwatch-cdk-java/README.md
@@ -1,0 +1,83 @@
+# Amazon EventBridge to Amazon CloudWatch
+
+This project contains a sample AWS CDK template to create an EventBridge Rule, as well as, a CloudWatch Logs Group. The EventBridge Rule publishes matched events to CloudWatch Logs. In this example, the rule filters for specific attributes in the event before sending to the CloudWatch Logs target.
+
+Learn more about this pattern at Serverless Land Patterns: https://serverlessland.com/patterns/eventbridge-cloudwatch-cdk-java.
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+- [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+- [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+- [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+
+1. Clone the project to your local working directory
+    ```
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+
+2. Change the working directory to this pattern's directory
+    ```
+    cd serverless-patterns/apigw-http-api-step-functions-express-java
+    ```
+
+3. From the command line, configure AWS CDK:
+   ```bash
+   cdk bootstrap ACCOUNT-NUMBER/REGION # e.g.
+   cdk bootstrap 1111111111/us-east-1
+   cdk bootstrap --profile test 1111111111/us-east-1
+   ```
+4. From the command line, use AWS CDK to deploy the AWS resources for the pattern as specified in the `lib/cdk-stack.ts` file:
+   ```bash
+   cdk deploy
+   ```
+5. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## How it works
+
+The CDK stack deploys the resources and the IAM permissions required to run the application.
+
+The EventBridge rule filters the events based upon the defined criteria. When matching events are sent to EventBridge that trigger the rule, they are published to the CloudWatch Logs Group.
+
+## Testing
+
+Use the [AWS CLI](https://aws.amazon.com/cli/) to send a test event to EventBridge and observe the event delivered to the Amazon CloudWatch by reviewing the logs:
+
+1. Send an event to EventBridge:
+
+```sh
+aws events put-events --entries file://event.json
+```
+
+2. Check the CloudWatch Logs, referencing the log group name from the Outputs section of the deployed Stack, to see an event matching this example:
+```json
+{
+    "Version": "0",
+    "Account": "123456789012",
+    "Region": "eu-west-2",
+    "Detail": {
+        "location": "EUR-"
+    },
+    "detail-type": "transaction",
+    "Source": "cdk.myapp",
+    "Time": "2022-05-01T21:32:11Z",
+    "Id": "879bd868-08b4-6d45-ea11-252978d0a332",
+    "Resources": []
+}
+```
+
+## Cleanup
+
+Run the given command to delete the resources that were created. It might take some time for the CloudFormation stack to get deleted.
+```
+cdk destroy
+```
+
+----
+Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/eventbridge-cloudwatch-cdk-java/README.md
+++ b/eventbridge-cloudwatch-cdk-java/README.md
@@ -11,8 +11,8 @@ Important: this application uses various AWS services and there are costs associ
 - [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
 - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
 - [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-- [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
-
+- [AWS CDK](https://docs.aws.amazon.com/cdk/v2/guide/cli.html) installed and configured
+  
 ## Deployment Instructions
 
 1. Clone the project to your local working directory

--- a/eventbridge-cloudwatch-cdk-java/README.md
+++ b/eventbridge-cloudwatch-cdk-java/README.md
@@ -41,7 +41,7 @@ Important: this application uses various AWS services and there are costs associ
 
 The CDK stack deploys the resources and the IAM permissions required to run the application.
 
-The EventBridge rule filters the events based upon the defined criteria. When matching events are sent to EventBridge that trigger the rule, they are published to the CloudWatch Logs Group.
+The EventBridge rule filters the events based upon the defined criteria. Matched events are published to the CloudWatch Logs log group.
 
 ## Testing
 

--- a/eventbridge-cloudwatch-cdk-java/README.md
+++ b/eventbridge-cloudwatch-cdk-java/README.md
@@ -22,7 +22,7 @@ Important: this application uses various AWS services and there are costs associ
 
 2. Change the working directory to this pattern's directory
     ```
-    cd serverless-patterns/apigw-http-api-step-functions-express-java
+    cd serverless-patterns/eventbridge-cloudwatch-cdk-java
     ```
 
 3. From the command line, configure AWS CDK:

--- a/eventbridge-cloudwatch-cdk-java/README.md
+++ b/eventbridge-cloudwatch-cdk-java/README.md
@@ -1,6 +1,6 @@
 # Amazon EventBridge to Amazon CloudWatch
 
-This project contains a sample AWS CDK template to create an EventBridge Rule, as well as, a CloudWatch Logs Group. The EventBridge Rule publishes matched events to CloudWatch Logs. In this example, the rule filters for specific attributes in the event before sending to the CloudWatch Logs target.
+This project contains a sample AWS CDK template to create an EventBridge Rule and a CloudWatch Logs log group. The EventBridge Rule publishes matched events to the log group. In this example, the rule filters for specific attributes in the event before sending to the target.
 
 Learn more about this pattern at Serverless Land Patterns: https://serverlessland.com/patterns/eventbridge-cloudwatch-cdk-java.
 

--- a/eventbridge-cloudwatch-cdk-java/README.md
+++ b/eventbridge-cloudwatch-cdk-java/README.md
@@ -35,7 +35,7 @@ Important: this application uses various AWS services and there are costs associ
    ```bash
    cdk deploy
    ```
-5. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+5. Note the outputs from the CDK deployment process. These contain the resource names and/or ARNs which are used for testing.
 
 ## How it works
 

--- a/eventbridge-cloudwatch-cdk-java/cdk.json
+++ b/eventbridge-cloudwatch-cdk-java/cdk.json
@@ -1,0 +1,63 @@
+{
+  "app": "mvn -e -q compile exec:java",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "target",
+      "pom.xml",
+      "src/test"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ],
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+    "@aws-cdk/core:enablePartitionLiterals": true,
+    "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
+    "@aws-cdk/aws-iam:standardizedServicePrincipals": true,
+    "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
+    "@aws-cdk/aws-iam:importedRoleStackSafeDefaultPolicyName": true,
+    "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
+    "@aws-cdk/aws-route53-patters:useCertificate": true,
+    "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
+    "@aws-cdk/aws-rds:databaseProxyUniqueResourceName": true,
+    "@aws-cdk/aws-codedeploy:removeAlarmsFromDeploymentGroup": true,
+    "@aws-cdk/aws-apigateway:authorizerChangeDeploymentLogicalId": true,
+    "@aws-cdk/aws-ec2:launchTemplateDefaultUserData": true,
+    "@aws-cdk/aws-secretsmanager:useAttachedSecretResourcePolicyForSecretTargetAttachments": true,
+    "@aws-cdk/aws-redshift:columnId": true,
+    "@aws-cdk/aws-stepfunctions-tasks:enableEmrServicePolicyV2": true,
+    "@aws-cdk/aws-ec2:restrictDefaultSecurityGroup": true,
+    "@aws-cdk/aws-apigateway:requestValidatorUniqueId": true,
+    "@aws-cdk/aws-kms:aliasNameRef": true,
+    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true,
+    "@aws-cdk/core:includePrefixInUniqueNameGeneration": true,
+    "@aws-cdk/aws-efs:denyAnonymousAccess": true,
+    "@aws-cdk/aws-opensearchservice:enableOpensearchMultiAzWithStandby": true,
+    "@aws-cdk/aws-lambda-nodejs:useLatestRuntimeVersion": true,
+    "@aws-cdk/aws-efs:mountTargetOrderInsensitiveLogicalId": true,
+    "@aws-cdk/aws-rds:auroraClusterChangeScopeOfInstanceParameterGroupWithEachParameters": true,
+    "@aws-cdk/aws-appsync:useArnForSourceApiAssociationIdentifier": true,
+    "@aws-cdk/aws-rds:preventRenderingDeprecatedCredentials": true,
+    "@aws-cdk/aws-codepipeline-actions:useNewDefaultBranchForCodeCommitSource": true,
+    "@aws-cdk/aws-cloudwatch-actions:changeLambdaPermissionLogicalIdForLambdaAction": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeysDefaultValueToFalse": true,
+    "@aws-cdk/aws-codepipeline:defaultPipelineTypeToV2": true
+  }
+}

--- a/eventbridge-cloudwatch-cdk-java/event.json
+++ b/eventbridge-cloudwatch-cdk-java/event.json
@@ -1,0 +1,8 @@
+[
+    {
+      "DetailType": "transaction",
+      "Source": "cdk.myapp",
+      "EventBusName": "MyCloudWatchEventBus",
+      "Detail": "{\"location\":\"EUR-\"}"
+    }
+  ]

--- a/eventbridge-cloudwatch-cdk-java/eventbridge-cloudwatch-logs-cdk-java.json
+++ b/eventbridge-cloudwatch-cdk-java/eventbridge-cloudwatch-logs-cdk-java.json
@@ -1,0 +1,78 @@
+{
+    "title": "Amazon EventBridge to Amazon CloudWatch Logs",
+    "description": "Create an EventBridge rule that sends events to CloudWatch Logs.",
+    "language": "Java",
+    "level": "200",
+    "framework": "CDK",
+    "introBox": {
+        "headline": "How it works",
+        "text": [
+            "This project contains a sample AWS CDK template to create an EventBridge Rule and a CloudWatch Logs log group.",
+            "The EventBridge Rule publishes matched events to CloudWatch Logs.",
+            "In this example, the rule filters for specific attributes in the event before sending to the target."
+        ]
+    },
+    "gitHub": {
+        "template": {
+            "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-cloudwatch-cdk-java",
+            "projectFolder": "eventbridge-cloudwatch-cdk-java",
+            "templateFile": "src/main/java/com/myorg/EventBridgeToCloudWatchLogsStackApp.java",
+            "templateURL": "serverless-patterns/eventbridge-cloudwatch-cdk-java"
+        }
+    },
+    "resources": {
+        "bullets": [
+            {
+                "text": "Reducing custom code by using advanced rules in Amazon EventBridge",
+                "link": "https://aws.amazon.com/blogs/compute/reducing-custom-code-by-using-advanced-rules-in-amazon-eventbridge/"
+            },
+            {
+                "text": "Use Amazon EventBridge to Build Decoupled, Event-Driven Architectures",
+                "link": "https://serverlessland.com/learn/eventbridge"
+            }
+        ]
+    },
+    "deploy": {
+        "text": [
+            "cdk deploy"
+        ]
+    },
+    "testing": {
+        "text": [
+            "See the GitHub repo for detailed testing instructions."
+        ]
+    },
+    "cleanup": {
+        "text": [
+            "Delete the stack: <code>cdk destroy</code>."
+        ]
+    },
+    "authors": [
+        {
+            "name": "Matt Ridehalgh",
+            "image": "https://avatars.githubusercontent.com/u/9155962",
+            "bio": "Matt Ridehalgh is a Solutions Architect at AWS.",
+            "linkedin": "matthew-ridehalgh",
+            "twitter": "mrideh"
+        }
+    ],
+    "patternArch": {
+        "icon1": {
+            "x": 20,
+            "y": 50,
+            "service": "eventbridge",
+            "label": "Amazon EventBridge"
+        },
+        "icon2": {
+            "x": 80,
+            "y": 50,
+            "service": "cloudwatch",
+            "label": "Amazon CloudWatch Logs"
+        },
+        "line1": {
+            "from": "icon1",
+            "to": "icon2",
+            "label": ""
+        }
+    }
+}

--- a/eventbridge-cloudwatch-cdk-java/example-pattern.json
+++ b/eventbridge-cloudwatch-cdk-java/example-pattern.json
@@ -1,0 +1,59 @@
+{
+  "title": "EventBridge to CloudWatch Logs",
+  "description": "Create an EventBridge rule that sends events to CloudWatch Logs.",
+  "language": "Java",
+  "level": "200",
+  "framework": "CDK",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "This project contains a sample AWS CDK template to create an EventBridge Rule, as well as, a CloudWatch Logs Group.",
+      "The EventBridge Rule publishes matched events to CloudWatch Logs.",
+      "In this example, the rule filters for specific attributes in the event before sending to the CloudWatch Logs target."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-cloudwatch-cdk-java",
+      "projectFolder": "eventbridge-cloudwatch-cdk-java",
+      "templateFile": "src/main/java/com/myorg/EventBridgeToCloudWatchLogsStackApp.java",
+      "templateURL": "serverless-patterns/eventbridge-cloudwatch-cdk-java"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "Reducing custom code by using advanced rules in Amazon EventBridge",
+        "link": "https://aws.amazon.com/blogs/compute/reducing-custom-code-by-using-advanced-rules-in-amazon-eventbridge/"
+      },
+      {
+        "text": "Use Amazon EventBridge to Build Decoupled, Event-Driven Architectures",
+        "link": "https://serverlessland.com/learn/eventbridge"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "cdk deploy"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the GitHub repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>cdk delete</code>."
+    ]
+  },
+  "authors": [
+    {
+      "name": "Matt Ridehalgh",
+      "image": "https://avatars.githubusercontent.com/u/9155962",
+      "bio": "Matt Ridehalgh is a Solutions Architect at AWS.",
+      "linkedin": "matthew-ridehalgh",
+      "twitter": "mrideh"
+    }
+  ]
+}

--- a/eventbridge-cloudwatch-cdk-java/pom.xml
+++ b/eventbridge-cloudwatch-cdk-java/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.myorg</groupId>
+    <artifactId>apigw-http-sfn</artifactId>
+    <version>0.1</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <cdk.version>2.133.0</cdk.version>
+        <constructs.version>[10.0.0,11.0.0)</constructs.version>
+        <junit.version>5.7.1</junit.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <release>17</release>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <mainClass>com.myorg.EventBridgeToCloudWatchLogsStackApp</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <!-- AWS Cloud Development Kit -->
+        <dependency>
+            <groupId>software.amazon.awscdk</groupId>
+            <artifactId>aws-cdk-lib</artifactId>
+            <version>${cdk.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>software.constructs</groupId>
+            <artifactId>constructs</artifactId>
+            <version>${constructs.version}</version>
+        </dependency>
+
+        <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter</artifactId>
+          <version>${junit.version}</version>
+          <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/eventbridge-cloudwatch-cdk-java/src/main/java/com/myorg/EventBridgeToCloudWatchLogsStack.java
+++ b/eventbridge-cloudwatch-cdk-java/src/main/java/com/myorg/EventBridgeToCloudWatchLogsStack.java
@@ -1,0 +1,53 @@
+package com.myorg;
+
+import software.amazon.awscdk.CfnOutput;
+import software.amazon.awscdk.RemovalPolicy;
+import software.amazon.awscdk.Stack;
+import software.amazon.awscdk.StackProps;
+import software.amazon.awscdk.services.events.EventBus;
+import software.amazon.awscdk.services.events.EventPattern;
+import software.amazon.awscdk.services.events.Rule;
+import software.amazon.awscdk.services.events.targets.CloudWatchLogGroup;
+import software.amazon.awscdk.services.logs.LogGroup;
+import software.amazon.awscdk.services.logs.RetentionDays;
+import software.constructs.Construct;
+
+import java.util.Collections;
+
+public class EventBridgeToCloudWatchLogsStack extends Stack {
+    public EventBridgeToCloudWatchLogsStack(final Construct scope, final String id) {
+        this(scope, id, null);
+    }
+
+    public EventBridgeToCloudWatchLogsStack(final Construct scope, final String id, final StackProps props) {
+        super(scope, id, props);
+
+        // CloudWatch Log Group
+        LogGroup cloudWatchLogGroup = LogGroup.Builder.create(this, "EventBridgeCloudWatchLogs")
+                .removalPolicy(RemovalPolicy.DESTROY)
+                .retention(RetentionDays.ONE_DAY)
+                .build();
+
+        // EventBridge Event Bus
+        EventBus eventBus = EventBus.Builder.create(this, "MyCloudWatchEventBus")
+                .eventBusName("MyCloudWatchEventBus")
+                .build();
+
+        // EventBridge Rule
+        Rule cloudWatchLogsRule = Rule.Builder.create(this, "cloudWatchLogsRule")
+                .description("CloudWatch Logs Event Bus Rule")
+                .eventPattern(EventPattern.builder()
+                        .source(Collections.singletonList("cdk.myapp"))
+                        .build())
+                .eventBus(eventBus)
+                .build();
+
+        cloudWatchLogsRule.addTarget(new CloudWatchLogGroup(cloudWatchLogGroup));
+
+        // CDK Outputs
+        CfnOutput.Builder.create(this, "LogGroupName")
+                .value(cloudWatchLogGroup.getLogGroupName())
+                .description("CloudWatch Log Group Name")
+                .build();
+    }
+}

--- a/eventbridge-cloudwatch-cdk-java/src/main/java/com/myorg/EventBridgeToCloudWatchLogsStackApp.java
+++ b/eventbridge-cloudwatch-cdk-java/src/main/java/com/myorg/EventBridgeToCloudWatchLogsStackApp.java
@@ -7,7 +7,7 @@ public class EventBridgeToCloudWatchLogsStackApp {
     public static void main(final String[] args) {
         App app = new App();
 
-        new EventBridgeToCloudWatchLogsStack(app, "EventBridgeToCloudWatchLogsStack", StackProps.builder()
+        new EventBridgeToCloudWatchLogsStack(app, "EventBridgeToCloudWatchLogsStack", StackProps.builder().description("(uksb-1tthgi812) (tag:eventbridge-cloudwatch-cdk-java")
                 // If you don't specify 'env', this stack will be environment-agnostic.
                 // Account/Region-dependent features and context lookups will not work,
                 // but a single synthesized template can be deployed anywhere.

--- a/eventbridge-cloudwatch-cdk-java/src/main/java/com/myorg/EventBridgeToCloudWatchLogsStackApp.java
+++ b/eventbridge-cloudwatch-cdk-java/src/main/java/com/myorg/EventBridgeToCloudWatchLogsStackApp.java
@@ -1,0 +1,39 @@
+package com.myorg;
+
+import software.amazon.awscdk.App;
+import software.amazon.awscdk.StackProps;
+
+public class EventBridgeToCloudWatchLogsStackApp {
+    public static void main(final String[] args) {
+        App app = new App();
+
+        new EventBridgeToCloudWatchLogsStack(app, "EventBridgeToCloudWatchLogsStack", StackProps.builder()
+                // If you don't specify 'env', this stack will be environment-agnostic.
+                // Account/Region-dependent features and context lookups will not work,
+                // but a single synthesized template can be deployed anywhere.
+
+                // Uncomment the next block to specialize this stack for the AWS Account
+                // and Region that are implied by the current CLI configuration.
+                /*
+                .env(Environment.builder()
+                        .account(System.getenv("CDK_DEFAULT_ACCOUNT"))
+                        .region(System.getenv("CDK_DEFAULT_REGION"))
+                        .build())
+                */
+
+                // Uncomment the next block if you know exactly what Account and Region you
+                // want to deploy the stack to.
+                /*
+                .env(Environment.builder()
+                        .account("123456789012")
+                        .region("us-east-1")
+                        .build())
+                */
+
+                // For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html
+                .build());
+
+        app.synth();
+    }
+}
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a sample AWS CDK template to create an EventBridge Rule that forwards events to CloudWatch logs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
