### PR TITLE
chore: update samples without JS SDK from node 16 to 20

### DIFF
--- a/alb-lambda-serverless/serverless.yml
+++ b/alb-lambda-serverless/serverless.yml
@@ -4,7 +4,7 @@ useDotenv: true
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs20.x
   memorySize: 256
   timeout: 30
   # override the default stage (dev) to be `prod`, or you can use the `--stage` CLI option

--- a/apigw-api-key/template.yaml
+++ b/apigw-api-key/template.yaml
@@ -4,7 +4,7 @@ Description: Serverless patterns - Amazon API Gateway REST API with API Key (uks
 
 Globals:
   Function:
-    Runtime: nodejs16.x
+    Runtime: nodejs20.x
     CodeUri: src/
 
 Resources:

--- a/apigw-client-certificate/template.yaml
+++ b/apigw-client-certificate/template.yaml
@@ -4,7 +4,7 @@ Description: Serverless patterns - Amazon API Gateway REST API with a Client Cer
 
 Globals:
   Function:
-    Runtime: nodejs16.x
+    Runtime: nodejs20.x
     CodeUri: src/
 
 Resources:

--- a/apigw-http-api-eventbridge/template.yaml
+++ b/apigw-http-api-eventbridge/template.yaml
@@ -42,7 +42,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.lambdaHandler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Events:
         EventBridgeTrigger:
           Type: CloudWatchEvent

--- a/apigw-http-api-lambda/template.yml
+++ b/apigw-http-api-lambda/template.yml
@@ -6,7 +6,7 @@ Description: An Amazon API Gateway HTTP API and an AWS Lambda function. (uksb-1t
 Globals:
   Function:
     CodeUri: ./src
-    Runtime: nodejs16.x
+    Runtime: nodejs20.x
     MemorySize: 128
     Timeout: 15
 

--- a/apigw-http-api-sqs-lambda-sls/serverless.yml
+++ b/apigw-http-api-sqs-lambda-sls/serverless.yml
@@ -8,7 +8,7 @@ provider:
   name: aws
 
   # common configuration for all Lambda functions in this stack
-  runtime: nodejs16.x
+  runtime: nodejs20.x
   architecture: arm64 # use Graviton for running all Lambda functions
 
   # use --region option value or the default - us-east-1

--- a/apigw-iam/template.yaml
+++ b/apigw-iam/template.yaml
@@ -48,7 +48,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Events:
         ApiEvent:
           Type: Api

--- a/apigw-lambda-observability/template.yaml
+++ b/apigw-lambda-observability/template.yaml
@@ -6,7 +6,7 @@ Description: Serverless patterns - API Gateway/Lambda with observability (uksb-1
 Globals:
   # Default values for the Lambda function configuration
   Function:
-    Runtime: nodejs16.x
+    Runtime: nodejs20.x
     MemorySize: 128
     Timeout: 100
     Tracing: Active

--- a/apigw-lambda-qldb/template.yaml
+++ b/apigw-lambda-qldb/template.yaml
@@ -40,7 +40,7 @@ Resources:
     Properties:
       CodeUri: src
       Handler: create-person.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Policies:
         - AWSLambdaBasicExecutionRole
         - Version: 2012-10-17
@@ -68,7 +68,7 @@ Resources:
     Properties:
       CodeUri: src
       Handler: get-person.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       MemorySize: 512
       Policies:
         - AWSLambdaBasicExecutionRole
@@ -95,7 +95,7 @@ Resources:
     Properties:
       CodeUri: src
       Handler: get-person-history.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       MemorySize: 512
       Policies:
         - AWSLambdaBasicExecutionRole
@@ -122,7 +122,7 @@ Resources:
     Properties:
       CodeUri: src
       Handler: update-person.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       MemorySize: 512
       Policies:
         - AWSLambdaBasicExecutionRole
@@ -151,7 +151,7 @@ Resources:
     Properties:
       CodeUri: src
       Handler: delete-person.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       MemorySize: 512
       Policies:
         - AWSLambdaBasicExecutionRole

--- a/apigw-lambda-request-validator/template.yaml
+++ b/apigw-lambda-request-validator/template.yaml
@@ -7,7 +7,7 @@ Description: >
 Globals:
   Function:
     CodeUri: ./src
-    Runtime: nodejs16.x
+    Runtime: nodejs20.x
     MemorySize: 128
     Timeout: 15
 

--- a/apigw-lambda-sfn-transcribe-translate-polly-sam/template.yaml
+++ b/apigw-lambda-sfn-transcribe-translate-polly-sam/template.yaml
@@ -54,7 +54,7 @@ Resources:
     Properties:
       Handler: src/transcribeLaunch.handler
       FunctionName: "translator-dev-transcribeLaunch"
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Architectures:
         - x86_64
       MemorySize: 128
@@ -65,7 +65,7 @@ Resources:
     Properties:
       Handler: src/transcribeCheck.handler
       FunctionName: "translator-dev-transcribeCheck"
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Architectures:
         - x86_64
       MemorySize: 128
@@ -76,7 +76,7 @@ Resources:
     Properties:
       Handler: src/translate.handler
       FunctionName: "translator-dev-translate"
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Architectures:
         - x86_64
       MemorySize: 128
@@ -87,7 +87,7 @@ Resources:
     Properties:
       Handler: src/speech.handler
       FunctionName: "translator-dev-speech"
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Architectures:
         - x86_64
       MemorySize: 128

--- a/apigw-lambda-sls/serverless.yml
+++ b/apigw-lambda-sls/serverless.yml
@@ -8,7 +8,7 @@ provider:
   name: aws
 
   # common configuration for all Lambda functions in this stack
-  runtime: nodejs16.x
+  runtime: nodejs20.x
   architecture: arm64 # use Graviton for running all Lambda functions
 
   # override the default stage (dev)

--- a/apigw-method-cache/template.yaml
+++ b/apigw-method-cache/template.yaml
@@ -4,7 +4,7 @@ Description: Serverless patterns - Amazon API Gateway REST API with method-level
 
 Globals:
   Function:
-    Runtime: nodejs16.x
+    Runtime: nodejs20.x
     CodeUri: src/
 
 Resources:

--- a/apigw-mutualtls-lambda/template.yaml
+++ b/apigw-mutualtls-lambda/template.yaml
@@ -7,7 +7,7 @@ Description: >
 Globals:
   Function:
     CodeUri: ./src
-    Runtime: nodejs16.x
+    Runtime: nodejs20.x
     MemorySize: 128
     Timeout: 15
 

--- a/apigw-resource-policy/template.yaml
+++ b/apigw-resource-policy/template.yaml
@@ -30,7 +30,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Events:
         ApiEvent:
           Type: Api

--- a/apigw-rest-api-eventbridge-sqs-sam/template.yml
+++ b/apigw-rest-api-eventbridge-sqs-sam/template.yml
@@ -3,7 +3,7 @@ Description: Serverless pattern API Gateway to EventBridge (uksb-1tthgi812) (tag
 
 Globals:
   Function:
-    Runtime: nodejs16.x
+    Runtime: nodejs20.x
     Architectures: ["arm64"]
     Timeout: 29
     MemorySize: 1024

--- a/apigw-rest-apigw-rest/template.yaml
+++ b/apigw-rest-apigw-rest/template.yaml
@@ -74,7 +74,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       CodeUri: src
       Environment:
         Variables:
@@ -92,7 +92,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       CodeUri: src
       Environment:
         Variables:

--- a/apigw-sqs-lambda/template.yaml
+++ b/apigw-sqs-lambda/template.yaml
@@ -38,7 +38,7 @@ Resources:
       Description: Lambda to be invoked by the SQS Queue
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Timeout: 3
       MemorySize: 128
       Events:

--- a/apigw-websocket-api-connection-dynamodb/template.yaml
+++ b/apigw-websocket-api-connection-dynamodb/template.yaml
@@ -46,7 +46,7 @@ Resources:
   DefaultRouteFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Handler: index.handler
       InlineCode: 'exports.handler = async (event) => {return {statusCode: 200, body: JSON.stringify(event)}}'
 

--- a/apigw-websocket-api-lambda/template.yml
+++ b/apigw-websocket-api-lambda/template.yml
@@ -6,7 +6,7 @@ Description: An Amazon API Gateway WebSocket API and an AWS Lambda function.
 Globals:
   Function:
     CodeUri: ./src
-    Runtime: nodejs16.x
+    Runtime: nodejs20.x
     MemorySize: 128
     Timeout: 15
 

--- a/appconfig-feature-flag-sam/template.yaml
+++ b/appconfig-feature-flag-sam/template.yaml
@@ -128,7 +128,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.lambdaHandler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Architectures:
         - x86_64
       

--- a/bedrock-lambda-nodejs/template.yml
+++ b/bedrock-lambda-nodejs/template.yml
@@ -8,7 +8,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       MemorySize: 128
       Timeout: 600
       Policies:

--- a/cloudwatch-logs-subscription-lambda-sam/template.yaml
+++ b/cloudwatch-logs-subscription-lambda-sam/template.yaml
@@ -8,7 +8,7 @@ Globals:
   Function:
     Timeout: 3
     MemorySize: 128
-    Runtime: nodejs16.x
+    Runtime: nodejs20.x
     Architectures:
         - x86_64
 

--- a/cognito-httpapi/template.yaml
+++ b/cognito-httpapi/template.yaml
@@ -55,7 +55,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Events:
         AppApi:
           Type: HttpApi

--- a/cognito-sns-sms-origination-id-sam/template.yaml
+++ b/cognito-sns-sms-origination-id-sam/template.yaml
@@ -141,7 +141,7 @@ Resources:
       FunctionName: !Sub 'CustomSmsSender-${AWS::StackName}'
       Layers:
         - !Ref DependencyLayer
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Architectures:
       - x86_64
       Environment:

--- a/dynamodb-eventbridge/template.yaml
+++ b/dynamodb-eventbridge/template.yaml
@@ -23,7 +23,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       CodeUri: publish/
       Description: A Lambda function that forward changes on DynamoDB table to EventBridge bus.
       MemorySize: 128
@@ -47,7 +47,7 @@ Resources:
     Properties:
       CodeUri: subscribe/
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Description: A Lambda function that receive Insert events from the table.
       MemorySize: 128
       Timeout: 3
@@ -57,7 +57,7 @@ Resources:
     Properties:
       CodeUri: subscribe/
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Description: A Lambda function that receive Deletion events from the table.
       MemorySize: 128
       Timeout: 3

--- a/dynamodb-lambda/template.yaml
+++ b/dynamodb-lambda/template.yaml
@@ -6,7 +6,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       CodeUri: src/
       Description: An Amazon DynamoDB trigger that logs the updates made to a table.
       MemorySize: 128

--- a/dynamodb-streams-lambda-event-filters/template.yaml
+++ b/dynamodb-streams-lambda-event-filters/template.yaml
@@ -14,7 +14,7 @@ Resources:
     Properties:
       CodeUri: src/handlers/
       Handler: dynamodb-insert-trigger.putItemTriggerHandler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Architectures:
         - x86_64
       MemorySize: 128
@@ -41,7 +41,7 @@ Resources:
     Properties:
       CodeUri: src/handlers/
       Handler: dynamodb-delete-trigger.deleteItemTriggerHandler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Architectures:
         - x86_64
       MemorySize: 128

--- a/eventbridge-cross-region/eventbus-destination/template.yaml
+++ b/eventbridge-cross-region/eventbus-destination/template.yaml
@@ -21,7 +21,7 @@ Resources:
       Handler: app.handler
       MemorySize: 128
       Timeout: 3
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
 
   EventRule: 
     Type: AWS::Events::Rule

--- a/eventbridge-cross-region/eventbus-source/template.yaml
+++ b/eventbridge-cross-region/eventbus-source/template.yaml
@@ -106,7 +106,7 @@ Resources:
       Handler: app.handler
       MemorySize: 128
       Timeout: 3
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Environment:
         Variables:
           EVENTSOURCE: !Ref EventSource

--- a/eventbridge-lambda-sls/serverless.yml
+++ b/eventbridge-lambda-sls/serverless.yml
@@ -8,7 +8,7 @@ provider:
   name: aws
 
   # common configuration for all Lambda functions in this stack
-  runtime: nodejs16.x
+  runtime: nodejs20.x
   architecture: arm64 # use Graviton for running all Lambda functions
 
   # use --region option value or the default - us-east-1

--- a/eventbridge-lambda/template.yaml
+++ b/eventbridge-lambda/template.yaml
@@ -10,7 +10,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Timeout: 3
       Events:
         Trigger:

--- a/eventbridge-pipes-dynamodbstream-to-sqs-serverless/serverless.yml
+++ b/eventbridge-pipes-dynamodbstream-to-sqs-serverless/serverless.yml
@@ -8,7 +8,7 @@ custom:
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs20.x
   memorySize: 256
   timeout: 30
   # override the default stage (dev) to be `prod`, or you can use the `--stage` CLI option

--- a/eventbridge-pipes-msk-iam-auth-to-lambda/pipes.yaml
+++ b/eventbridge-pipes-msk-iam-auth-to-lambda/pipes.yaml
@@ -107,7 +107,7 @@ Resources:
                 }
             }
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Policies:
       - AWSLambdaBasicExecutionRole
 

--- a/eventbridge-pipes-msk-to-lambda/pipes.yaml
+++ b/eventbridge-pipes-msk-to-lambda/pipes.yaml
@@ -97,7 +97,7 @@ Resources:
                 }
             }
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Policies:
       - AWSLambdaBasicExecutionRole
 

