### PR TITLE
chore: update terraform samples without JS SDK from node 16 to 20

### DIFF
--- a/alb-lambda-terraform/main.tf
+++ b/alb-lambda-terraform/main.tf
@@ -177,7 +177,7 @@ resource "aws_lb_target_group_attachment" "target_group_attachment" {
 # Create the Lambda Function
 resource "aws_lambda_function" "lambda_function" {
   function_name = "lambdaFunction"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
   handler       = "index.handler"
   filename      = "lambda.zip"
   role          = aws_iam_role.lambda_role.arn

--- a/apigw-lambda-qldb-terraform/main.tf
+++ b/apigw-lambda-qldb-terraform/main.tf
@@ -35,7 +35,7 @@ resource "aws_lambda_function" "lambda_function_create_person" {
   source_code_hash = data.archive_file.lambda_zip_file.output_base64sha256
   handler          = "create-person.handler"
   role             = aws_iam_role.lambda_iam_role_create_person.arn
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
   environment {
     variables = {
       LEDGER_NAME = aws_qldb_ledger.ledger.id
@@ -118,7 +118,7 @@ resource "aws_lambda_function" "lambda_function_get_person" {
   source_code_hash = data.archive_file.lambda_zip_file.output_base64sha256
   handler          = "get-person.handler"
   role             = aws_iam_role.lambda_iam_role_get_person.arn
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
   memory_size      = 512
   environment {
     variables = {
@@ -193,7 +193,7 @@ resource "aws_lambda_function" "lambda_function_get_person_history" {
   source_code_hash = data.archive_file.lambda_zip_file.output_base64sha256
   handler          = "get-person-history.handler"
   role             = aws_iam_role.lambda_iam_role_get_person_history.arn
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
   memory_size      = 512
   environment {
     variables = {
@@ -268,7 +268,7 @@ resource "aws_lambda_function" "lambda_function_update_person" {
   source_code_hash = data.archive_file.lambda_zip_file.output_base64sha256
   handler          = "update-person.handler"
   role             = aws_iam_role.lambda_iam_role_update_person.arn
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
   memory_size      = 512
   environment {
     variables = {
@@ -344,7 +344,7 @@ resource "aws_lambda_function" "lambda_function_delete_person" {
   source_code_hash = data.archive_file.lambda_zip_file.output_base64sha256
   handler          = "delete-person.handler"
   role             = aws_iam_role.lambda_iam_role_delete_person.arn
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
   memory_size      = 512
   environment {
     variables = {

--- a/dynamodb-streams-lambda-terraform/main.tf
+++ b/dynamodb-streams-lambda-terraform/main.tf
@@ -40,7 +40,7 @@ resource "aws_lambda_function" "lambda_dynamodb_stream_handler" {
   source_code_hash = data.archive_file.lambda_zip_file.output_base64sha256
   handler          = "index.handler"
   role             = aws_iam_role.iam_for_lambda.arn
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
 }
 
 data "archive_file" "lambda_zip_file" {

--- a/eventbridge-lambda-terraform/main.tf
+++ b/eventbridge-lambda-terraform/main.tf
@@ -20,7 +20,7 @@ resource "aws_lambda_function" "lambda_function" {
   source_code_hash = data.archive_file.lambda_zip_file.output_base64sha256
   handler          = "app.handler"
   role             = aws_iam_role.lambda_iam_role.arn
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
 }
 
 data "archive_file" "lambda_zip_file" {

--- a/eventbridge-sns-lambda-terraform/main.tf
+++ b/eventbridge-sns-lambda-terraform/main.tf
@@ -103,7 +103,7 @@ resource "aws_lambda_function" "lambda_function" {
   source_code_hash = data.archive_file.lambda_zip_file.output_base64sha256
   handler          = "app.handler"
   role             = aws_iam_role.lambda_iam_role.arn
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
 }
 
 

--- a/kinesis-lambda-terraform/main.tf
+++ b/kinesis-lambda-terraform/main.tf
@@ -22,7 +22,7 @@ resource "aws_lambda_function" "sample_lambda" {
   function_name    = "sample-lambda"
   role             = aws_iam_role.lambda_role.arn
   handler          = "index.handler"
-  runtime          = "nodejs16.x"  # Change to your preferred runtime
+  runtime          = "nodejs20.x"  # Change to your preferred runtime
 }
 resource "aws_iam_role" "lambda_role" {
   name = "lambda-role"

--- a/lambda-eventbridge-terraform/main.tf
+++ b/lambda-eventbridge-terraform/main.tf
@@ -29,7 +29,7 @@ resource "aws_lambda_function" "publisher_function" {
   source_code_hash = data.archive_file.lambda_zip_file.output_base64sha256
   handler          = "app.handler"
   role             = aws_iam_role.iam_for_lambda.arn
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
 }
 
 data "archive_file" "lambda_zip_file" {

--- a/lambda-function-url-terraform/main.tf
+++ b/lambda-function-url-terraform/main.tf
@@ -20,7 +20,7 @@ resource "aws_lambda_function" "lambda_function" {
   source_code_hash = data.archive_file.lambda_zip_file.output_base64sha256
   handler          = "app.handler"
   role             = aws_iam_role.lambda_iam_role.arn
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
 }
 
 data "archive_file" "lambda_zip_file" {

--- a/lambda-sns-terraform/main.tf
+++ b/lambda-sns-terraform/main.tf
@@ -22,7 +22,7 @@ resource "aws_lambda_function" "lambda_function" {
   source_code_hash = data.archive_file.lambda_zip_file.output_base64sha256
   handler          = "app.handler"
   role             = aws_iam_role.lambda_iam_role.arn
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
   environment {
     variables = {
       SNStopic = aws_sns_topic.sns_topic.arn

--- a/lambda-sqs-terraform/main.tf
+++ b/lambda-sqs-terraform/main.tf
@@ -22,7 +22,7 @@ resource "aws_lambda_function" "lambda_function" {
   source_code_hash = data.archive_file.lambda_zip_file.output_base64sha256
   handler          = "app.handler"
   role             = aws_iam_role.lambda_iam_role.arn
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
   environment {
     variables = {
       SQSqueueName = aws_sqs_queue.sqs_queue.url

--- a/s3-lambda-terraform/main.tf
+++ b/s3-lambda-terraform/main.tf
@@ -32,7 +32,7 @@ resource "aws_lambda_function" "lambda_s3_handler" {
   source_code_hash = data.archive_file.lambda_zip_file.output_base64sha256
   handler          = "index.handler"
   role             = aws_iam_role.iam_for_lambda.arn
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
 }
 
 data "archive_file" "lambda_zip_file" {


### PR DESCRIPTION
*Issue #, if available:*
* Refs: https://github.com/aws-samples/serverless-patterns/issues/2290
* This is terraform equivalent of https://github.com/aws-samples/serverless-patterns/pull/2292

*Description of changes:*
Updates terraform samples without JS SDK from node 16 to 20

The terraform samples which use AWS SDK for JavaScript need migration to v3, and are being migrated in https://github.com/aws-samples/serverless-patterns/pull/2294

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
