### PR TITLE
Rust: update example to GA version of AWS SDK for Rust

### DIFF
--- a/alb-lambda-rust/Cargo.toml
+++ b/alb-lambda-rust/Cargo.toml
@@ -9,8 +9,8 @@ name = "handler"
 path = "src/bin/handler.rs"
 
 [dependencies]
-lambda_http = "0.7.2"
-lambda_runtime = "0.7.2"
+lambda_http = "0.11"
+lambda_runtime = "0.11"
 serde = {version = "1.0", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros"] }

--- a/alb-lambda-rust/src/bin/handler.rs
+++ b/alb-lambda-rust/src/bin/handler.rs
@@ -1,5 +1,5 @@
 use lambda_http::{
-    http::StatusCode, run, service_fn, Error, IntoResponse, Request, RequestExt, Response,
+    http::StatusCode, run, service_fn, Error, IntoResponse, Request, RequestPayloadExt, Response,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;

--- a/apigw-http-api-lambda-rust/Cargo.toml
+++ b/apigw-http-api-lambda-rust/Cargo.toml
@@ -9,8 +9,8 @@ name = "handler"
 path = "src/bin/handler.rs"
 
 [dependencies]
-lambda_http = "0.7.2"
-lambda_runtime = "0.7.2"
+lambda_http = "0.11"
+lambda_runtime = "0.11"
 serde_json = "1"
 tokio = { version = "1", features = ["macros"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "json"] }

--- a/apigw-http-api-lambda-rust/src/bin/handler.rs
+++ b/apigw-http-api-lambda-rust/src/bin/handler.rs
@@ -19,6 +19,6 @@ pub async fn function_handler(event: Request) -> Result<impl IntoResponse, Error
         event
             .query_string_parameters()
             .first("name")
-            .unwrap_or_else(|| "stranger")
+            .unwrap_or("stranger")
     ))
 }

--- a/apigw-lambda-rust/Cargo.toml
+++ b/apigw-lambda-rust/Cargo.toml
@@ -9,8 +9,8 @@ name = "handler"
 path = "src/bin/handler.rs"
 
 [dependencies]