--- a/eventbridge-pipes-sqs-to-lambda-with-stepfunction-enrichment/template.yaml
+++ b/eventbridge-pipes-sqs-to-lambda-with-stepfunction-enrichment/template.yaml
@@ -22,7 +22,7 @@ Resources:
       FunctionName: !Sub ${AWS::StackName}-target-lambda
       CodeUri: src/
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       MemorySize: 128
       Timeout: 15
       Architectures:

--- a/eventbridge-schedule-to-lambda/template.yaml
+++ b/eventbridge-schedule-to-lambda/template.yaml
@@ -15,7 +15,7 @@ Resources:
     Properties:
       CodeUri: functions/
       Handler: app.lambdaHandler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Architectures:
         - x86_64
     Metadata: # Manage esbuild properties

--- a/firehose-transformation-sam/template.yaml
+++ b/firehose-transformation-sam/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       FunctionName: TransformationFunction
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       CodeUri: src/
       Timeout: 90
   

--- a/iot-lambda/template.yaml
+++ b/iot-lambda/template.yaml
@@ -8,7 +8,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       CodeUri: src/
       Description: A Lambda function that logs the IoT events sent to a IoT Thing topic.
       MemorySize: 128

--- a/iot-mqttoverhttp-customauth/template.yaml
+++ b/iot-mqttoverhttp-customauth/template.yaml
@@ -26,7 +26,7 @@ Resources:
     Properties:
       FunctionName: iot-events-processor
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Timeout: 29
       CodeUri: src/
       Events:
