### PR TITLE
fix an issue that causes the VTL to fail if input payload contains '&'

### DIFF
--- a/apigw-websocket-api-sqs-lambda/template.yaml
+++ b/apigw-websocket-api-sqs-lambda/template.yaml
@@ -161,7 +161,7 @@ Resources:
       RequestParameters:
         integration.request.header.Content-Type: "'application/x-www-form-urlencoded'"
       RequestTemplates:
-        $default: Action=SendMessage&MessageGroupId=$input.path('$.MessageGroupId')&MessageDeduplicationId=$context.requestId&MessageAttribute.1.Name=connectionId&MessageAttribute.1.Value.StringValue=$context.connectionId&MessageAttribute.1.Value.DataType=String&MessageAttribute.2.Name=requestId&MessageAttribute.2.Value.StringValue=$context.requestId&MessageAttribute.2.Value.DataType=String&MessageBody=$input.json('$')
+        $default: Action=SendMessage&MessageGroupId=$input.path('$.MessageGroupId')&MessageDeduplicationId=$context.requestId&MessageAttribute.1.Name=connectionId&MessageAttribute.1.Value.StringValue=$context.connectionId&MessageAttribute.1.Value.DataType=String&MessageAttribute.2.Name=requestId&MessageAttribute.2.Value.StringValue=$context.requestId&MessageAttribute.2.Value.DataType=String&MessageBody=$util.urlEncode($input.json('$'))
       TemplateSelectionExpression: \$default
   SQSRoute:
     Type: AWS::ApiGatewayV2::Route


### PR DESCRIPTION

*Description of changes:* If input payload from ApiGW contains `&`, it parses the payload as a parameter key to SQS, causing the transformation to fail.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
