### PR TITLE
New serverless pattern - Invoke Private API Custom Domain from Eventbridge schedule

### DIFF
--- a/eventbridge-private-api-customdomain/README.md
+++ b/eventbridge-private-api-customdomain/README.md
@@ -1,0 +1,80 @@
+# Invoke Private REST API gateway custom domain from EventBridge schedule
+
+The SAM template deploys a EventBridge schedule that invokes a Private REST API gateway custom domain using Eventbridge connection, API destinations, Amazon VPC Lattice and AWS PrivateLink. The SAM template contains all the required resources with IAM permission to invoke the private endpoint.
+
+Learn more about this pattern at Serverless Land Patterns: https://serverlessland.com/patterns/eventbridge-private-api-customdomain
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+* [Private REST API gateway custom domain](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-private-custom-domains-tutorial.html)
+* [Public Route 53 Hosted zone for your domain](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/AboutHZWorkingWith.html)
+
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+2. Change directory to the pattern directory:
+    ```
+    cd eventbridge-private-api-customdomain
+    ```
+
+3. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
+    ```
+    sam deploy --guided
+    ```
+5. During the prompts:
+
+    * Enter **stack name**.
+    * Enter desired **AWS Region**.
+    * Enter **Private Custom Domain Name** (e.g. private.mydomain.com) for the Domainname parameter.
+    * Enter **PrivateAPIInvokeURL**  (e.g. https://private.mydomain.com/<apigw-resource-path>) which is complete API invocation url.
+    * Enter **VPC Id** for the VPCId parameter to create VPC latticre resource gateway in VPC. Recommendation: use same VPC as of API Gateway VPC endpoint attached to private api gateway. 
+    * Enter **Subnet Id's** for the SubnetIds parameter (comma seperated e.g. subnet1,subnet2) to create resource gateway. Recommendation: use same subnets as of API gateway VPC endpoint. 
+    * Enter **SecurityGroup Id's** for the SecurityGroup parameter which allows inbound access on port 443 from your VPC's CIDR range.
+    * Allow SAM CLI to create IAM roles with the required permissions.
+
+    Once you have run `sam deploy --guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+
+6. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+7. **Imp Note** : Once the stack is deployed, Create a 'A' record in your Public Route53 hosted zone for the 'Domainname' with below target:
+        
+        a) Target type - alias
+        b) Alis - VPC Endpoint
+        c) Endpoint - select the VPC Endpoint which is attached to your Private API. Eg: vpce-1123444556666-avx567.execute-api.<AWS-region>.vpce.amazonaws.com
+
+
+## Testing
+
+1. Eventbridge schedule will invoke the Private API every 5 minutes as configured in the scheduled expression.
+
+2. Check the Private API stage or integration logs to verify invocations, invocations from eventbridge will contain a custom added header 'invokedby: eventbridgeinvoke' & 'User-Agent:Amazon/EventBridge/ApiDestinations'.
+
+
+### Example output in API Gateway logs:
+
+```bash
+Endpoint request body after transformations: {"resource":"/lambda-resource","path":"/lambda-resource","httpMethod":"GET","headers":{"Accept-Encoding":"gzip, x-gzip, deflate, br","Content-Type":"application/json; charset=utf-8","Host":"HOSTNAME","invokedby":"eventbridgeinvoke","User-Agent":"Amazon/EventBridge/ApiDestinations","x-amzn-vpc-id":"vpc-1111222c123456c","x-amzn-vpce-config":"1","x-amzn-vpce-id":"vpce-112233c3344bb4",},"
+```
+
+
+## Cleanup
+ 
+Delete the stack
+```bash
+    sam delete
+```
+
+----
+Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/eventbridge-private-api-customdomain/pattern.json
+++ b/eventbridge-private-api-customdomain/pattern.json
@@ -1,0 +1,67 @@
+{
+  "title": "Invoke Private REST API gateway custom domain from EventBridge schedule",
+  "description": "The SAM template deploys a EventBridge schedule that invokes a Private REST API gateway custom domain.",
+  "language": "YAML",
+  "level": "200",
+  "framework": "SAM",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "Eventbridge schedule is created using the SAM template which will Invoke the Eventbridge API destinations every 5 minutes.",
+      "Eventbridge API destinations will invoke the Private REST API gateway custom domain using the EventBridge connection.",
+      "EventBridge connection is configured with the Amazon VPC Lattice and AWS PrivateLink to connect to Private API within AWS network."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/eventbridge-private-api-customdomain",
+      "templateURL": "serverless-patterns/eventbridge-private-api-customdomain",
+      "projectFolder": "eventbridge-private-api-customdomain",
+      "templateFile": "template.yaml"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "Custom domain names for private APIs in API gateway ",
+        "link": "https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-private-custom-domains.html"
+      },
+      {
+          "text": "API destinations as targets in Amazon EventBridge",
+          "link": "https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-api-destinations.html"
+      },
+      {
+          "text": "Amazon EventBridge and AWS Step Functions announce integration with private APIs",
+          "link": "https://aws.amazon.com/about-aws/whats-new/2024/12/amazon-eventbridge-step-functions-integration-private-apis/"
+      },
+      {
+          "text": "Securely share AWS resources across VPC and account boundaries with PrivateLink, VPC Lattice",
+          "link": "https://aws.amazon.com/blogs/aws/securely-share-aws-resources-across-vpc-and-account-boundaries-with-privatelink-vpc-lattice-eventbridge-and-step-functions/"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "sam deploy"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the GitHub repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>sam delete</code>."
+    ]
+  },
+  "authors": [
+    {
+      "name": "Sahil Kapoor",
+      "image": "https://media.licdn.com/dms/image/v2/D5603AQHTVptga3RxcA/profile-displayphoto-shrink_800_800/B56ZO3ZfseHoAc-/0/1733948735068?e=1739404800&v=beta&t=FX6MFZ2JFH17KQc89u4gY6tQXGoMJLiLkB2qT3MtV2g",
+      "bio": "Cloud Support Engineer at AWS",
+      "linkedin": "sahil-kapoor-503391a7",
+      "twitter": ""
+    }
+  ]
+}

--- a/eventbridge-private-api-customdomain/template.yaml
+++ b/eventbridge-private-api-customdomain/template.yaml
@@ -1,0 +1,139 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: SAM Template to invoke Private API Custom Domain from EventBridge Schedule Expression
+
+Parameters:
+  Domainname:
+    Type: String
+    Description: Custom Domain name configured for Private REST API. 
+
+  PrivateAPIInvokeURL:
+    Type: String
+    Description: Complete Invocation url for the Private API Gateway resource. Eg - https://DOMAIN/<API-RESOURCE-PATH>
+
+  VPCId:
+    Type: AWS::EC2::VPC::Id
+    Description: VPC ID to create Resource Gateway & Configuration
+
+  SubnetIds:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: Subnet IDs Resource Gateway & Configuration
+
+  SecurityGroups:
+    Type: List<AWS::EC2::SecurityGroup::Id>
+    Description: SecurityGroups IDs for Resource Gateway.
+
+Resources:
+  ResourceGatewayVpcLattice:
+    Type: AWS::VpcLattice::ResourceGateway
+    Properties:
+      IpAddressType: IPV4
+      Name: resourcegatewayeventbridgeprivateapi
+      SecurityGroupIds: !Ref SecurityGroups
+      SubnetIds: !Ref SubnetIds
+      VpcIdentifier: !Ref VPCId
+
+
+  ResourceConfiguration:
+    Type: AWS::VpcLattice::ResourceConfiguration
+    Properties:
+      AllowAssociationToSharableServiceNetwork: True
+      Name: resourceconfigebprivate
+      PortRanges: 
+        - 1-65535
+      ProtocolType: TCP
+      ResourceConfigurationAuthType: NONE
+      ResourceConfigurationDefinition: 
+        DnsResource: 
+          DomainName: !Ref Domainname
+          IpAddressType: IPV4
+      ResourceConfigurationType: SINGLE
+      ResourceGatewayId: !GetAtt ResourceGatewayVpcLattice.Arn
+
+  APIConnection:
+    Type: AWS::Events::Connection
+    Properties:
+      Name: 'Private-APIGateway-Connection-Eventbridge'
+      InvocationConnectivityParameters:
+        ResourceParameters:
+            ResourceConfigurationArn: !GetAtt ResourceConfiguration.Arn
+      AuthorizationType: API_KEY
+      AuthParameters:
+        ApiKeyAuthParameters:
+          ApiKeyName: x-api-key
+          ApiKeyValue: 'test'
+
+
+  EventBridgeApiDestination:
+    Type: AWS::Events::ApiDestination
+    Properties:
+      ConnectionArn: !GetAtt APIConnection.Arn
+      HttpMethod: GET
+      InvocationEndpoint: !Ref PrivateAPIInvokeURL
+      Name: EventBridge-Private-API-Destination
+
+  EventBridgeRulePattern:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: Invoke the API Gateway URL every 5 minutes. 
+      EventBusName: default
+      ScheduleExpression: rate(5 minutes)
+      Name: Invoke-Private-APIGW-Custom-Domain-Rule
+      State: ENABLED
+      Targets:
+        - Id: 123456-b0e6-4c9a-b5d6-123445
+          Arn: !GetAtt EventBridgeApiDestination.Arn
+          RoleArn: !GetAtt EventBridgeRulePatternRole.Arn
+          HttpParameters:
+            PathParameterValues: []
+            HeaderParameters:
+              invokedby: eventbridgeinvoke
+            QueryStringParameters: {}
+
+  EventBridgeRulePatternRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: sts:AssumeRole
+      MaxSessionDuration: 3600
+
+  EventBridgeRulePolicy:
+    Type: AWS::IAM::RolePolicy
+    Properties:
+      PolicyName: Amazon_EventBridge_Invoke_Api_Destination_66257085964cef766
+      RoleName: !Ref EventBridgeRulePatternRole
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - events:InvokeApiDestination
+            Resource:
+              - Fn::Sub: >-
+                  arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:api-destination/*
+
+
+Outputs:
+  ResourceGatewayVpcLattice:
+    Description: "ResourceGatewayVpcLattice ARN"
+    Value: !GetAtt ResourceGatewayVpcLattice.Arn
+
+  ResourceConfiguration:
+    Description: "ResourceConfiguration ARN"
+    Value: !GetAtt ResourceConfiguration.Arn
+
+  APIConnection:
+    Description: "APIConnection Name"
+    Value: !GetAtt APIConnection.Arn
+
+  EventBridge:
+    Description: "EventBridge ARN"
+    Value: !GetAtt EventBridgeRulePattern.Arn
+
+
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This pattern shows how to invoke private endpoints for REST API Gateway from eventbridge schedule.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
