### PR TITLE
New serverless pattern - cloudfront-oac-lambda-url-nodejs-cdk

### DIFF
--- a/cloudfront-oac-lambda-url-nodejs-cdk/.gitignore
+++ b/cloudfront-oac-lambda-url-nodejs-cdk/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/cloudfront-oac-lambda-url-nodejs-cdk/.npmignore
+++ b/cloudfront-oac-lambda-url-nodejs-cdk/.npmignore
@@ -1,0 +1,3 @@
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/cloudfront-oac-lambda-url-nodejs-cdk/README.md
+++ b/cloudfront-oac-lambda-url-nodejs-cdk/README.md
@@ -1,0 +1,68 @@
+# Amazon CloudFront Origin Access Control for AWS Lambda Function URL
+
+This pattern shows how to protect AWS Lambda URL origins by using CloudFront Origin Access Control (OAC) to only allow access from designated CloudFront distributions.
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [Node and NPM](https://nodejs.org/en/download/) installed
+* [AWS Cloud Development Kit](https://docs.aws.amazon.com/cdk/latest/guide/cli.html) (AWS CDK) installed
+
+## Deployment Instructions
+
+1. Clone the project to your local working directory
+    ```bash
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+
+2. Change the working directory to this pattern's directory
+    ```bash
+    cd cloudfront-oac-lambda-url-nodejs-cdk
+    ```
+
+3. Install dependencies
+    ```bash
+    npm install
+    ```
+
+4. Deploy the stack to your default AWS account and region. The output of this command should give you the HTTP API URL.
+    ```bash
+    cdk deploy
+    ```
+
+## How it works
+Amazon CloudFront will use Origin Access Control (OAC) to authenticate access to Lambda Function URLS from their designated CloudFront distributions.
+
+## Testing
+
+The solution can be validated by accessing the URLs provided in the CloudFormation output:  
+
+1. Positive testing - Check the output for a hello world message
+    ```bash
+    curl <cloudfrontUrl>
+   
+   "Hello from Lambda Function URL!"
+    ```
+
+2. Negative testing - Check the output for Forbidden access error
+    ```bash
+    curl <lambdaUrl>
+   
+   {"Message":"Forbidden"}
+    ```
+
+## Cleanup
+
+Run the given command to delete the resources that were created. It might take some time for the CloudFormation stack to get deleted.
+```bash
+cdk destroy
+```
+
+----
+Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/cloudfront-oac-lambda-url-nodejs-cdk/bin/cloudfront-oac-lambda-url-nodejs-cdk.js
+++ b/cloudfront-oac-lambda-url-nodejs-cdk/bin/cloudfront-oac-lambda-url-nodejs-cdk.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+const cdk = require('aws-cdk-lib');
+const { CloudfrontOacLambdaUrlNodejsCdkStack } = require('../lib/cloudfront-oac-lambda-url-nodejs-cdk-stack');
+
+const app = new cdk.App();
+new CloudfrontOacLambdaUrlNodejsCdkStack(app, 'CloudfrontOacLambdaUrlNodejsCdkStack');

--- a/cloudfront-oac-lambda-url-nodejs-cdk/cdk.json
+++ b/cloudfront-oac-lambda-url-nodejs-cdk/cdk.json
@@ -1,0 +1,62 @@
+{
+  "app": "node bin/cloudfront-oac-lambda-url-nodejs-cdk.js",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "jest.config.js",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ],
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+    "@aws-cdk/core:enablePartitionLiterals": true,
+    "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
+    "@aws-cdk/aws-iam:standardizedServicePrincipals": true,
+    "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
+    "@aws-cdk/aws-iam:importedRoleStackSafeDefaultPolicyName": true,
+    "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
+    "@aws-cdk/aws-route53-patters:useCertificate": true,
+    "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
+    "@aws-cdk/aws-rds:databaseProxyUniqueResourceName": true,
+    "@aws-cdk/aws-codedeploy:removeAlarmsFromDeploymentGroup": true,
+    "@aws-cdk/aws-apigateway:authorizerChangeDeploymentLogicalId": true,
+    "@aws-cdk/aws-ec2:launchTemplateDefaultUserData": true,
+    "@aws-cdk/aws-secretsmanager:useAttachedSecretResourcePolicyForSecretTargetAttachments": true,
+    "@aws-cdk/aws-redshift:columnId": true,
+    "@aws-cdk/aws-stepfunctions-tasks:enableEmrServicePolicyV2": true,
+    "@aws-cdk/aws-ec2:restrictDefaultSecurityGroup": true,
+    "@aws-cdk/aws-apigateway:requestValidatorUniqueId": true,
+    "@aws-cdk/aws-kms:aliasNameRef": true,
+    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true,
+    "@aws-cdk/core:includePrefixInUniqueNameGeneration": true,
+    "@aws-cdk/aws-efs:denyAnonymousAccess": true,
+    "@aws-cdk/aws-opensearchservice:enableOpensearchMultiAzWithStandby": true,
+    "@aws-cdk/aws-lambda-nodejs:useLatestRuntimeVersion": true,
+    "@aws-cdk/aws-efs:mountTargetOrderInsensitiveLogicalId": true,
+    "@aws-cdk/aws-rds:auroraClusterChangeScopeOfInstanceParameterGroupWithEachParameters": true,
+    "@aws-cdk/aws-appsync:useArnForSourceApiAssociationIdentifier": true,
+    "@aws-cdk/aws-rds:preventRenderingDeprecatedCredentials": true,
+    "@aws-cdk/aws-codepipeline-actions:useNewDefaultBranchForCodeCommitSource": true
+  }
+}

--- a/cloudfront-oac-lambda-url-nodejs-cdk/cloudfront-oac-lambda-url-nodejs-cdk.json
+++ b/cloudfront-oac-lambda-url-nodejs-cdk/cloudfront-oac-lambda-url-nodejs-cdk.json
@@ -1,0 +1,70 @@
+{
+    "title": "Amazon CloudFront Origin Access Control for AWS Lambda Function URL",
+    "description": "Shows how to protect AWS Lambda URL origins by using CloudFront Origin Access Control to only allow access from designated CloudFront distributions",
+    "language": "Node.js",
+    "level": "300",
+    "framework": "CDK",
+    "introBox": {
+        "headline": "How it works",
+        "text": [
+            "Amazon CloudFront will use Origin Access Control (OAC) to authenticate access to Lambda Function URLS from their designated CloudFront distributions"
+        ]
+    },
+    "gitHub": {
+        "template": {
+            "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/cloudfront-oac-lambda-url-nodejs-cdk",
+            "templateURL": "serverless-patterns/cloudfront-oac-lambda-url-nodejs-cdk",
+            "projectFolder": "cloudfront-oac-lambda-url-nodejs-cdk/lib",
+            "templateFile": "cloudfront-oac-lambda-url-nodejs-cdk-construct.js"
+        }
+    },
+    "resources": {
+        "bullets": [
+            {
+                "text": "Amazon CloudFront Origin Access Control (OAC) for Lambda function URL origins",
+                "link": "https://aws.amazon.com/about-aws/whats-new/2024/04/amazon-cloudfront-oac-lambda-function-url-origins/"
+            }
+        ]
+    },
+    "deploy": {
+        "text": [
+            "cdk deploy"
+        ]
+    },
+    "testing": {
+        "text": [
+            "See the GitHub repo for detailed testing instructions."
+        ]
+    },
+    "cleanup": {
+        "text": [
+            "cdk destroy"
+        ]
+    },
+    "authors": [
+        {
+            "name": "Thiago Pádua",
+            "image": "https://serverlessland.com/assets/images/resources/thiago-padua.jpeg",
+            "bio": "Senior Partner Solutions Architect, Serverless at Amazon Web Services (AWS)",
+            "linkedin": "thiagopadua"
+        }
+    ],
+    "patternArch": {
+        "icon1": {
+            "x": 20,
+            "y": 50,
+            "service": "cloudfront",
+            "label": "Amazon CloudFront"
+        },
+        "icon2": {
+            "x": 80,
+            "y": 50,
+            "service": "lambda",
+            "label": "AWS Lambda"
+        },
+        "line1": {
+            "from": "icon1",
+            "to": "icon2"
+        }
+    }
+}

--- a/cloudfront-oac-lambda-url-nodejs-cdk/jest.config.js
+++ b/cloudfront-oac-lambda-url-nodejs-cdk/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node'
+}

--- a/cloudfront-oac-lambda-url-nodejs-cdk/lambda/index.js
+++ b/cloudfront-oac-lambda-url-nodejs-cdk/lambda/index.js
@@ -1,0 +1,9 @@
+exports.handler = async (event) => {
+
+    const response = {
+        statusCode: 200,
+        body: JSON.stringify('Hello from Lambda Function URL!'),
+    };
+
+    return response;
+};

--- a/cloudfront-oac-lambda-url-nodejs-cdk/lib/cloudfront-oac-lambda-url-nodejs-cdk-construct.js
+++ b/cloudfront-oac-lambda-url-nodejs-cdk/lib/cloudfront-oac-lambda-url-nodejs-cdk-construct.js
@@ -1,0 +1,70 @@
+const {Construct} = require('constructs');
+const cdk = require('aws-cdk-lib');
+const iam = require('aws-cdk-lib/aws-iam');
+const lambda = require('aws-cdk-lib/aws-lambda');
+const cloudfront = require('aws-cdk-lib/aws-cloudfront');
+const origins = require('aws-cdk-lib/aws-cloudfront-origins');
+
+const NAME = 'cloudfront-oac-lambda-url';
+
+class CloudfrontOacLambdaUrlNodejsCdkConstruct extends Construct {
+    /**
+     * @param {cdk.App} scope
+     * @param {string} id
+     * @param {cdk.StackProps=} props
+     */
+    constructor(scope, id, props) {
+        super(scope, id);
+
+        const lambdaFunction = new lambda.Function(this, 'lambdaFunction', {
+            code: lambda.Code.fromAsset('lambda'),
+            handler: 'index.handler',
+            functionName: NAME,
+            architecture: lambda.Architecture.ARM_64,
+            runtime: lambda.Runtime.NODEJS_20_X
+        });
+
+        const functionUrl = lambdaFunction.addFunctionUrl({
+            authType: lambda.FunctionUrlAuthType.AWS_IAM
+        });
+
+        const functionOrigin = new origins.FunctionUrlOrigin(functionUrl);
+
+        const cfDistribution = new cloudfront.Distribution(this, 'Distribution', {
+            comment: NAME,
+            defaultBehavior: {origin: functionOrigin}
+        });
+
+        const cfnOriginAccessControl = new cloudfront.CfnOriginAccessControl(this, 'MyCfnOriginAccessControl', {
+            originAccessControlConfig: {
+                name: NAME,
+                originAccessControlOriginType: 'lambda',
+                signingBehavior: 'always',
+                signingProtocol: 'sigv4'
+            }
+        });
+
+        const distributionResource = cfDistribution.node.defaultChild;
+        distributionResource.addPropertyOverride('DistributionConfig.Origins.0.OriginAccessControlId', cfnOriginAccessControl.attrId);
+
+
+        lambdaFunction.addPermission('cfn-permission', {
+            principal: new iam.ServicePrincipal('cloudfront.amazonaws.com'),
+            action: 'lambda:InvokeFunctionUrl',
+            sourceArn: `arn:aws:cloudfront::${scope.account}:distribution/${cfDistribution.distributionId}`
+        });
+
+
+        new cdk.CfnOutput(this, 'lambdaUrl', {
+            key: 'lambdaUrl',
+            value: functionUrl.url
+        });
+
+        new cdk.CfnOutput(this, 'cloudfrontUrl', {
+            key: 'cloudfrontUrl',
+            value: `https://${cfDistribution.domainName}`
+        });
+    }
+}
+
+module.exports = {CloudfrontOacLambdaUrlNodejsCdkConstruct: CloudfrontOacLambdaUrlNodejsCdkConstruct}