@@ -81,7 +81,7 @@ Resources:
     Properties:
       FunctionName: iot-publish-authorizer
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Environment:
         Variables:
           AWS_ACCOUNTID: !Ref AWS::AccountId

--- a/kinesis-lambda-efo/template.yaml
+++ b/kinesis-lambda-efo/template.yaml
@@ -21,7 +21,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: src/
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Handler: app.lambdaHandler
       Tracing: Active
       Events:

--- a/kinesis-lambda/template.yaml
+++ b/kinesis-lambda/template.yaml
@@ -14,7 +14,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: src/
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Handler: app.lambdaHandler
       Tracing: Active
       Events:

--- a/lambda-cloudwatch/template.yaml
+++ b/lambda-cloudwatch/template.yaml
@@ -17,7 +17,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.lambdaHandler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       # SAM Managed Policy for inserting custom CloudWatch Metrics
       Policies:
         - CloudWatchPutMetricPolicy: {}

--- a/lambda-destinations-sam/template.yaml
+++ b/lambda-destinations-sam/template.yaml
@@ -8,7 +8,7 @@ Globals:
   Function:
     Timeout: 3
     MemorySize: 128
-    Runtime: nodejs16.x
+    Runtime: nodejs20.x
     Architectures:
         - x86_64
 

--- a/lambda-dynamodb/template.yaml
+++ b/lambda-dynamodb/template.yaml
@@ -12,7 +12,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Timeout: 3
       Environment:
         Variables:

