### PR TITLE
Modified Python lambda runtimes from 3.7 to 3.12

### DIFF
--- a/alb-cognito-lambda/template.yaml
+++ b/alb-cognito-lambda/template.yaml
@@ -64,7 +64,7 @@ Resources:
       FunctionName: "ALBLambda"
       Description: An Application Load Balancer Lambda Target that returns regional metrics
       Handler: index.lambda_handler
-      Runtime: python3.7
+      Runtime: python3.12
       Role: !GetAtt "MyLambdaFunctionPermission.Arn"
       Layers:
         - !Ref LambdaLayerARN

--- a/amplify_cognito_apigateway_lambda_envvariables/template.yaml
+++ b/amplify_cognito_apigateway_lambda_envvariables/template.yaml
@@ -53,7 +53,7 @@ Resources:
     Properties:
       CodeUri: lambdaExample/
       Handler: app.lambda_handler
-      Runtime: python3.7
+      Runtime: python3.12
       Events:
         EmyFunction:
           Type: Api

--- a/apigw-cors-nonproxy/template.yaml
+++ b/apigw-cors-nonproxy/template.yaml
@@ -80,7 +80,7 @@ Resources:
       Type: AWS::Serverless::Function
       Properties:
           Handler: index.handler
-          Runtime: python3.7
+          Runtime: python3.12
           InlineCode: | 
               import json 
               def handler(event, context): 

--- a/apigw-cors-proxy/template.yaml
+++ b/apigw-cors-proxy/template.yaml
@@ -63,7 +63,7 @@ Resources:
         Type: AWS::Serverless::Function
         Properties:
             Handler: index.handler
-            Runtime: python3.7
+            Runtime: python3.12
             InlineCode: | 
                 import json 
                 def handler(event, context): 
@@ -86,7 +86,7 @@ Resources:
         DependsOn: ApiGatewayRestApi
         Properties:
             Handler: index.handler
-            Runtime: python3.7
+            Runtime: python3.12
             InlineCode: | 
                 import json 
                 def handler(event, context): 

--- a/apigw-execution-access-logs/template.yaml
+++ b/apigw-execution-access-logs/template.yaml
@@ -62,7 +62,7 @@ Resources:
         Type: AWS::Serverless::Function
         Properties:
             Handler: index.handler
-            Runtime: python3.7
+            Runtime: python3.12
             InlineCode: | 
                 import json 
                 def handler(event, context): 

--- a/apigw-lambda-dynamodb/template.yaml
+++ b/apigw-lambda-dynamodb/template.yaml
@@ -8,7 +8,7 @@ Resources:
     Properties:
       FunctionName: WeatherFunction
       Handler: index.lambda_handler
-      Runtime: python3.7
+      Runtime: python3.12
       CodeUri: src/
       Policies:
         DynamoDBCrudPolicy:

--- a/lambda-esm-msk-filters-sam/template.yaml
+++ b/lambda-esm-msk-filters-sam/template.yaml
@@ -20,7 +20,7 @@ Globals:
     Timeout: 3
     CodeUri: src/
     Handler: app.lambda_handler
-    Runtime: python3.7
+    Runtime: python3.12
     Architectures:
       - x86_64
 

--- a/lambda-layer/template.yml
+++ b/lambda-layer/template.yml
@@ -28,7 +28,6 @@ Resources:
       LayerName: pymysql-layer
       ContentUri: dependencies/
       CompatibleRuntimes:
-        - python3.7
         - python3.8
 
   PyMySQLLayerLambdaFunction:

--- a/rabbitmq-lambda/template.yaml
+++ b/rabbitmq-lambda/template.yaml
@@ -23,7 +23,7 @@ Resources:
       CodeUri: src/
       Timeout: 3
       Handler: app.lambda_handler
-      Runtime: python3.7
+      Runtime: python3.12
       Policies:
         - Version: '2012-10-17'
           Statement:

--- a/s3-large-deployments-cdk/README.md
+++ b/s3-large-deployments-cdk/README.md
@@ -29,7 +29,7 @@ cd aws-cdk-large-deployments-to-s3
 ### Create Python virtual environment and install the dependencies
 
 ```bash
-python3.7 -m venv .venv
+python3 -m venv .venv
 source .venv/bin/activate
 pip install pip-licenses
 pip-licenses --output NOTICE.txt

--- a/step-function-lambda-terraform/modules/terraform-aws-lambda/main.tf
+++ b/step-function-lambda-terraform/modules/terraform-aws-lambda/main.tf
@@ -45,7 +45,7 @@ resource "aws_lambda_function" "aws_lambda_example" {
   role          = aws_iam_role.example_lambda_role.arn
   handler       = local.handler_name
 
-  runtime = "python3.7"
+  runtime = "python3.12"
 
   environment {
     variables = {

--- a/systems-manager-automation-to-lambda/template.yaml
+++ b/systems-manager-automation-to-lambda/template.yaml
@@ -70,7 +70,7 @@ Resources:
     Properties:
       Handler: app.handler
       CodeUri: ./src
-      Runtime: python3.7
+      Runtime: python3.12
       Timeout: 60
       ReservedConcurrentExecutions: 5
       Policies:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Multiple Patterns will no longer work because the AWS Lambda Runtime was set to `python3.7`. In some cases it would be difficult to change as the solution incorporates their own packages/libraries that were built for this version of python (for example by pulling in source from an s3 bucket). 

I went through most examples, and where the solution was simple, changed the python runtime to Python3.12, to give us more runtime before we need to change these again. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