--- a/cloudfront-oac-lambda-url-nodejs-cdk/lib/cloudfront-oac-lambda-url-nodejs-cdk-stack.js
+++ b/cloudfront-oac-lambda-url-nodejs-cdk/lib/cloudfront-oac-lambda-url-nodejs-cdk-stack.js
@@ -1,0 +1,19 @@
+const cdk = require('aws-cdk-lib');
+
+const { CloudfrontOacLambdaUrlNodejsCdkConstruct } = require('./cloudfront-oac-lambda-url-nodejs-cdk-construct');
+
+class CloudfrontOacLambdaUrlNodejsCdkStack extends cdk.Stack {
+  /**
+   * @param {cdk.App} scope
+   * @param {string} id
+   * @param {cdk.StackProps=} props
+   */
+  constructor(scope, id, props) {
+    super(scope, id, props);
+
+    const construct = new CloudfrontOacLambdaUrlNodejsCdkConstruct(this, 'CloudfrontAocLambdaUrlNodejsCdkConstruct');
+
+  }
+}
+
+module.exports = { CloudfrontOacLambdaUrlNodejsCdkStack: CloudfrontOacLambdaUrlNodejsCdkStack }

--- a/cloudfront-oac-lambda-url-nodejs-cdk/package.json
+++ b/cloudfront-oac-lambda-url-nodejs-cdk/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "cloudfront-oac-lambda-url-nodejs-cdk",
+  "version": "0.1.0",
+  "bin": {
+    "cloudfront-oac-lambda-url-nodejs-cdk": "bin/cloudfront-oac-lambda-url-nodejs-cdk.js"
+  },
+  "scripts": {
+    "build": "echo \"The build step is not required when using JavaScript!\" && exit 0",
+    "cdk": "cdk",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "aws-cdk": "2.137.0",
+    "jest": "^29.7.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "2.137.0",
+    "constructs": "^10.0.0"
+  }
+}