--- a/lambda-eventbridge/template.yaml
+++ b/lambda-eventbridge/template.yaml
@@ -16,7 +16,7 @@ Resources:
       CodeUri: src/
       Handler: app.handler
       Timeout: 3
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Policies:
         - EventBridgePutEventsPolicy:
             EventBusName: !Ref EventBusName

--- a/lambda-function-url-sls/serverless.yml
+++ b/lambda-function-url-sls/serverless.yml
@@ -4,7 +4,7 @@ frameworkVersion: '^3' # requires serverless 3.12 or later
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs20.x
   architecture: arm64 
   stage: ${opt:stage, "dev"} # Default stage to "dev"
   region: ${opt:region, "us-east-1"} # Default region to "us-east-1"

--- a/lambda-function-url/template.yaml
+++ b/lambda-function-url/template.yaml
@@ -12,7 +12,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Timeout: 3
       FunctionUrlConfig:
         AuthType: AWS_IAM

--- a/lambda-inspector-scans/template.yaml
+++ b/lambda-inspector-scans/template.yaml
@@ -10,7 +10,7 @@ Resources:
       FunctionName: !Sub ${AWS::StackName}-consumer
       CodeUri: src/
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       MemorySize: 128
       Timeout: 15
       Architectures:

--- a/lambda-lambda/template.yaml
+++ b/lambda-lambda/template.yaml
@@ -9,7 +9,7 @@ Resources:
     Properties:
       CodeUri: ProducerFunction/
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Timeout: 3
       EventInvokeConfig:
         DestinationConfig:
