### PR TITLE
Clarified readme

### DIFF
--- a/dynamodb-eventbridge-transformer/README.md
+++ b/dynamodb-eventbridge-transformer/README.md
@@ -1,6 +1,6 @@
-# Amazon DynamoDB to Amazon EventBridge using Amazon Eventbridge Pipes
+# Amazon DynamoDB to Amazon EventBridge using Amazon Eventbridge Pipes to unmarshall
 
-This pattern takes a change data capture event from DynamoDB, removes the data type descriptors and sends the simplified event to an EventBridge bus.
+This pattern takes a change data capture event from DynamoDB, removes the data type descriptors and sends the simplified ('unmarshalled') event to an EventBridge bus.
 
 The key components of this architecture are DynamoDB as source and EventBridge as target, connected by a pipe.
 

--- a/dynamodb-eventbridge-transformer/src/README.md
+++ b/dynamodb-eventbridge-transformer/src/README.md
@@ -1,6 +1,6 @@
-# AWS DynamoDB Streams to Event Bridge using Input Transformer.
+# AWS DynamoDB Streams to Event Bridge using Input Transformer  to unmarshall.
 
-This pattern takes a change data capture event from DynamoDB, removes the data type descriptors and sends the simplified event to an EventBridge bus.
+This pattern takes a change data capture event from DynamoDB, removes the data type descriptors and sends the simplified ('unmarshalled') event to an EventBridge bus.
 
 The key components of this architecture are DynamoDB as source and EventBridge as target, connected by a pipe.
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_  
Multiple customers have approached us because they were searching for this pattern but unable to identify it. The reason was that they searched for the term "unmarshall", rather than "removing type descriptors". I added the term to increase discoverability.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.