### PR TITLE
Apigw http api lambda rds proxy

### DIFF
--- a/apigw-http-api-lambda-rds-proxy/template-rds-proxy.yaml
+++ b/apigw-http-api-lambda-rds-proxy/template-rds-proxy.yaml
@@ -13,11 +13,11 @@ Mappings:
   ClusterSettings:
     global:
       dbSchema: mylab
-      dbVersion: 5.7.mysql_aurora.2.11.2
+      dbVersion: 8.0.mysql_aurora.3.04.0
       dbEngine: aurora-mysql
-      dbFamily: aurora-mysql5.7
+      dbFamily: aurora-mysql8.0
       port: 3306
-      nodeType: db.r5.large
+      nodeType: db.t4g.medium
 
 Resources:
   # VPC for creating database and proxy
@@ -199,6 +199,7 @@ Resources:
   dbNode1:
     Type: "AWS::RDS::DBInstance"
     Properties:
+      DeletionProtection: false
       DBClusterIdentifier: !Ref dbCluster
       DBInstanceIdentifier: !Sub "${AWS::StackName}-mysql-node-1"
       CopyTagsToSnapshot: true
@@ -210,8 +211,10 @@ Resources:
       PubliclyAccessible: false
       EnablePerformanceInsights: true
       PerformanceInsightsRetentionPeriod: 7
+      StorageEncrypted: true
       Tags:
         - Key: Name
+      
           Value: !Sub "${AWS::StackName}-mysql-node-1"
 
   # Reader node instance for RDS Aurora Cluster
@@ -228,6 +231,8 @@ Resources:
       MonitoringRoleArn: !GetAtt roleEnhancedMonitoring.Arn
       PubliclyAccessible: false
       EnablePerformanceInsights: true
+      DeletionProtection: false
+      StorageEncrypted: true
       PerformanceInsightsRetentionPeriod: 7
       Tags:
         - Key: Name

--- a/apigw-http-api-lambda-rds-proxy/template-rds-proxy.yaml
+++ b/apigw-http-api-lambda-rds-proxy/template-rds-proxy.yaml
@@ -191,6 +191,7 @@ Resources:
       EnableCloudwatchLogsExports: [ error, slowquery ]
       BacktrackWindow: 86400
       EnableIAMDatabaseAuthentication: true
+      DeletionProtection: false
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-mysql-cluster"
@@ -199,7 +200,6 @@ Resources:
   dbNode1:
     Type: "AWS::RDS::DBInstance"
     Properties:
-      DeletionProtection: false
       DBClusterIdentifier: !Ref dbCluster
       DBInstanceIdentifier: !Sub "${AWS::StackName}-mysql-node-1"
       CopyTagsToSnapshot: true
@@ -231,7 +231,6 @@ Resources:
       MonitoringRoleArn: !GetAtt roleEnhancedMonitoring.Arn
       PubliclyAccessible: false
       EnablePerformanceInsights: true
-      DeletionProtection: false
       StorageEncrypted: true
       PerformanceInsightsRetentionPeriod: 7
       Tags:

--- a/apigw-http-api-lambda-rds-proxy/template.yaml
+++ b/apigw-http-api-lambda-rds-proxy/template.yaml
@@ -31,7 +31,7 @@ Parameters:
 Globals:
   Function:
     CodeUri: ./src
-    Runtime: python3.9
+    Runtime: python3.13
     MemorySize: 128
     Timeout: 30
 

--- a/apigw-http-api-lambda-rds-proxy/template.yaml
+++ b/apigw-http-api-lambda-rds-proxy/template.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: 2010-09-09
 Transform: AWS::Serverless-2016-10-31
 Description: >
   (uksb-1tthgi812) (tag:apigw-http-api-lambda-rds-proxy)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Updated underlying template to create rds proxy + rds with up to date aurora mysql version
- Updated main template to use the latest python3.13 (up to date sam cli required).
Tested both templates in us-east-1 with success.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