@@ -25,7 +25,7 @@ Resources:
     Properties:
       CodeUri: OnFailureFunction/
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Timeout: 3
   OnSuccessFunction:
     Type: AWS::Serverless::Function
@@ -33,7 +33,7 @@ Resources:
     Properties:
       CodeUri: OnSuccessFunction/
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Timeout: 3
 Outputs:
   ProducerFunctionName:

--- a/lambda-layer-ssm-parameters/function/template.yml
+++ b/lambda-layer-ssm-parameters/function/template.yml
@@ -20,7 +20,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       FunctionName: !Sub ${AppName}-function
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       CodeUri: ./src
       Handler: app.handler
       FunctionUrlConfig:

--- a/lambda-pinpoint/template.yaml
+++ b/lambda-pinpoint/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       MemorySize: 128
       Timeout: 100
       Description: A simple example of sending an SMS with Pinpoint

--- a/lambda-rekognition/template.yaml
+++ b/lambda-rekognition/template.yaml
@@ -77,7 +77,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Description: Lambda function that will recieve CloudWatch events and will trigger
         CodeBuild build job.
       FunctionName: 'TextRecognitionLambdaFunction'

--- a/lambda-s3-sfn/template.yaml
+++ b/lambda-s3-sfn/template.yaml
@@ -6,7 +6,7 @@ Description: >
 
 Globals:
   Function:
-    Runtime: nodejs16.x
+    Runtime: nodejs20.x
     Timeout: 10  
     Environment:
         Variables:

--- a/lambda-secretsmanager-node-sdkv3-sam/template.yml
+++ b/lambda-secretsmanager-node-sdkv3-sam/template.yml
@@ -24,7 +24,7 @@ Resources:
     Properties:
       Description: Lambda function to retrieve Secrets Manager secret
       CodeUri: src/
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Handler: app.handler
       MemorySize: 128
       Timeout: 15

--- a/lambda-ses/template.yaml
+++ b/lambda-ses/template.yaml
@@ -20,7 +20,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Timeout: 3
       MemorySize: 128
       Environment:

--- a/lambda-sfn-sls/serverless.yml
+++ b/lambda-sfn-sls/serverless.yml
@@ -9,7 +9,7 @@ provider:
   name: aws
 
   # common configuration for all Lambda functions in this stack
-  runtime: nodejs16.x
+  runtime: nodejs20.x
   architecture: arm64 # use Graviton for running all Lambda functions
 
   # use --region option value or the default - us-east-1

--- a/lambda-sfn/template.yaml
+++ b/lambda-sfn/template.yaml
@@ -12,7 +12,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Timeout: 3
       Policies:
         - StepFunctionsExecutionPolicy:

--- a/lambda-sns-sms/template.yaml
+++ b/lambda-sns-sms/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Timeout: 3
       MemorySize: 128
       Environment:

--- a/lambda-sns/template.yaml
+++ b/lambda-sns/template.yaml
@@ -13,7 +13,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Timeout: 3
       MemorySize: 128
       Environment:

--- a/lambda-sqs/template.yaml
+++ b/lambda-sqs/template.yaml
@@ -13,7 +13,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Timeout: 3
       MemorySize: 128
       Environment:

--- a/lambda-streaming-large-sam/template.yaml
+++ b/lambda-streaming-large-sam/template.yaml
@@ -7,7 +7,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Timeout: 30
       MemorySize: 256
       AutoPublishAlias: live

--- a/lambda-streaming-sdk-sam/template.yaml
+++ b/lambda-streaming-sdk-sam/template.yaml
@@ -8,7 +8,7 @@ Transform:
 
 Globals:
   Function:
-    Runtime: nodejs16.x
+    Runtime: nodejs20.x
     Timeout: 10
     MemorySize: 128
     Architectures:

--- a/lambda-streaming-ttfb-pipeline-sam/template.yaml
+++ b/lambda-streaming-ttfb-pipeline-sam/template.yaml
@@ -7,7 +7,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Timeout: 30
       MemorySize: 256
       AutoPublishAlias: live

--- a/lambda-streaming-ttfb-write-sam-with-bedrock-streaming/template.yaml
+++ b/lambda-streaming-ttfb-write-sam-with-bedrock-streaming/template.yaml
@@ -7,7 +7,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Timeout: 300
       MemorySize: 512
       AutoPublishAlias: live

--- a/lambda-streaming-ttfb-write-sam/template.yaml
+++ b/lambda-streaming-ttfb-write-sam/template.yaml
@@ -7,7 +7,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Timeout: 30
       MemorySize: 512
       AutoPublishAlias: live

--- a/lambda-vpc-secrets-sls/serverless.yml
+++ b/lambda-vpc-secrets-sls/serverless.yml
@@ -4,7 +4,7 @@ frameworkVersion: '^3' # requires serverless 3.0 or later
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs20.x
   architecture: arm64 
   stage: ${opt:stage, "dev"} # Default stage to "dev"
   region: ${opt:region, "us-east-1"} # Default region to "us-east-1"

