### PR TITLE
chore: update samples with JS SDK from node 16 to 20

### DIFF
--- a/apigw-websocket-api-sqs-lambda/src/SQSWebsocketResponse.js
+++ b/apigw-websocket-api-sqs-lambda/src/SQSWebsocketResponse.js
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-const AWS = require("aws-sdk");
-const apig = new AWS.ApiGatewayManagementApi({ endpoint: process.env.ApiGatewayEndpoint });
+const { ApiGatewayManagementApi } = require("@aws-sdk/client-apigatewaymanagementapi");
+const apig = new ApiGatewayManagementApi({ endpoint: process.env.ApiGatewayEndpoint });
 
 exports.handler = async (event, context) => {
     //console.log("Event: ", JSON.stringify(event, null, 2));
@@ -14,7 +14,9 @@ exports.handler = async (event, context) => {
                     requestId: event.Records[r].messageAttributes.requestId.stringValue,
                     message: event.Records[r].body
                 };
-                await apig.postToConnection({ ConnectionId: event.Records[r].messageAttributes.connectionId.stringValue, Data: JSON.stringify(response) }).promise();
+                await apig.postToConnection(
+                    { ConnectionId: event.Records[r].messageAttributes.connectionId.stringValue, Data: JSON.stringify(response) }
+                );
             }
             catch (err) {
                 console.error(err);

--- a/apigw-websocket-api-sqs-lambda/template.yaml
+++ b/apigw-websocket-api-sqs-lambda/template.yaml
@@ -5,7 +5,7 @@ Description: An Amazon API Gateway WebSocket API and SQS with a AWS Lambda funct
 Globals:
   Function:
     CodeUri: ./src
-    Runtime: nodejs16.x
+    Runtime: nodejs20.x
     MemorySize: 128
     Timeout: 15
 

--- a/apigw-websocket-api-sqs-lambda/template.yaml
+++ b/apigw-websocket-api-sqs-lambda/template.yaml
@@ -86,7 +86,8 @@ Resources:
           ApiGatewayEndpoint:
             Fn::Join:
               - ""
-              - - Ref: APIGWWebsocketSQSLambda
+              - - "https://"
+                - Ref: APIGWWebsocketSQSLambda
                 - .execute-api.
                 - Ref: AWS::Region
                 - "."

--- a/appsync-notify-subscribers-of-database-updates/3-lambda/externalDepsLayer/nodejs/package.json
+++ b/appsync-notify-subscribers-of-database-updates/3-lambda/externalDepsLayer/nodejs/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "aws-appsync": "^4.1.2",
     "axios": "^0.28.0",
-    "graphql": "^15.6.1",
+    "graphql": "^15.3.0",
     "graphql-tag": "^2.12.5",
     "isomorphic-fetch": "^3.0.0"
   }

--- a/appsync-notify-subscribers-of-database-updates/3-lambda/src/lambdaUsesEventBridge.js
+++ b/appsync-notify-subscribers-of-database-updates/3-lambda/src/lambdaUsesEventBridge.js
@@ -1,7 +1,7 @@
 "use strict";
-const AWS = require("aws-sdk");
+const { EventBridge } = require("@aws-sdk/client-eventbridge");
 
-const eventbridge = new AWS.EventBridge();
+const eventbridge = new EventBridge();
 
 exports.handler = async (event) => {
     try {
@@ -19,7 +19,7 @@ exports.handler = async (event) => {
             }]
         };
         console.log("push data to EventBridge ", params);
