### PR TITLE
Update Serverless Pattern - DDB Stream read throttling advice

### DIFF
--- a/lambda-esm-ddb-filters-sam/README.md
+++ b/lambda-esm-ddb-filters-sam/README.md
@@ -2,6 +2,11 @@
 
 This pattern demonstrates the ability to filter Amazon DynamoDB Stream events so that only a subset of all events is sent to an AWS Lambda function for processing. Demo stack will create a single Amazon DynamoDB Table (table-lambda-esm-filter), enable [Change Data Capture](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html) for that table, and create a number of AWS Lambda functions that are subscribed to the Amazon DynamoDB stream using different filter configurations.
 
+> Please note that this template is meant to be for testing the filters, you can subscribe more than two Lambda functions to a DynamoDB Stream, but you'll likely experience [read throttling](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.Lambda.html).
+> 
+> If you require more than two consumers ([one if it is a global table](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ServiceQuotas.html#limits-dynamodb-streams)), consider integrating with [Amazon EventBridge](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/eventbridge-for-dynamodb.html).
+
+
 Review [Filter rule syntax](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventfiltering.html#filtering-syntax) for more details on the message filtering configuration.
 **Important note**: Filter definition should not contain any whitespace (tabs, space, etc.) in order to work properly!
 

--- a/lambda-esm-ddb-filters-sam/example-pattern.json
+++ b/lambda-esm-ddb-filters-sam/example-pattern.json
@@ -1,0 +1,58 @@
+{
+  "title": "AWS Event Source Mapping for Lambda from Amazon DynamoDB Stream",
+  "description": "Sample Lambda ESM Filter rules for DynamoDB Stream triggers",
+  "language": "Node.js",
+  "level": "200",
+  "framework": "SAM",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "Use this code to test out different trigger filters for your Lambda functions. You can use event filtering to control which events Lambda sends to your function for processing. You can use this template to explore and test how to configure event filtering for Amazon DynamoDB Stream messages triggering a Lambda function.",
+      "Please note that this template is meant to be for testing, you can subscribe more than two Lambda functions to a DynamoDB Stream, but you'll likely experience read throttling, refer to the GitHub template README for more information.",
+      "The SAM template deploys multiple Lambda functions, a single stream-enabled Amazon DynamoDB Table and the permissions required to run the application. The template enforces 3 days retention period for all AWS Lambda CloudWatch logs. All AWS Lambda functions are deployed to NodeJS 18 runtime running on ARM64 processors powered by AWS Graviton."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/lambda-esm-ddb-filters-sam/",
+      "templateURL": "serverless-patterns/lambda-esm-ddb-filters-sam",
+      "projectFolder": "lambda-esm-ddb-filters-sam",
+      "templateFile": "lambda-esm-ddb-filters-sam/template.yaml"
+    }
+  },
+  "resources": {
+    "headline": "Additional resources",
+    "bullets": [
+      {
+        "text": "Lambda event filtering",
+        "link": "https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventfiltering.html"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "sam build",
+      "sam deploy --guided"
+    ]
+  },
+  "testing": {
+    "headline": "Testing",
+    "text": [
+      "See the GitHub repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "headline": "Cleanup",
+    "text": [
+      "Delete the stack: <code>sam delete --stack-name STACK_NAME</code>."
+    ]
+  },
+  "authors": [
+    {
+      "name": "Dmitry Gulin",
+      "image": "https://s.gravatar.com/avatar/223055bd132d244f6a96c3aef7453a5a",
+      "bio": "Senior Modernization Architect, AWS",
+      "linkedin": "dmitry-gulin"
+    }
+  ]
+}


### PR DESCRIPTION
*Issue #, if available:* [2406](https://github.com/aws-samples/serverless-patterns/issues/2406)

*Description of changes:*
Updating this pattern to warn users of DDB streams read throttling.

As mentioned in the issue's comments, I had to restore the json file, the only update to it is I added the following line:

```
"Please note that this template is meant to be for testing, you can subscribe more than two Lambda functions to a DynamoDB Stream, but you'll likely experience read throttling, refer to the GitHub template README for more information.",
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