--- a/lambda/template.yaml
+++ b/lambda/template.yaml
@@ -12,7 +12,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       MemorySize: 512
       EphemeralStorage:
         Size: 512           

--- a/msk-lambda/template.yaml
+++ b/msk-lambda/template.yaml
@@ -17,7 +17,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.lambdaHandler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Events:
         MSKEvent:
           Type: MSK

--- a/qldb-kinesis-lambda-dynamodb/template.yaml
+++ b/qldb-kinesis-lambda-dynamodb/template.yaml
@@ -27,7 +27,7 @@ Resources:
     Properties:
       CodeUri: src
       Handler: qldb-streams-dynamodb.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       MemorySize: 1024
       Policies:
         - AWSLambdaBasicExecutionRole

--- a/s3-eventbridge-direct/template.yaml
+++ b/s3-eventbridge-direct/template.yaml
@@ -34,7 +34,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       MemorySize: 128
       Timeout: 3
       Policies:

--- a/s3-sqs-lambda/template.yaml
+++ b/s3-sqs-lambda/template.yaml
@@ -68,7 +68,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       MemorySize: 2048
       Layers:
         - !Sub 'arn:aws:lambda:${AWS::Region}:175033217214:layer:graphicsmagick:2'

--- a/sam-webapp-cognito/template.yaml
+++ b/sam-webapp-cognito/template.yaml
@@ -179,7 +179,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Events:
         HttpApi:
           Type: HttpApi

--- a/sfn-apigw/template.yaml
+++ b/sfn-apigw/template.yaml
@@ -32,7 +32,7 @@ Resources:
     Properties:
       CodeUri: src
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Events:
         Api:
           Type: Api

--- a/sfn-lambda-dynamodb/template.yml
+++ b/sfn-lambda-dynamodb/template.yml
@@ -34,7 +34,7 @@ Resources:
         - CloudWatchLogsFullAccess
         - DynamoDBCrudPolicy:
             TableName: !Ref DynamoDBTable
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Timeout: 30
       Tracing: Active
     Type: AWS::Serverless::Function

--- a/sfn-lambda-lambda/template.yaml
+++ b/sfn-lambda-lambda/template.yaml
@@ -33,7 +33,7 @@ Resources:
     Properties:
       CodeUri: firstfunction/
       Handler: first-function.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Timeout: 3
       Policies: 
         - CloudWatchPutMetricPolicy: {}
@@ -42,7 +42,7 @@ Resources:
     Properties:
       CodeUri: secondfunction/
       Handler: second-function.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Timeout: 3
       Policies: 
         - CloudWatchPutMetricPolicy: {}

--- a/sfn-lambda/template.yaml
+++ b/sfn-lambda/template.yaml
@@ -33,7 +33,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Timeout: 3
       Policies: 
         - CloudWatchPutMetricPolicy: {}

--- a/sns-lambda/template.yaml
+++ b/sns-lambda/template.yaml
@@ -25,7 +25,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Timeout: 3
       MemorySize: 128
 

--- a/systems-manager-automation-to-stepfunctions/template.yaml
+++ b/systems-manager-automation-to-stepfunctions/template.yaml
@@ -120,7 +120,7 @@ Resources:
     Properties:
       Handler: iterate.handler
       CodeUri: ./src
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       Timeout: 60
       ReservedConcurrentExecutions: 5
 


### PR DESCRIPTION
*Issue #, if available:*

Refs: https://github.com/aws-samples/serverless-patterns/issues/2290

*Description of changes:*

Updates samples which does not use AWS SDK for JavaScript from node 16 to 20.

The samples which use AWS SDK for JavaScript will need migration to JS SDK v3, and were done in https://github.com/aws-samples/serverless-patterns/pull/2293

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