-        const response = await eventbridge.putEvents(params).promise();
+        const response = await eventbridge.putEvents(params);
         console.log("response ", response);
 
     } catch (error) {

--- a/appsync-notify-subscribers-of-database-updates/3-lambda/src/lambdaUsesIAM.js
+++ b/appsync-notify-subscribers-of-database-updates/3-lambda/src/lambdaUsesIAM.js
@@ -1,5 +1,4 @@
 require('isomorphic-fetch');
-const AWS = require('aws-sdk/global');
 const AUTH_TYPE = require('aws-appsync').AUTH_TYPE;
 const AWSAppSyncClient = require('aws-appsync').default;
 const gql = require('graphql-tag');
@@ -9,7 +8,11 @@ const config = {
     region: process.env.AWS_REGION,
     auth: {
         type: AUTH_TYPE.AWS_IAM,
-        credentials: AWS.config.credentials,
+        credentials: {
+            accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+            secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+            sessionToken: process.env.AWS_SESSION_TOKEN
+        },
     },
     disableOffline: true
 };

--- a/appsync-notify-subscribers-of-database-updates/3-lambda/template.yml
+++ b/appsync-notify-subscribers-of-database-updates/3-lambda/template.yml
@@ -5,7 +5,7 @@ Description: Notify subscribers of database updates
 Globals:
   Function:
     CodeUri: src/
-    Runtime: nodejs16.x
+    Runtime: nodejs20.x
     Timeout: 10
     MemorySize: 128
     Layers:

--- a/cfn-custom-resource-s3-create/src/app.js
+++ b/cfn-custom-resource-s3-create/src/app.js
@@ -3,9 +3,9 @@
  */
 
 // Lambda function used as CloudFormation custom resource to create an S3 object.
-//const AWS = require("aws-sdk");
-//const S3 = new AWS.S3();
-const { S3 } = require("aws-sdk");
+const { Upload } = require("@aws-sdk/lib-storage");
+const { S3 } = require("@aws-sdk/client-s3");
+
 const s3 = new S3();
 const response = require("./cfn-response.js");
 
@@ -25,7 +25,7 @@ exports.handler = async (event, context) => {
         Bucket: event.ResourceProperties.Bucket,
         Key: event.ResourceProperties.Key,
       };
-      await s3.deleteObject(params).promise();
+      await s3.deleteObject(params);
     } catch (error) {
       console.error("Error during S3 delete:\n", error);
     }
@@ -39,7 +39,7 @@ exports.handler = async (event, context) => {
         ContentType: event.ResourceProperties.ContentType,
         Body: event.ResourceProperties.Body,
       };
-      const s3Upload = await s3.upload(params).promise();
+      const s3Upload = await new Upload({ client: s3, params }).done();
       // Response data that is sent back to CloudFormation:
       responseData = { ObjectKey: s3Upload.Key };
       responseStatus = response.SUCCESS;

--- a/cfn-custom-resource-s3-create/template.yml
+++ b/cfn-custom-resource-s3-create/template.yml
@@ -6,7 +6,7 @@ Description: A CloudFormation Custom Resource and a Lambda function to create an
 Globals:
   Function:
     CodeUri: ./src
-    Runtime: nodejs16.x
+    Runtime: nodejs20.x
     MemorySize: 128
     Timeout: 15
 

