### PR TITLE
lambda-aurora-serverlessv2-postgresql: aurora scales to zero

### DIFF
--- a/lambda-aurora-serverlessv2-postgresql/README.md
+++ b/lambda-aurora-serverlessv2-postgresql/README.md
@@ -39,7 +39,7 @@ Important: this application uses various AWS services and there are costs associ
 
 ## How it works
 
-This pattern creates an AWS Lambda function and an [Amazon Aurora PostgreSQL DB](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.AuroraPostgreSQL.html) in an [Aurora Serverless v2](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.html) DB cluster with [RDS Data API](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html) and a Secrets Manager secret. The function creates an example table named "music", inserts a row with data from the event object, then returns the results of a select query.
+This pattern creates an AWS Lambda function and an [Amazon Aurora PostgreSQL DB](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.AuroraPostgreSQL.html) in an [Aurora Serverless v2](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.html) DB cluster that scales to zero, with [RDS Data API](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html) and a Secrets Manager secret. The function creates an example table named "music", inserts a row with data from the event object, then returns the results of a select query.
 
 ## Testing
 
@@ -67,7 +67,14 @@ Response:
 }
 ```
 
+Aurora Serverless v2 DB instances can automatically pause after a period with no user connections, and automatically resume when a connection request arrives. If it was paused, it will automatically resume and accept the connection. You may see this error in the Lambda logs:
+```
+"An error occurred (DatabaseResumingException) when calling the ExecuteStatement operation: The Aurora DB instance arn:aws:rds:..... is resuming after being auto-paused. Please wait a few seconds and try again."
+```
+
+
 ## Documentation
+- [Amazon Aurora Serverless v2 supports scaling to zero capacity](https://aws.amazon.com/about-aws/whats-new/2024/11/amazon-aurora-serverless-v2-scaling-zero-capacity/)
 - [Using the Data API for Aurora Serverless](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html)
 - [Data API - ExecuteStatement](https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_ExecuteStatement.html)
 - [Data API - ExecuteStatement Response Elements](https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_ExecuteStatement.html#API_ExecuteStatement_ResponseElements)

--- a/lambda-aurora-serverlessv2-postgresql/template.yaml
+++ b/lambda-aurora-serverlessv2-postgresql/template.yaml
@@ -8,7 +8,7 @@ Description: >
 Globals:
   Function:
     CodeUri: ./src
-    Runtime: python3.12
+    Runtime: python3.13
     MemorySize: 128
     Timeout: 10
     LoggingConfig:

--- a/lambda-aurora-serverlessv2-postgresql/template.yaml
+++ b/lambda-aurora-serverlessv2-postgresql/template.yaml
@@ -65,11 +65,12 @@ Resources:
       DatabaseName: !Ref DatabaseName
       Engine: aurora-postgresql
       EngineMode: provisioned
+      EngineVersion: '16.4'
       StorageEncrypted: true
       # Enable the Data API for Aurora Serverless
       EnableHttpEndpoint: true
       ServerlessV2ScalingConfiguration:
-        MinCapacity: 0.5
+        MinCapacity: 0 #auto-pause
         MaxCapacity: 1
   AuroraInstance:
     Type: 'AWS::RDS::DBInstance'

--- a/lambda-aurora-serverlessv2-postgresql/template.yaml
+++ b/lambda-aurora-serverlessv2-postgresql/template.yaml
@@ -12,6 +12,7 @@ Globals:
     MemorySize: 128
     Timeout: 10
     LoggingConfig:
+      LogGroup: !Sub /aws/lambda/${AWS::StackName}
       LogFormat: JSON
     Architectures:
       - arm64


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Amazon Aurora Serverless v2 supports scaling to zero capacity
2. Update to python 3.13
3. Set CloudWatch LogGroup for Lambda functions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
