### PR TITLE
Fix blog link since acloudguru is no more

### DIFF
--- a/eventbridge-api-destinations/2-slack/example-pattern.json
+++ b/eventbridge-api-destinations/2-slack/example-pattern.json
@@ -46,7 +46,7 @@
         "bullets": [
             {
                 "text": "How to integrate your workload with Slack using Amazon EventBridge API Destinations",
-                "link": "https://acloudguru.com/blog/engineering/how-to-integrate-your-workload-with-slack-using-amazon-eventbridge-api-destinations"
+                "link": "https://www.pluralsight.com/resources/blog/cloud/how-to-integrate-your-workload-with-slack-using-amazon-eventbridge-api-destinations"
             },
             {
                 "text": "Using API destinations with Amazon EventBridge",


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*

This fixes the link to the mentioned blog since acloudguru is no more.
