### PR TITLE
Fixing broken github URL - eventbridge-schedule-remove-one-time-schedules-cdk-python

### DIFF
--- a/eventbridge-schedule-remove-one-time-schedules-cdk-python/eventbridge-schedule-remove-one-time-schedules-cdk-python.json
+++ b/eventbridge-schedule-remove-one-time-schedules-cdk-python/eventbridge-schedule-remove-one-time-schedules-cdk-python.json
@@ -1,5 +1,5 @@
 {
-    "title": "Amazon EventBridge Scheduler remove one time schedule",
+    "title": "Amazon EventBridge Scheduler remove One time Schedule",
     "description": "Amazon EventBridge Scheduler job runs every five minutes to identify and delete one time Amazon EventBridge Scheduler jobs expired more than 7 days.",
     "language": "Python",
     "level": "300",
@@ -7,15 +7,15 @@
     "introBox": {
         "headline": "How it works",
         "text": [
-            "Amazon EventBridge Scheduler job runs every five minutes and uses AWS Lambda to identify and delete one time Scheduler jobs that are expired more than 7 days",
-            "Scheduler job uses Amazon Simple Notification Service to send email notification once the activity is complete.",
+            "Amazon EventBridge Scheduler job runs every five minutes and uses AWS Lambda to identify and delete one time Amazon EventBridge Scheduler jobs that are expired more than 7 days",
+            "Scheduler job sends a Amazon Simple Notification Service to send email notification once the activity is completed.",
             "This pattern deploys AWS Lambda, Amazon EventBridge Scheduler(one recurring ,and two one-time jobs) and Amazon Simple Notification Service"
         ]
     },
     "gitHub": {
         "template": {
-            "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-schedule-remove-onetime-schedule-to-sns-cdk-python",
-            "templateURL": "serverless-patterns/eventbridge-schedule-remove-one-time-schedule-to-sns-cdk-python",
+            "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-schedule-remove-one-time-schedules-cdk-python",
+            "templateURL": "serverless-patterns/eventbridge-schedule-remove-one-time-schedules-cdk-python",
             "projectFolder": "eventbridge-schedule-remove-one-time-schedules-cdk-python",
             "templateFile": "eventbridge_schedule_remove_onetime_schedules_cdk_python/eventbridge_schedule_remove_onetime_schedules_cdk_python_stack.py"
         }


### PR DESCRIPTION
*Issue #, if available:* #2380

*Description of changes:*
Fixing the reference to the incorrect folder path in the json file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
