### PR TITLE
Update resizing READMEs with correct names

### DIFF
--- a/s3-lambda-resizing-dotnet/README.md
+++ b/s3-lambda-resizing-dotnet/README.md
@@ -2,7 +2,7 @@
 
 The SAM template deploys a .NET 6 Lambda function, an S3 bucket and the IAM resources required to run the application. A Lambda function consumes <code>ObjectCreated</code> events from an Amazon S3 bucket. The function code checks the uploaded file is an image and creates a thumbnail version of the image in the same bucket.
 
-Learn more about this pattern at Serverless Land Patterns: [https://serverlessland.com/patterns/s3-lambda-dotnet](https://serverlessland.com/patterns/s3-lambda-dotnet)
+Learn more about this pattern at Serverless Land Patterns: [https://serverlessland.com/patterns/s3-lambda-resizing-dotnet](https://serverlessland.com/patterns/s3-lambda-resizing-dotnet)
 
 Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
 
@@ -23,7 +23,7 @@ Important: this application uses various AWS services and there are costs associ
     ```
 1. Change directory to the pattern directory:
     ```
-    cd s3-lambda-dotnet
+    cd s3-lambda-resizing-dotnet
     ```
 1. From the command line, use AWS SAM to build and deploy the AWS resources for the pattern as specified in the template.yml file:
     ```

--- a/s3-lambda-resizing-dotnet/template.yaml
+++ b/s3-lambda-resizing-dotnet/template.yaml
@@ -1,7 +1,7 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: >
-  (uksb-1tthgi812) (tag:s3-lambda-dotnet)
+  (uksb-1tthgi812) (tag:s3-lambda-resizing-dotnet)
   .NET Image resizing service
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst

--- a/s3-lambda-resizing-node/README.md
+++ b/s3-lambda-resizing-node/README.md
@@ -2,7 +2,7 @@
 
 The SAM template deploys a Lambda function, an S3 bucket and the IAM resources required to run the application. A Lambda function consumes <code>ObjectCreated</code> events from an Amazon S3 bucket. The Lambda code checks the uploaded file is an image and creates a thumbnail version of the image in the same bucket.
 
-Learn more about this pattern at Serverless Land Patterns: [https://serverlessland.com/patterns/s3-lambda](https://serverlessland.com/patterns/s3-lambda)
+Learn more about this pattern at Serverless Land Patterns: [https://serverlessland.com/patterns/s3-lambda-resizing-node](https://serverlessland.com/patterns/s3-lambda-resizing-node)
 
 Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
 
@@ -21,7 +21,7 @@ Important: this application uses various AWS services and there are costs associ
     ```
 1. Change directory to the pattern directory:
     ```
-    cd s3-lambda
+    cd s3-lambda-resizing-node
     ```
 1. From the command line, use AWS SAM to build and deploy the AWS resources for the pattern as specified in the template.yml file:
     ```

--- a/s3-lambda-resizing-node/template.yaml
+++ b/s3-lambda-resizing-node/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
-Description: Image resizing service (uksb-1tthgi812) (tag:s3-lambda)
+Description: Image resizing service (uksb-1tthgi812) (tag:s3-lambda-resizing-node)
 
 Parameters:
   SourceBucketName:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated S3-Lambda resizing images pattern READMEs with new names of patterns (`s3-lambda-resizing-node` and `s3-lambda-resizing-dotnet`).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