-lambda_http = "0.7.2"
-lambda_runtime = "0.7.2"
+lambda_http = "0.11"
+lambda_runtime = "0.11"
 serde = {version = "1.0", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros"] }

--- a/apigw-lambda-rust/src/bin/handler.rs
+++ b/apigw-lambda-rust/src/bin/handler.rs
@@ -1,5 +1,5 @@
 use lambda_http::{
-    http::StatusCode, run, service_fn, Error, IntoResponse, Request, RequestExt, Response,
+    http::StatusCode, run, service_fn, Error, IntoResponse, Request, RequestPayloadExt, Response
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;

--- a/appconfig-lambda-rust/Cargo.toml
+++ b/appconfig-lambda-rust/Cargo.toml
@@ -9,10 +9,10 @@ name = "handler"
 path = "src/bin/handler.rs"
 
 [dependencies]
-aws-config = "0.52.0"
-lambda_runtime = "0.7.2"
-lazy_static = "1.4.0"
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "json"] }
+aws-config = {version = "1", features = ["behavior-version-latest"] }
+lambda_runtime = "0.11"
+lazy_static = "1.4"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 serde = {version = "1.0", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros"] }

--- a/cloudfront-apigw-http-api-lambda-rust/Cargo.toml
+++ b/cloudfront-apigw-http-api-lambda-rust/Cargo.toml
@@ -9,7 +9,7 @@ name = "handler"
 path = "src/bin/handler.rs"
 
 [dependencies]
-lambda_http = "0.7.2"
+lambda_http = "0.11"
 serde_json = "1"
 tokio = { version = "1", features = ["macros"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "json"] }

--- a/cloudfront-apigw-http-api-lambda-rust/src/bin/handler.rs
+++ b/cloudfront-apigw-http-api-lambda-rust/src/bin/handler.rs
@@ -37,7 +37,7 @@ pub async fn function_handler(event: Request) -> Result<impl IntoResponse, Error
 fn get_ip_address(event: &Request) -> Option<String> {
     let header_ip_address = event.headers().get("x-forwarded-for");
     if let Some(header_ip_address) = header_ip_address {
-        let ips: Vec<&str> = header_ip_address.to_str().unwrap().split(",").collect();
+        let ips: Vec<&str> = header_ip_address.to_str().unwrap().split(',').collect();
         return Some(ips[0].to_string());
     }
     None

--- a/cloudfront-failover-apigw-http-api-lambda-rust/Cargo.toml
+++ b/cloudfront-failover-apigw-http-api-lambda-rust/Cargo.toml
@@ -9,7 +9,7 @@ name = "handler"
 path = "src/bin/handler.rs"
 
 [dependencies]
-lambda_http = "0.7.2"
+lambda_http = "0.11"
 serde_json = "1"
 tokio = { version = "1", features = ["macros"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "json"] }

--- a/cloudfront-lambda-url-rust/Cargo.toml
+++ b/cloudfront-lambda-url-rust/Cargo.toml
@@ -9,7 +9,7 @@ name = "handler"
 path = "src/bin/handler.rs"
 
 [dependencies]
-lambda_http = "0.7.2"
+lambda_http = "0.11"
 serde_json = "1"
 tokio = { version = "1", features = ["macros"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "json"] }

--- a/cloudfront-lambda-url-rust/src/bin/handler.rs
+++ b/cloudfront-lambda-url-rust/src/bin/handler.rs
@@ -37,7 +37,7 @@ pub async fn function_handler(event: Request) -> Result<impl IntoResponse, Error
 fn get_ip_address(event: &Request) -> Option<String> {
     let header_ip_address = event.headers().get("x-forwarded-for");
     if let Some(header_ip_address) = header_ip_address {
-        let ips: Vec<&str> = header_ip_address.to_str().unwrap().split(",").collect();
+        let ips: Vec<&str> = header_ip_address.to_str().unwrap().split(',').collect();
         return Some(ips[0].to_string());
     }
     None

--- a/dynamodb-streams-lambda-eventbridge-sam-rust/Cargo.toml
+++ b/dynamodb-streams-lambda-eventbridge-sam-rust/Cargo.toml
@@ -9,13 +9,13 @@ name = "handler"
 path = "src/bin/handler.rs"
 
 [dependencies]
-aws_lambda_events = { version = "0.7", default-features = false, features = ["dynamodb"] }
-aws-types = "0.54"
-aws-config = "0.54"
-aws-sdk-eventbridge = "0.24"
-lambda_runtime = "0.7"
+aws_lambda_events = { version = "0.15", default-features = false, features = ["dynamodb"] }
+aws-types = "1"
+aws-config = {version = "1", features = ["behavior-version-latest"] }
+aws-sdk-eventbridge = "1"
+lambda_runtime = "0.11"
 serde_json = "1"
 serde = {version = "1.0", features = ["derive"] }
 tokio = { version = "1", features = ["macros"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "json"] }
-typed-builder = "0.12"
+typed-builder = "0.18"

--- a/eventbridge-lambda-rust/Cargo.toml
+++ b/eventbridge-lambda-rust/Cargo.toml
@@ -10,6 +10,6 @@ path = "src/bin/handler.rs"
 
 [dependencies]
 aws_lambda_events = { version = "0.7", default-features = false, features = ["cloudwatch_events"] }
-lambda_runtime = "0.7.2"
+lambda_runtime = "0.11"
 tokio = { version = "1", features = ["macros"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "json"] }

--- a/lambda-dynamodb-rust/Cargo.toml
+++ b/lambda-dynamodb-rust/Cargo.toml
@@ -10,9 +10,9 @@ name = "handler"
 path = "src/bin/handler.rs"
 
 [dependencies]
-aws-config = "0.52.0"
-aws-sdk-dynamodb = "0.22.0"
-lambda_runtime = "0.7.2"
+aws-config = {version = "1", features = ["behavior-version-latest"] }
+aws-sdk-dynamodb = "1"
+lambda_runtime = "0.11"
 serde_json = "1"
 tokio = { version = "1", features = ["macros"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "json"] }

--- a/lambda-dynamodb-rust/src/bin/handler.rs
+++ b/lambda-dynamodb-rust/src/bin/handler.rs
@@ -1,4 +1,4 @@
-use aws_sdk_dynamodb::model::AttributeValue;
+use aws_sdk_dynamodb::types::AttributeValue;
 use chrono::Utc;
 use lambda_runtime::{run, service_fn, Error, LambdaEvent};
 use serde_json::Value;
@@ -32,7 +32,7 @@ pub async fn function_handler(
         .put_item()
         .table_name(table)
         .item("ID", AttributeValue::S(Utc::now().timestamp().to_string()))
-        .item("metadata", AttributeValue::S(metadata.into()))
+        .item("metadata", AttributeValue::S(metadata))
         .send()
         .await?;
 

--- a/lambda-eventbridge-rust/Cargo.toml
+++ b/lambda-eventbridge-rust/Cargo.toml
@@ -9,10 +9,10 @@ name = "handler"
 path = "src/bin/handler.rs"
 
 [dependencies]
-aws-config = "0.52.0"
-aws-types = "0.52.0"
-aws-sdk-eventbridge = "0.22.0"
-lambda_runtime = "0.7.2"
+aws-config = {version = "1", features = ["behavior-version-latest"] }
+aws-types = "1"
+aws-sdk-eventbridge = "1"
+lambda_runtime = "0.11"
 serde = {version = "1.0", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros"] }

--- a/lambda-eventbridge-rust/src/bin/handler.rs
+++ b/lambda-eventbridge-rust/src/bin/handler.rs
@@ -1,4 +1,4 @@
-use aws_sdk_eventbridge::model::PutEventsRequestEntry;
+use aws_sdk_eventbridge::types::PutEventsRequestEntry;
 use lambda_runtime::{run, service_fn, Error, LambdaEvent};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/lambda-rekognition-rust/Cargo.toml
+++ b/lambda-rekognition-rust/Cargo.toml
@@ -9,9 +9,9 @@ name = "handler"
 path = "src/bin/handler.rs"
 
 [dependencies]
-aws-config = "0.52.0"
-aws-sdk-rekognition = "0.22.0"
-lambda_runtime = "0.7.2"
+aws-config = {version = "1", features = ["behavior-version-latest"] }
+aws-sdk-rekognition = "1"
+lambda_runtime = "0.11"
 serde = {version = "1.0", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros"] }

--- a/lambda-rekognition-rust/src/bin/handler.rs
+++ b/lambda-rekognition-rust/src/bin/handler.rs
@@ -1,4 +1,4 @@
-use aws_sdk_rekognition::model::Image;
+use aws_sdk_rekognition::types::Image;
 use lambda_runtime::{run, service_fn, Error, LambdaEvent};
 use serde::{Deserialize, Serialize};
 
@@ -25,7 +25,7 @@ pub async fn function_handler(
 ) -> Result<(), Error> {
     println!("{:?}", event);
 
-    let s3_object = aws_sdk_rekognition::model::S3Object::builder()
+    let s3_object = aws_sdk_rekognition::types::S3Object::builder()
         .bucket(event.payload.bucket.name)
         .name(event.payload.object.key)
         .build();
@@ -34,11 +34,13 @@ pub async fn function_handler(
 
     let result = client.detect_text().image(params).send().await?;
 
-    if let Some(text_detections) = result.text_detections() {
-        for text_detection in text_detections.into_iter().filter(|x| x.parent_id == None) {
-            println!("{:?}", text_detection);
-        }
-    } else {
+    let text_detections = result.text_detections();
+
+    for text_detection in text_detections.iter().filter(|x| x.parent_id.is_none()) {
+        println!("{:?}", text_detection);
+    }
+
+    if text_detections.is_empty() {
         println!("No text detected");
     }
 

--- a/lambda-s3-rust/Cargo.toml
+++ b/lambda-s3-rust/Cargo.toml
@@ -9,9 +9,9 @@ name = "handler"
 path = "src/bin/handler.rs"
 
 [dependencies]
-aws-config = "0.52.0"
-aws-sdk-s3 = "0.22.0"
-lambda_runtime = "0.7.2"
+aws-config = {version = "1", features = ["behavior-version-latest"] }
+aws-sdk-s3 = "1"
+lambda_runtime = "0.11"
 serde_json = "1"
 tokio = { version = "1", features = ["macros"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "json"] }

--- a/lambda-s3-rust/src/bin/handler.rs
+++ b/lambda-s3-rust/src/bin/handler.rs
@@ -1,4 +1,4 @@
-use aws_sdk_s3::types::ByteStream;
+use aws_sdk_s3::primitives::ByteStream;
 use lambda_runtime::{run, service_fn, Error, LambdaEvent};
 use serde_json::Value;
 

--- a/lambda-sfn-rust/Cargo.toml
+++ b/lambda-sfn-rust/Cargo.toml
@@ -9,9 +9,9 @@ name = "handler"
 path = "src/bin/handler.rs"
 
 [dependencies]
-aws-config = "0.52.0"
-aws-sdk-sfn = "0.22.0"
-lambda_runtime = "0.7.2"
+aws-config = {version = "1", features = ["behavior-version-latest"] }
+aws-sdk-sfn = "1"
+lambda_runtime = "0.11"
 serde = {version = "1.0", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros"] }

--- a/lambda-sqs-rust-sam/Cargo.toml
+++ b/lambda-sqs-rust-sam/Cargo.toml
@@ -10,9 +10,9 @@ name = "handler"
 path = "src/bin/handler.rs"
 
 [dependencies]
-aws-config = "0.52.0"
-aws-sdk-sqs = "0.22.0"
-lambda_runtime = "0.7.2"
+aws-config = {version = "1", features = ["behavior-version-latest"] }
+aws-sdk-sqs = "1"
+lambda_runtime = "0.11"
 serde_json = "1"
 tokio = { version = "1", features = ["macros"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "json"] }

--- a/s3-eventbridge-rust-sam/Cargo.toml
+++ b/s3-eventbridge-rust-sam/Cargo.toml
@@ -10,9 +10,9 @@ name = "handler"
 path = "src/bin/handler.rs"
 
 [dependencies]
-aws-config = "0.52.0"
-aws-sdk-s3 = "0.22.0"
-lambda_runtime = "0.7.2"
+aws-config = {version = "1", features = ["behavior-version-latest"] }
+aws-sdk-s3 = "1"
+lambda_runtime = "0.11"
 serde_json = "1"
 serde = {version = "1.0", features = ["derive"] }
 tokio = { version = "1", features = ["macros"] }

--- a/sns-sqs-lambda-rust-sam/Cargo.toml
+++ b/sns-sqs-lambda-rust-sam/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/bin/handler.rs"
 [dependencies]
 aws_lambda_events = { version = "0.7", default-features = false, features = ["sqs", "sns"] }
 futures = "0.3"
-lambda_runtime = "0.7.2"
+lambda_runtime = "0.11"
 serde = {version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros"] }

--- a/sns-sqs-lambda-rust-sam/src/bin/handler.rs
+++ b/sns-sqs-lambda-rust-sam/src/bin/handler.rs
@@ -24,7 +24,7 @@ pub async fn function_handler(event: LambdaEvent<SqsEvent>) -> Result<(), Error>
     for record in event.payload.records.into_iter() {
         tasks.push(tokio::spawn(async move {
             if let Some(body) = &record.body {
-                let sns_message = serde_json::from_str::<SnsMessage>(&body).unwrap();
+                let sns_message = serde_json::from_str::<SnsMessage>(body).unwrap();
                 let sns_message = sns_message.message;
                 let request = serde_json::from_str::<MyStruct>(&sns_message);
                 if let Ok(request) = request {

--- a/sqs-lambda-partial-batch-rust-sam/Cargo.toml
+++ b/sqs-lambda-partial-batch-rust-sam/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/bin/handler.rs"
 [dependencies]
 aws_lambda_events = { version = "0.7", default-features = false, features = ["sqs"] }
 futures = "0.3"
-lambda_runtime = "0.7.2"
+lambda_runtime = "0.11"
 serde = {version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros"] }

--- a/sqs-lambda-partial-batch-rust-sam/src/bin/handler.rs
+++ b/sqs-lambda-partial-batch-rust-sam/src/bin/handler.rs
@@ -29,7 +29,7 @@ pub async fn function_handler(event: LambdaEvent<SqsEvent>) -> Result<Value, Err
 
         tasks.push(tokio::spawn(async move {
             if let Some(body) = &record.body {
-                let request = serde_json::from_str::<MyStruct>(&body);
+                let request = serde_json::from_str::<MyStruct>(body);
                 if let Ok(request) = request {
                     do_something(&request).await.map_or_else(
                         |_e| {
@@ -59,9 +59,9 @@ pub async fn function_handler(event: LambdaEvent<SqsEvent>) -> Result<Value, Err
             .clone()
             .into_iter()
             .map(|message_id| {
-                return ItemIdentifier {
+                ItemIdentifier {
                     item_identifier: message_id,
-                };
+                }
             })
             .collect(),
     };

--- a/sqs-lambda-rust-sam/Cargo.toml
+++ b/sqs-lambda-rust-sam/Cargo.toml
@@ -11,6 +11,6 @@ path = "src/bin/handler.rs"
 
 [dependencies]
 aws_lambda_events = { version = "0.7", default-features = false, features = ["sqs"] }
-lambda_runtime = "0.7.2"
+lambda_runtime = "0.11"
 tokio = { version = "1", features = ["macros"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "json"] }


### PR DESCRIPTION
*Description of changes:*
Nov 27, 2023 - AWS announces the general availability of the AWS SDK for Rust

This MR align the current examples with the current official version of the AWS SDK for Rust

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
