### PR TITLE
Updated policy so lambda function role has proper permissions

### DIFF
--- a/s3-lambda-dotnet/ImageResize/Function.cs
+++ b/s3-lambda-dotnet/ImageResize/Function.cs
@@ -103,7 +103,7 @@ public class Function
                 }
 
                 LambdaLogger.Log("----> Thumbnail file Key: " + thumbnailObjectKey);
-                var destinationBucket = Environment.GetEnvironmentVariable("DESTINATION_BUCKET");
+                var destinationBucket = Environment.GetEnvironmentVariable("DESTINATION_BUCKET_NAME");
                 await S3Client.PutObjectAsync(new PutObjectRequest
                 {
                     BucketName = destinationBucket,

--- a/s3-lambda-dotnet/ImageResize/Function.cs
+++ b/s3-lambda-dotnet/ImageResize/Function.cs
@@ -103,10 +103,10 @@ public class Function
                 }
 
                 LambdaLogger.Log("----> Thumbnail file Key: " + thumbnailObjectKey);
-
+                var destinationBucket = Environment.GetEnvironmentVariable("DESTINATION_BUCKET");
                 await S3Client.PutObjectAsync(new PutObjectRequest
                 {
-                    BucketName = record.S3.Bucket.Name,
+                    BucketName = destinationBucket,
                     Key = thumbnailObjectKey,
                     InputStream = imageStream
                 });

--- a/s3-lambda-dotnet/README.md
+++ b/s3-lambda-dotnet/README.md
@@ -42,8 +42,8 @@ Important: this application uses various AWS services and there are costs associ
 ## How it works
 
 * Use the AWS CLI upload an image to S3
-* If the object is a .jpeg in the /images folder, the code creates a thumbnail and saves it to the target bucket in a new folder, /thumbnails. 
-* The code assumes that the destination bucket exists and is watching a folder you need to create called "images".
+* If the object is a .jpeg in the source bucket, the code creates a thumbnail and saves it to the destination bucket in a new folder, /thumbnails. 
+* The code assumes that the destination bucket exists and is defined in the `template.yaml` file
 
 ==============================================
 
@@ -52,7 +52,7 @@ Important: this application uses various AWS services and there are costs associ
 Run the following S3 CLI  command to upload an image to the S3 bucket. Note, you must edit the {SourceBucketName} placeholder with the name of the S3 Bucket. This is provided in the stack outputs.
 
 ```bash
-aws s3 cp './images/example.jpeg'  s3://{BucketName}/images/example.jpeg
+aws s3 cp 'example.jpeg'  s3://{BucketName}/example.jpeg
 ```
 
 Run the following command to check that a new thumbnails folder has been created with a new version of the image.

--- a/s3-lambda-dotnet/template.yaml
+++ b/s3-lambda-dotnet/template.yaml
@@ -11,24 +11,41 @@ Globals:
     Timeout: 10
     Runtime: dotnet6
 
+Parameters:
+  SourceBucketName:
+    Type: String
+    # Pass your bucket name dynamically or change it here
+    Default: my-source-bucket-name
+  DestinationBucketName:
+    Type: String
+    # Pass your bucket name dynamically or change it here
+    Default: my-destination-bucket-name
+
 Resources:
-  ## Source S3 bucket
   SourceBucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Sub "imageresizer-source-${AWS::AccountId}"
-  ## Destination S3 bucket
+      BucketName: !Ref SourceBucketName
+
   DestinationBucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Sub "imageresizer-destination-${AWS::AccountId}"
+      BucketName: !Ref DestinationBucketName
 
   ResizerFunction:
-    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+    Type: AWS::Serverless::Function
     Properties:
       CodeUri: ImageResize/
       Handler: ImageResize::ImageResize.Function::FunctionHandler
       MemorySize: 2048
+      Environment:
+        Variables:
+          DESTINATION_BUCKET_NAME: !Ref DestinationBucketName
+      Policies:
+        - S3ReadPolicy:
+            BucketName: !Ref SourceBucketName
+        - S3CrudPolicy:
+            BucketName: !Ref DestinationBucketName
       Events:
         FileUpload:
           Type: S3
@@ -38,32 +55,16 @@ Resources:
             Filter:
               S3Key:
                 Rules:
-                  - Name: prefix
-                    Value: 'images/'
                   - Name: suffix
                     Value: '.jpeg'
-        Environment:
-          Variables:
-            SOURCE_BUCKET: !Ref SourceBucket
-            DESTINATION_BUCKET: !Ref DestinationBucket
-      Policies:
-        - Statement:
-            - Effect: Allow
-              Action:
-                - s3:GetObject
-              Resource: !Sub arn:aws:s3:::imageresizer-source-${AWS::AccountId}/*
-            - Effect: Allow
-              Action:
-                - s3:PutObject
-              Resource: !Sub arn:aws:s3:::imageresizer-destination-${AWS::AccountId}/*
 
 Outputs:
   SourceBucketName:
-    Value: !Ref SourceBucket
-    Description: S3 Source Bucket for incoming images
-   DestinationBucketName:
-    Value: !Ref DestinationBucket
-    Description: S3 Destination Bucket for resized images
+    Value: !Ref SourceBucketName
+    Description: S3 Bucket for object storage
+  DestinationBucketName:
+    Value: !Ref DestinationBucketName
+    Description: S3 destination Bucket for object storage
   FunctionArn:
     Value: !Ref ResizerFunction
     Description: ResizerFunction function Arn

--- a/s3-lambda-dotnet/template.yaml
+++ b/s3-lambda-dotnet/template.yaml
@@ -12,11 +12,16 @@ Globals:
     Runtime: dotnet6
 
 Resources:
-  ## S3 bucket
+  ## Source S3 bucket
   SourceBucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Sub "imageresizer-${AWS::AccountId}"
+      BucketName: !Sub "imageresizer-source-${AWS::AccountId}"
+  ## Destination S3 bucket
+  DestinationBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub "imageresizer-destination-${AWS::AccountId}"
 
   ResizerFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
@@ -37,21 +42,28 @@ Resources:
                     Value: 'images/'
                   - Name: suffix
                     Value: '.jpeg'
+        Environment:
+          Variables:
+            SOURCE_BUCKET: !Ref SourceBucket
+            DESTINATION_BUCKET: !Ref DestinationBucket
       Policies:
         - Statement:
             - Effect: Allow
               Action:
                 - s3:GetObject
-              Resource: !Sub arn:aws:s3:::imageresizer-${AWS::AccountId}/*
+              Resource: !Sub arn:aws:s3:::imageresizer-source-${AWS::AccountId}/*
             - Effect: Allow
               Action:
                 - s3:PutObject
-              Resource: !Sub arn:aws:s3:::imageresizer-${AWS::AccountId}/*
+              Resource: !Sub arn:aws:s3:::imageresizer-destination-${AWS::AccountId}/*
 
 Outputs:
   SourceBucketName:
     Value: !Ref SourceBucket
-    Description: S3 Bucket for object storage
+    Description: S3 Source Bucket for incoming images
+   DestinationBucketName:
+    Value: !Ref DestinationBucket
+    Description: S3 Destination Bucket for resized images
   FunctionArn:
     Value: !Ref ResizerFunction
-    Description: ResizerFunction function  Arn
+    Description: ResizerFunction function Arn

--- a/s3-lambda-dotnet/template.yaml
+++ b/s3-lambda-dotnet/template.yaml
@@ -38,8 +38,15 @@ Resources:
                   - Name: suffix
                     Value: '.jpeg'
       Policies:
-        - S3FullAccessPolicy:
-            BucketName: !Sub "imageresizer-${AWS::AccountId}/*"
+        - Statement:
+            - Effect: Allow
+              Action:
+                - s3:GetObject
+              Resource: !Sub arn:aws:s3:::imageresizer-${AWS::AccountId}/*
+            - Effect: Allow
+              Action:
+                - s3:PutObject
+              Resource: !Sub arn:aws:s3:::imageresizer-${AWS::AccountId}/*
 
 Outputs:
   SourceBucketName:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Previous policy gave me the below error when trying to invoke the Lambda function:
```
errorType": "AmazonS3Exception",
  "errorMessage": "User: arn:aws:sts::683517028648:assumed-role/s3dotnet-ResizerFunctionRole-TZwnuYpDb5Rv/s3dotnet-ResizerFunction-12oroDMZmSGE is not authorized to perform: s3:GetObject on resource: \"arn:aws:s3:::imageresizer-683517028648/seshub-photo.jpeg\" because no identity-based policy allows the s3:GetObject action"
```

Updated the policy so the Lambda function role has proper permissions. Tested that invocation works with updated policy.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