--- a/lambda-aurora-serverless/src/app.js
+++ b/lambda-aurora-serverless/src/app.js
@@ -1,5 +1,5 @@
-const AWS = require("aws-sdk");
-const rdsDataService = new AWS.RDSDataService();
+const { RDSData } = require("@aws-sdk/client-rds-data");
+const rdsDataService = new RDSData();
 
 async function RunCommand(sqlStatement, sqlValues){
   // Prepare the SQL parameters required for Data API
@@ -21,7 +21,7 @@ async function RunCommand(sqlStatement, sqlValues){
   console.log("SQL Parameters:\n", JSON.stringify(sqlParams));
 
   // Use the Data API ExecuteStatement operation to run the SQL command
-  const result = await rdsDataService.executeStatement(sqlParams).promise();
+  const result = await rdsDataService.executeStatement(sqlParams);
   //console.log("Result:\n", result);
   return result;
 }

--- a/lambda-aurora-serverless/template.yml
+++ b/lambda-aurora-serverless/template.yml
@@ -6,7 +6,7 @@ Description: An AWS Lambda function and an Amazon Aurora Serverless DB cluster w
 Globals:
   Function:
     CodeUri: ./src
-    Runtime: nodejs16.x
+    Runtime: nodejs20.x
     MemorySize: 128
     Timeout: 30
 

--- a/lambda-iot-sam/cf-customResource/GetIoTEndpoint.js
+++ b/lambda-iot-sam/cf-customResource/GetIoTEndpoint.js
@@ -2,7 +2,7 @@
  *  SPDX-License-Identifier: MIT-0
  */
 
-const aws = require("aws-sdk")
+const { IoT } = require("@aws-sdk/client-iot");
 
 exports.handler = function (event, context) {
   console.log("REQUEST RECEIVED:\n" + JSON.stringify(event))
@@ -13,7 +13,7 @@ exports.handler = function (event, context) {
     return
   }
 
-  const iot = new aws.Iot()
+  const iot = new IoT()
   iot.describeEndpoint({
     endpointType: "iot:Data-ATS",
   }, (err, data) => {

--- a/lambda-iot-sam/src/handler.js
+++ b/lambda-iot-sam/src/handler.js
@@ -1,11 +1,8 @@
 "use strict";
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.handler = void 0;
-const iotdata_1 = __importDefault(require("aws-sdk/clients/iotdata"));
-const iotdata = new iotdata_1.default({ endpoint: process.env.IOT_DATA_ENDPOINT });
+const client_iot_data_plane_1 = require("@aws-sdk/client-iot-data-plane");
+const iotdata = new client_iot_data_plane_1.IoTDataPlane({ endpoint: process.env.IOT_DATA_ENDPOINT });
 const handler = async (event) => {
     const params = {
         topic: `${process.env.IOT_TOPIC}`,
@@ -15,7 +12,7 @@ const handler = async (event) => {
             detail: "world"
         })
     };
-    await iotdata.publish(params).promise();
+    await iotdata.publish(params);
 };
 exports.handler = handler;
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiaGFuZGxlci5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbImhhbmRsZXIudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6Ijs7Ozs7O0FBQUEsc0VBQThDO0FBRTlDLE1BQU0sT0FBTyxHQUFHLElBQUksaUJBQU8sQ0FBQyxFQUFFLFFBQVEsRUFBRSxPQUFPLENBQUMsR0FBRyxDQUFDLGlCQUFpQixFQUFFLENBQUMsQ0FBQTtBQUVqRSxNQUFNLE9BQU8sR0FBUSxLQUFLLEVBQUUsS0FBVSxFQUFnQixFQUFFO0lBQzdELE1BQU0sTUFBTSxHQUFHO1FBQ2IsS0FBSyxFQUFFLEdBQUcsT0FBTyxDQUFDLEdBQUcsQ0FBQyxTQUFTLEVBQUU7UUFDakMsR0FBRyxFQUFFLENBQUM7UUFDTixPQUFPLEVBQUUsSUFBSSxDQUFDLFNBQVMsQ0FBQztZQUN0QixJQUFJLEVBQUUsT0FBTztZQUNiLE1BQU0sRUFBRSxPQUFPO1NBQ2hCLENBQUM7S0FDSCxDQUFDO0lBQ0YsTUFBTSxPQUFPLENBQUMsT0FBTyxDQUFDLE1BQU0sQ0FBQyxDQUFDLE9BQU8sRUFBRSxDQUFDO0FBQzFDLENBQUMsQ0FBQztBQVZXLFFBQUEsT0FBTyxXQVVsQiJ9
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiaGFuZGxlci5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbImhhbmRsZXIudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6Ijs7O0FBQUEsMEVBQThEO0FBRTlELE1BQU0sT0FBTyxHQUFHLElBQUksb0NBQVksQ0FBQyxFQUFFLFFBQVEsRUFBRSxPQUFPLENBQUMsR0FBRyxDQUFDLGlCQUFpQixFQUFFLENBQUMsQ0FBQTtBQUV0RSxNQUFNLE9BQU8sR0FBUSxLQUFLLEVBQUUsS0FBVSxFQUFnQixFQUFFO0lBQzdELE1BQU0sTUFBTSxHQUFHO1FBQ2IsS0FBSyxFQUFFLEdBQUcsT0FBTyxDQUFDLEdBQUcsQ0FBQyxTQUFTLEVBQUU7UUFDakMsR0FBRyxFQUFFLENBQUM7UUFDTixPQUFPLEVBQUUsSUFBSSxDQUFDLFNBQVMsQ0FBQztZQUN0QixJQUFJLEVBQUUsT0FBTztZQUNiLE1BQU0sRUFBRSxPQUFPO1NBQ2hCLENBQUM7S0FDSCxDQUFDO0lBQ0YsTUFBTSxPQUFPLENBQUMsT0FBTyxDQUFDLE1BQU0sQ0FBQyxDQUFDO0FBQ2hDLENBQUMsQ0FBQztBQVZXLFFBQUEsT0FBTyxXQVVsQiJ9

--- a/lambda-iot-sam/src/handler.ts
+++ b/lambda-iot-sam/src/handler.ts
@@ -1,6 +1,6 @@
-import IotData from "aws-sdk/clients/iotdata";
+import { IoTDataPlane } from "@aws-sdk/client-iot-data-plane";
 
-const iotdata = new IotData({ endpoint: process.env.IOT_DATA_ENDPOINT })
+const iotdata = new IoTDataPlane({ endpoint: process.env.IOT_DATA_ENDPOINT })
 
 export const handler: any = async (event: any): Promise<any> => {
   const params = {
@@ -11,5 +11,5 @@ export const handler: any = async (event: any): Promise<any> => {
       detail: "world"
     })
   };
-  await iotdata.publish(params).promise();
+  await iotdata.publish(params);
 };

--- a/lambda-iot-sam/template.yaml
+++ b/lambda-iot-sam/template.yaml
@@ -84,7 +84,11 @@ Resources:
       Handler: handler.handler
       Environment:
         Variables:
-          IOT_DATA_ENDPOINT: !GetAtt IotEndpoint.IotEndpointAddress
+          IOT_DATA_ENDPOINT:
+            Fn::Join:
+              - ""
+              - - "https://"
+                - !GetAtt IotEndpoint.IotEndpointAddress
           IOT_TOPIC: !Ref IOTRealtime
       Policies:
         - Statement:

--- a/lambda-iot-sam/template.yaml
+++ b/lambda-iot-sam/template.yaml
@@ -2,7 +2,7 @@ Transform: AWS::Serverless-2016-10-31
 
 Globals:
   Function:
-    Runtime: nodejs16.x
+    Runtime: nodejs20.x
     Architectures: ["arm64"]
     Timeout: 29
     MemorySize: 1024

--- a/lambda-ssm-parameter/src/app.js
+++ b/lambda-ssm-parameter/src/app.js
@@ -6,8 +6,8 @@
 // 2. GET or PUT an SSM Parameter Store parameter.
 // 3. Return a response with parameter result.
 
-const AWS = require("aws-sdk")
-const ssm = new AWS.SSM()
+const { SSM } = require("@aws-sdk/client-ssm");
+const ssm = new SSM()
 
 exports.handler = async (event, context) => {
   try {
@@ -34,12 +34,12 @@ exports.handler = async (event, context) => {
         Overwrite: true,
         Type: "String",
       };
-      result = await ssm.putParameter(ssmPutParams).promise()
+      result = await ssm.putParameter(ssmPutParams)
     } else if (method == "GET") {
       const ssmGetParams = {
         Name: parameterName,
       };
-      result = await ssm.getParameter(ssmGetParams).promise()
+      result = await ssm.getParameter(ssmGetParams)
     } else {
       result = "Method not supported"
     }

--- a/lambda-ssm-parameter/template.yml
+++ b/lambda-ssm-parameter/template.yml
@@ -6,7 +6,7 @@ Description: An AWS Lambda function and an AWS Systems Manager Parameter Store p
 Globals:
   Function:
     CodeUri: ./src
-    Runtime: nodejs16.x
+    Runtime: nodejs20.x
     MemorySize: 128
     Timeout: 15
 

--- a/s3-object-lambda/src/app.js
+++ b/s3-object-lambda/src/app.js
@@ -2,7 +2,8 @@
  *  SPDX-License-Identifier: MIT-0
  */
 
-const { S3 } = require("aws-sdk");
+const { S3 } = require("@aws-sdk/client-s3");
+
 const axios = require("axios").default;  // Promise-based HTTP requests
 const sharp = require("sharp"); // Used for image resizing
 
@@ -32,7 +33,7 @@ exports.handler = async (event) => {
     RequestToken: outputToken,
     Body: resized,
   };
-  await s3.writeGetObjectResponse(params).promise();
+  await s3.writeGetObjectResponse(params);
 
   // Exit the Lambda function.
   return { statusCode: 200 };

--- a/s3-object-lambda/template.yaml
+++ b/s3-object-lambda/template.yaml
@@ -66,7 +66,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs20.x
       MemorySize: 2048
       # The function needs permission to call back to the S3 Object Lambda Access Point with the WriteGetObjectResponse.
       Policies:


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws-samples/serverless-patterns/issues/2290

*Description of changes:*
Updates samples which use AWS SDK for JavaScript from node 16 to 20.

The AWS SDK for JavaScript v2 APIs were migrated to v3 using [aws-sdk-js-codemod](https://www.npmjs.com/package/aws-sdk-js-codemod).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