--- a/cloudfront-oac-lambda-url-nodejs-cdk/pattern.json
+++ b/cloudfront-oac-lambda-url-nodejs-cdk/pattern.json
@@ -1,0 +1,52 @@
+{
+  "title": "Amazon CloudFront Origin Access Control for AWS Lambda Function URL",
+  "description": "This pattern shows how to protect AWS Lambda URL origins by using CloudFront Origin Access Control (OAC) to only allow access from designated CloudFront distributions",
+  "language": "Node.js",
+  "level": "300",
+  "framework": "CDK",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "Amazon CloudFront will use Origin Access Control (OAC) to authenticate access to Lambda Function URLS from their designated CloudFront distributions"
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/cloudfront-oac-lambda-url-nodejs-cdk",
+      "templateURL": "serverless-patterns/cloudfront-oac-lambda-url-nodejs-cdk",
+      "projectFolder": "cloudfront-oac-lambda-url-nodejs-cdk",
+      "templateFile": "lib/cloudfront-oac-lambda-url-nodejs-cdk-construct.js"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "Amazon CloudFront Origin Access Control (OAC) for Lambda function URL origins",
+        "link": "https://aws.amazon.com/about-aws/whats-new/2024/04/amazon-cloudfront-oac-lambda-function-url-origins/"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "cdk deploy"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the GitHub repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "cdk destroy"
+    ]
+  },
+  "authors": [
+    {
+      "name": "Thiago Pádua",
+      "image": "https://serverlessland.com/assets/images/resources/thiago-padua.jpeg",
+      "bio": "Senior Partner Solutions Architect, Serverless at Amazon Web Services (AWS)",
+      "linkedin": "thiagopadua"
+    }
+  ]
+}

--- a/cloudfront-oac-lambda-url-nodejs-cdk/tsconfig.json
+++ b/cloudfront-oac-lambda-url-nodejs-cdk/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": [
+      "es2020",
+      "dom"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "typeRoots": [
+      "./node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "cdk.out"
+  ]
+}


### PR DESCRIPTION
*Description of changes:*
This pattern shows how to protect AWS Lambda URL origins by using CloudFront Origin Access Control (OAC) to only allow access from designated CloudFront distributions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
