### PR TITLE
Update msk-cfn-sasl-lambda/create-cluster-cfn/MSKSampleStack.yml

### DIFF
--- a/msk-cfn-sasl-lambda/create-cluster-cfn/MSKSampleStack.yml
+++ b/msk-cfn-sasl-lambda/create-cluster-cfn/MSKSampleStack.yml
@@ -165,6 +165,7 @@ Resources:
     Properties: 
       AutomaticStopTimeMinutes: 30
       Description: "Cloud9 EC2 environment"
+      ImageId: "amazonlinux-2023-x86_64"
       InstanceType: t3.large
       Name: !Sub "${AWS::StackName}-Cloud9EC2Bastion"
       SubnetId: !Ref PublicSubnetOne


### PR DESCRIPTION
Include ImageId: amazonlinux-2023-x86_64 for Cloud9EC2Bastion stack to avoid Property {/ImageID} validation failure



*Description of changes:
Error:
This change is intended to solve the msk-cfn-sasl-lambda/create-cluster-cfn/MSKSampleStack.yml which Errors out as [get Property validation failure: [The property {/ImageId} is required]. 

Fix :
ImageId: amazonlinux-2023-x86_64 was included as this is a required property now.
*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
