### PR TITLE
New serverless pattern -  websocket api with mapping template and Lambda authorizer

### DIFF
--- a/apigw-websocket-mapping-template-authorizer/README.md
+++ b/apigw-websocket-mapping-template-authorizer/README.md
@@ -1,0 +1,60 @@
+# AWS Service 1 to AWS Service 2
+
+This pattern << explain usage >>
+
+Learn more about this pattern at Serverless Land Patterns: << Add the live URL here >>
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+1. Change directory to the pattern directory:
+    ```
+    cd _patterns-model
+    ```
+1. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
+    ```
+    sam deploy --guided
+    ```
+1. During the prompts:
+    * Enter a stack name
+    * Enter the desired AWS Region
+    * Allow SAM CLI to create IAM roles with the required permissions.
+
+    Once you have run `sam deploy --guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+
+1. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## How it works
+
+Explain how the service interaction works.
+
+## Testing
+
+Provide steps to trigger the integration and show what should be observed if successful.
+
+## Cleanup
+ 
+1. Delete the stack
+    ```bash
+    aws cloudformation delete-stack --stack-name STACK_NAME
+    ```
+1. Confirm the stack has been deleted
+    ```bash
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'STACK_NAME')].StackStatus"
+    ```
+----
+Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/apigw-websocket-mapping-template-authorizer/README.md
+++ b/apigw-websocket-mapping-template-authorizer/README.md
@@ -101,7 +101,6 @@ You can then send the Json Payload to the `sendmessage` route
     ```
     > {"action": "sendmessage","message" : "hey queen"}
     < good job on deploying this template, keep slaying!!
-
     ```
 
 ## Cleanup

--- a/apigw-websocket-mapping-template-authorizer/README.md
+++ b/apigw-websocket-mapping-template-authorizer/README.md
@@ -21,7 +21,7 @@ Important: this application uses various AWS services and there are costs associ
     ```
 1. Change directory to the pattern directory:
     ```
-    cd _patterns-model
+    cd apigw-websocket-mapping-template-authorizer
     ```
 1. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
     ```
@@ -96,7 +96,7 @@ Once the template deployed, you would need to use a websocket client, I would re
     ```
 If you don't put the header and its value, you will get `Unauthorized`
 
-You can then send the Json Payload to the `sendmessage` route
+You can then send the Json Payload to the `sendmessage` route:
 ```
 > {"action": "sendmessage","message" : "hey queen"}
 < good job on deploying this template, keep slaying!!

--- a/apigw-websocket-mapping-template-authorizer/README.md
+++ b/apigw-websocket-mapping-template-authorizer/README.md
@@ -41,7 +41,7 @@ Important: this application uses various AWS services and there are costs associ
 Websocket APIs are commonly used for 2-ways communications between a client and a server (like a chatbot for instance).
 I once came across a scenario where a mapping template was needed, so I thought it could help other people if I published it here. 
 
-The routes $connect and $disconnect have a proxy integration with their Lambdas. 
+The routes `$connect` and `$disconnect` have a proxy integration with their Lambdas. 
 The integration for the "sendmessage" route is non-proxy with a Lambda function in the back-end. 
 The Mapping Template used is this one : 
 ```
@@ -68,14 +68,16 @@ The Mapping Template used is this one :
               "isBase64Encoded": "$context.isBase64Encoded"
           }
 ```
-So it will pass a bunch of important information like the Body and the connectionId. You can add and remove as many variables as you want. 
-To make it as independant as I could, the back-end Lambda "SendMessageFunction" does not need any of these information to run successfully, because it is getting the @connection URL from its environment variables and the connectionId from the DynamoDB which name is also in the environment variables.
+So it will pass a bunch of important information like the `Body` and the `connectionId`. You can add and remove as many variables as you want. 
+To make it as independant as I could, the back-end Lambda "SendMessageFunction" does not need any of these information to run successfully, because it is getting the `@connection` URL from its environment variables and the `connectionId` from the DynamoDB which name is also in the environment variables.
 
-Only the stage name "stage" is hardcodeded in the environment variable of the Lambda, so if you want to change it you would need to change the environment variable or get it from the Mapping Template in the event sent to Lambda. 
+Only the stage name `stage` is hard-codeded in the environment variable of the Lambda, so if you want to change it you would need to change the environment variable or get it from the Mapping Template in the event sent to Lambda. 
 
-The Websocket API is also protected by a Lambda REQUEST Authorizer. This Lambda function will look for the header "token" and will only allow the request if its value is "hello" - else it will throw a 401 Unauthorized response to the client. 
+The Websocket API is also protected by a Lambda REQUEST Authorizer. This Lambda function will look for the header `token` and will only allow the request if its value is `hello` - else it will throw a 401 Unauthorized response to the client. 
 
 All Lambda functions are written in Node.js 22 with ".mjs" files and implement the ES module import syntax. 
+
+To get a response when the client sends a message, the Lambda has to send a request to the Websocket `connectioId`. It does so bu using the endpoint `"https://" + process.env.API_ID + ".execute-api." + process.env.AWS_REGION + ".amazonaws.com/" + process.env.STAGE + "/"` and the command `PostToConnectionCommand` from the client [`ApiGatewayManagementApiClient`](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/apigatewaymanagementapi/).
 
 ## Testing
 

--- a/apigw-websocket-mapping-template-authorizer/README.md
+++ b/apigw-websocket-mapping-template-authorizer/README.md
@@ -97,11 +97,10 @@ Once the template deployed, you would need to use a websocket client, I would re
 If you don't put the header and its value, you will get `Unauthorized`
 
 You can then send the Json Payload to the `sendmessage` route
-
-    ```bash
-    > {"action": "sendmessage","message" : "hey queen"}
-    < good job on deploying this template, keep slaying!!
-    ```
+```
+> {"action": "sendmessage","message" : "hey queen"}
+< good job on deploying this template, keep slaying!!
+```
 
 ## Cleanup
  

--- a/apigw-websocket-mapping-template-authorizer/README.md
+++ b/apigw-websocket-mapping-template-authorizer/README.md
@@ -69,7 +69,7 @@ The Mapping Template used is this one :
           }
 ```
 So it will pass a bunch of important information like the `Body` and the `connectionId`. You can add and remove as many variables as you want. 
-To make it as independant as I could, the back-end Lambda "SendMessageFunction" does not need any of these information to run successfully, because it is getting the `@connection` URL from its environment variables and the `connectionId` from the DynamoDB which name is also in the environment variables.
+To make it as independant as I could, the back-end Lambda "SendMessageFunction" does not need any of these information to run successfully, because it is getting the endpoint from its environment variables and the `connectionId` from the DynamoDB which name is also in the environment variables.
 
 Only the stage name `stage` is hard-codeded in the environment variable of the Lambda, so if you want to change it you would need to change the environment variable or get it from the Mapping Template in the event sent to Lambda. 
 

--- a/apigw-websocket-mapping-template-authorizer/README.md
+++ b/apigw-websocket-mapping-template-authorizer/README.md
@@ -1,4 +1,4 @@
-# AWS Wesocket API to Lambda 
+# AWS Websocket API to Lambda non-proxy
 
 This pattern will create a websocket API protected by a Lambda authorizer. The websocket is integrated with a Lambda function through a mapping template that passes the main informations of the request.
 

--- a/apigw-websocket-mapping-template-authorizer/README.md
+++ b/apigw-websocket-mapping-template-authorizer/README.md
@@ -98,7 +98,7 @@ If you don't put the header and its value, you will get `Unauthorized`
 
 You can then send the Json Payload to the `sendmessage` route
 
-    ```
+    ```bash
     > {"action": "sendmessage","message" : "hey queen"}
     < good job on deploying this template, keep slaying!!
     ```

--- a/apigw-websocket-mapping-template-authorizer/example-pattern.json
+++ b/apigw-websocket-mapping-template-authorizer/example-pattern.json
@@ -1,34 +1,38 @@
 {
-  "title": "Step Functions to Athena",
-  "description": "Create a Step Functions workflow to query Amazon Athena.",
-  "language": "Python",
+  "title": "Websocket API Gateway with an Authorizer and mapping template",
+  "description": "Create a Websocket API with a Lambda authorizer and a Lambda in the back-end.",
+  "language": "NodeJs",
   "level": "200",
-  "framework": "CDK",
+  "framework": "SAM",
   "introBox": {
     "headline": "How it works",
     "text": [
-      "This sample project demonstrates how to use an AWS Step Functions state machine to query Athena and get the results. This pattern is leveraging the native integration between these 2 services which means only JSON-based, structured language is used to define the implementation.",
-      "With Amazon Athena you can get up to 1000 results per invocation of the GetQueryResults method and this is the reason why the Step Function has a loop to get more results. The results are sent to a Map which can be configured to handle (the DoSomething state) the items in parallel or one by one by modifying the max_concurrency parameter.",
-      "This pattern deploys one Step Functions, two S3 Buckets, one Glue table and one Glue database."
+      "This projects demonstrates how to use a WebSocket API with a Lambda Authorizer",
+      "The WebSocket API does not have a Proxy integration with the back-end Lambda written NodeJs 22, instead it is using a mapping template that forwards the main information of the request.",
+      "The Connection ID is stored in a DynamoDB table and the Lambda sends a response to the websocket API through the @connections URL"
     ]
   },
   "gitHub": {
     "template": {
-      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/sfn-athena-cdk-python",
-      "templateURL": "serverless-patterns/sfn-athena-cdk-python",
-      "projectFolder": "sfn-athena-cdk-python",
-      "templateFile": "sfn_athena_cdk_python_stack.py"
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/apigw-websocket-mapping-template-authorizer",
+      "templateURL": "serverless-patterns/apigw-websocket-mapping-template-authorizer",
+      "projectFolder": "apigw-websocket-mapping-template-authorizer",
+      "templateFile": "apigw-websocket-mapping-template-authorizer/template.yaml"
     }
   },
   "resources": {
     "bullets": [
       {
-        "text": "Call Athena with Step Functions",
-        "link": "https://docs.aws.amazon.com/step-functions/latest/dg/connect-athena.html"
+        "text": "Invoke a Webscoket API with wscat",
+        "link": "https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-how-to-call-websocket-api-wscat.html"
       },
       {
-        "text": "Amazon Athena - Serverless Interactive Query Service",
-        "link": "https://aws.amazon.com/athena/"
+        "text": "Integration request in Websocket API Gateway",
+        "link": "https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-integration-requests.html"
+      },
+      {
+        "text": "Control access to WebSocket APIs with AWS Lambda REQUEST authorizers",
+        "link": "https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-lambda-auth.html"
       }
     ]
   },
@@ -44,16 +48,15 @@
   },
   "cleanup": {
     "text": [
-      "Delete the stack: <code>cdk delete</code>."
+      "Delete the stack: <code>sam delete</code>."
     ]
   },
   "authors": [
     {
-      "name": "Your name",
-      "image": "link-to-your-photo.jpg",
-      "bio": "Your bio.",
-      "linkedin": "linked-in-ID",
-      "twitter": "twitter-handle"
+      "name": "Alice Goumain",
+      "image": "https://media.licdn.com/dms/image/v2/C4E03AQFu1xnGt76xzg/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1662636937225?e=2147483647&v=beta&t=f4IFRXMLweHD9WieD3X1D3YkZO3Hf-bdTXHAfYcFpbo",
+      "bio": "Cloud Support Engineer in Serverless @ AWS",
+      "linkedin": "https://www.linkedin.com/in/alice-goumain/"
     }
   ]
 }

--- a/apigw-websocket-mapping-template-authorizer/example-pattern.json
+++ b/apigw-websocket-mapping-template-authorizer/example-pattern.json
@@ -1,0 +1,59 @@
+{
+  "title": "Step Functions to Athena",
+  "description": "Create a Step Functions workflow to query Amazon Athena.",
+  "language": "Python",
+  "level": "200",
+  "framework": "CDK",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "This sample project demonstrates how to use an AWS Step Functions state machine to query Athena and get the results. This pattern is leveraging the native integration between these 2 services which means only JSON-based, structured language is used to define the implementation.",
+      "With Amazon Athena you can get up to 1000 results per invocation of the GetQueryResults method and this is the reason why the Step Function has a loop to get more results. The results are sent to a Map which can be configured to handle (the DoSomething state) the items in parallel or one by one by modifying the max_concurrency parameter.",
+      "This pattern deploys one Step Functions, two S3 Buckets, one Glue table and one Glue database."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/sfn-athena-cdk-python",
+      "templateURL": "serverless-patterns/sfn-athena-cdk-python",
+      "projectFolder": "sfn-athena-cdk-python",
+      "templateFile": "sfn_athena_cdk_python_stack.py"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "Call Athena with Step Functions",
+        "link": "https://docs.aws.amazon.com/step-functions/latest/dg/connect-athena.html"
+      },
+      {
+        "text": "Amazon Athena - Serverless Interactive Query Service",
+        "link": "https://aws.amazon.com/athena/"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "sam deploy"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the GitHub repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>cdk delete</code>."
+    ]
+  },
+  "authors": [
+    {
+      "name": "Your name",
+      "image": "link-to-your-photo.jpg",
+      "bio": "Your bio.",
+      "linkedin": "linked-in-ID",
+      "twitter": "twitter-handle"
+    }
+  ]
+}

--- a/apigw-websocket-mapping-template-authorizer/example-pattern.json
+++ b/apigw-websocket-mapping-template-authorizer/example-pattern.json
@@ -9,7 +9,7 @@
     "text": [
       "This projects demonstrates how to use a WebSocket API with a Lambda Authorizer",
       "The WebSocket API does not have a Proxy integration with the back-end Lambda written NodeJs 22, instead it is using a mapping template that forwards the main information of the request.",
-      "The Connection ID is stored in a DynamoDB table and the Lambda sends a response to the websocket API through the @connections URL"
+      "The Connection ID is stored in a DynamoDB table and the Lambda sends a response to the websocket API through the endpoint URL"
     ]
   },
   "gitHub": {

--- a/apigw-websocket-mapping-template-authorizer/src/authorizer.mjs
+++ b/apigw-websocket-mapping-template-authorizer/src/authorizer.mjs
@@ -1,0 +1,32 @@
+        export const handler = function(event, context, callback) {
+            console.log('Received event:', JSON.stringify(event, null, 2));
+            // Retrieve request parameters from the Lambda function input:
+            var headers = event.headers;
+            
+            if (headers.token === "hello"){
+                callback(null, generateAllow('me', event.methodArn));
+            }  else {
+                callback("Unauthorized");
+            }
+        }
+        // Help function to generate an IAM policy
+        var generatePolicy = function(principalId, effect, resource) {
+            // Required output:
+            var authResponse = {};
+            authResponse.principalId = principalId;
+            if (effect && resource) {
+                var policyDocument = {};
+                policyDocument.Version = '2012-10-17'; // default version
+                policyDocument.Statement = [];
+                var statementOne = {};
+                statementOne.Action = 'execute-api:Invoke'; // default action
+                statementOne.Effect = effect;
+                statementOne.Resource = resource;
+                policyDocument.Statement[0] = statementOne;
+                authResponse.policyDocument = policyDocument;
+            }
+            return authResponse;
+        }
+        var generateAllow = function(principalId, resource) {
+            return generatePolicy(principalId, 'Allow', resource);
+        }

--- a/apigw-websocket-mapping-template-authorizer/src/onconnect.mjs
+++ b/apigw-websocket-mapping-template-authorizer/src/onconnect.mjs
@@ -1,0 +1,22 @@
+        import { DynamoDBClient, PutItemCommand } from "@aws-sdk/client-dynamodb";
+        const client = new DynamoDBClient({ region: process.env.AWS_REGION });
+        export const handler = async (event) => {
+          const connectionId = event.requestContext.connectionId;
+          console.log("connection ID:", connectionId ); // Print the connection ID
+            const putParams = {
+              "Item": {
+                "connectionId": {
+                  "S": connectionId
+                },
+              },
+              "TableName": process.env.TABLE_NAME
+            };
+          try {
+            const command = new PutItemCommand(putParams);
+            const response = await client.send(command);
+            console.log("put command:", response); // Print the response
+            } catch (err) {
+              return { statusCode: 500, body: "Failed to connect: " + JSON.stringify(err) };
+            }
+            return { statusCode: 200, body: "Connected." };
+        };

--- a/apigw-websocket-mapping-template-authorizer/src/ondisconnect.mjs
+++ b/apigw-websocket-mapping-template-authorizer/src/ondisconnect.mjs
@@ -1,0 +1,20 @@
+        import { DynamoDBClient, DeleteItemCommand } from "@aws-sdk/client-dynamodb";
+        const client = new DynamoDBClient({ region: process.env.AWS_REGION });
+        export const handler = async (event) => {
+          const connectionId = event.requestContext.connectionId;
+          const deleteParams = {
+              "Key": {
+                "connectionId": {
+                  "S": connectionId
+                },
+              },
+              "TableName": process.env.TABLE_NAME
+          };
+          try {
+            const command = new DeleteItemCommand(deleteParams);
+            await client.send(command);
+          } catch (err) {
+            return { statusCode: 500, body: "Failed to disconnect: " + JSON.stringify(err) };
+          }
+          return { statusCode: 200, body: "Disconnected." };
+        };

--- a/apigw-websocket-mapping-template-authorizer/src/sendmessage.mjs
+++ b/apigw-websocket-mapping-template-authorizer/src/sendmessage.mjs
@@ -32,7 +32,7 @@
             //parameters to post response to the connectionId
             const postParams = {
               ConnectionId: connectionId,
-              Data: Buffer.from("good job on deploying this template, keep slaying!!"),
+              Data: "good job on deploying this template, keep slaying!!",
             };
             try{
             const postCommand = new PostToConnectionCommand(postParams);
@@ -41,6 +41,5 @@
           } catch (err) {
             return { statusCode: 500, body: "Failed to connect: " + JSON.stringify(err) };
           }
-            //response returned to API GW
             return { statusCode: 200, body: "Data sent" };
         };

--- a/apigw-websocket-mapping-template-authorizer/src/sendmessage.mjs
+++ b/apigw-websocket-mapping-template-authorizer/src/sendmessage.mjs
@@ -1,0 +1,46 @@
+        import { DynamoDBClient, ScanCommand, DeleteItemCommand } from "@aws-sdk/client-dynamodb";
+        import { ApiGatewayManagementApiClient, PostToConnectionCommand } from "@aws-sdk/client-apigatewaymanagementapi";
+        const ddbClient = new DynamoDBClient({ region: process.env.AWS_REGION });
+
+        export const handler = async (event) => {
+            let connectionData;
+            console.log("event received:", event); //check the event received by Lambda
+
+            //scanning DB table to get the Connection ID
+            const scanParams = {
+              TableName: process.env.TABLE_NAME,
+              ProjectionExpression: "connectionId",
+            };
+            
+            const scanCommand = new ScanCommand(scanParams);
+            const responseDynamo = await ddbClient.send(scanCommand);
+            connectionData = responseDynamo.Items;
+            const connectionId = connectionData[0].connectionId.S;
+            console.log("connectionData:", connectionData); // print info about the DB connection
+            
+            //building endpoint from env variables, can also be buit from request parameters 
+            const endpoint = "https://" + process.env.API_ID + ".execute-api." + process.env.AWS_REGION + ".amazonaws.com/" + process.env.STAGE + "/";
+            
+            const apigwManagementApi = new ApiGatewayManagementApiClient({ apiVersion: "2018-11-29",
+            endpoint: endpoint,
+            });
+            
+            const body = JSON.parse(event.body);
+            const message = body.data;
+            console.log("Message sent by client:", message); //print the message received from the request
+
+            //parameters to post response to the connectionId
+            const postParams = {
+              ConnectionId: connectionId,
+              Data: Buffer.from("good job on deploying this template, keep slaying!!"),
+            };
+            try{
+            const postCommand = new PostToConnectionCommand(postParams);
+            const responseApi = await apigwManagementApi.send(postCommand);
+            console.log("response:", responseApi); //print the response
+          } catch (err) {
+            return { statusCode: 500, body: "Failed to connect: " + JSON.stringify(err) };
+          }
+            //response returned to API GW
+            return { statusCode: 200, body: "Data sent" };
+        };

--- a/apigw-websocket-mapping-template-authorizer/template.yaml
+++ b/apigw-websocket-mapping-template-authorizer/template.yaml
@@ -1,0 +1,233 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: SAM template for a websocket API with a mapping template and a Lambda integration
+
+Globals:
+  Function:
+    CodeUri: ./src
+    Runtime: nodejs22.x
+
+Resources:
+  WebsocketApi:
+    Type: AWS::ApiGatewayV2::Api
+    Properties:
+      Name: Websocket-api-mapping-template
+      ProtocolType: WEBSOCKET
+      RouteSelectionExpression: $request.body.action
+
+  LambdaAuthorizer: 
+    Type: AWS::ApiGatewayV2::Authorizer
+    Properties:
+      ApiId: !Ref WebsocketApi
+      AuthorizerType: REQUEST
+      AuthorizerUri: 
+        Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AuthFunction.Arn}/invocations
+      Name: lambda-authorizer-request
+      IdentitySource: 
+       - route.request.header.token
+      
+  ConnectRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId:
+        Ref: WebsocketApi
+      RouteKey: $connect
+      Target:
+        Fn::Join:
+        - /
+        - - integrations
+          - Ref: ConnectInteg
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref LambdaAuthorizer
+
+  ConnectInteg:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: Ref! WebsocketApi
+      IntegrationType: AWS_PROXY
+      IntegrationUri:
+        Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${OnConnectFunction.Arn}/invocations
+  
+  DisconnectRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId:
+        Ref: WebsocketApi
+      RouteKey: $disconnect
+      Target:
+        Fn::Join:
+        - /
+        - - integrations
+          - Ref: DisconnectInteg
+  DisconnectInteg:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId:
+        Ref: WebsocketApi
+      IntegrationType: AWS_PROXY
+      IntegrationUri:
+        Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${OnDisconnectFunction.Arn}/invocations
+  
+  SendRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId:
+        Ref: WebsocketApi
+      RouteKey: sendmessage
+      Target:
+        Fn::Join:
+        - /
+        - - integrations
+          - Ref: SendInteg
+
+  SendInteg:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId:
+        Ref: WebsocketApi
+      Description: Send Integration
+      IntegrationType: AWS
+      IntegrationUri:
+        Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SendMessageFunction.Arn}/invocations
+      RequestTemplates:
+        application/json: |
+          {
+            "requestContext": {
+              "routeKey": "$context.routeKey",
+              "messageId": "$context.messageId",
+              "auth": "$context.authorizer.principalId",
+              "test": "$context.authorizer.token",
+              "eventType": "$context.eventType",
+              "extendedRequestId": "$context.extendedRequestId",
+              "requestTime": "$context.requestTime",
+              "messageDirection": "$context.messageDirection",
+              "stage": "$context.stage",
+              "connectedAt": "$context.connectedAt",
+              "requestTimeEpoch": "$context.requestTimeEpoch",
+              "identity": {
+                "sourceIp": "$context.identity.sourceIp"
+              },
+              "requestId": "$context.requestId",
+              "domainName": "$context.domainName",
+              "connectionId": "$context.connectionId",
+              "apiId": "$context.apiId"
+            },
+              "body": "$util.escapeJavaScript($input.body)",
+              "isBase64Encoded": "$context.isBase64Encoded"
+          }
+
+  Deployment:
+    Type: AWS::ApiGatewayV2::Deployment
+    DependsOn:
+    - ConnectRoute
+    - SendRoute
+    - DisconnectRoute
+    Properties:
+      ApiId:
+        Ref: WebsocketApi
+
+  Stage:
+    Type: AWS::ApiGatewayV2::Stage
+    Properties:
+      StageName: slay
+      DeploymentId:
+        Ref: Deployment
+      ApiId:
+        Ref: WebsocketApi
+
+  ConnectionsTable:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      PrimaryKey:
+        Name: connectionId
+        Type: String
+      TableName: connection_table
+
+  AuthFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: authorizer.handler
+      MemorySize: 256
+
+  LambdaAuthPermission:
+    Type: AWS::Lambda::Permission
+    DependsOn:
+    - WebsocketApi
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName:
+        Ref: AuthFunction
+      Principal: apigateway.amazonaws.com
+     
+  OnConnectFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: onconnect.handler
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref ConnectionsTable
+      Policies:
+      - DynamoDBCrudPolicy:
+          TableName: !Ref ConnectionsTable
+
+  OnConnectPermission:
+    Type: AWS::Lambda::Permission
+    DependsOn:
+    - WebsocketApi
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName:
+        Ref: OnConnectFunction
+      Principal: apigateway.amazonaws.com
+
+  OnDisconnectFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: ondisconnect.handler
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref ConnectionsTable
+      Policies:
+      - DynamoDBCrudPolicy:
+          TableName: !Ref ConnectionsTable
+
+  OnDisconnectPermission:
+    Type: AWS::Lambda::Permission
+    DependsOn:
+    - WebsocketApi
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName:
+        Ref: OnDisconnectFunction
+      Principal: apigateway.amazonaws.com
+
+  SendMessageFunction:
+    Type: AWS::Serverless::Function
+    DependsOn:
+    - WebsocketApi
+    Properties:
+      Handler: sendmessage.handler
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref ConnectionsTable
+          API_ID: !Ref WebsocketApi
+          STAGE: "slay"
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref ConnectionsTable
+        - Statement:
+          - Effect: Allow
+            Action:
+            - execute-api:ManageConnections
+            Resource:
+            - Fn::Sub: arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${WebsocketApi}/*
+
+  SendMessagePermission:
+    Type: AWS::Lambda::Permission
+    DependsOn:
+    - WebsocketApi
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName:
+        Ref: SendMessageFunction
+      Principal: apigateway.amazonaws.com

--- a/apigw-websocket-mapping-template-authorizer/template.yaml
+++ b/apigw-websocket-mapping-template-authorizer/template.yaml
@@ -96,7 +96,7 @@ Resources:
               "routeKey": "$context.routeKey",
               "messageId": "$context.messageId",
               "auth": "$context.authorizer.principalId",
-              "test": "$context.authorizer.token",
+              "token": "$context.authorizer.token",
               "eventType": "$context.eventType",
               "extendedRequestId": "$context.extendedRequestId",
               "requestTime": "$context.requestTime",
@@ -104,9 +104,7 @@ Resources:
               "stage": "$context.stage",
               "connectedAt": "$context.connectedAt",
               "requestTimeEpoch": "$context.requestTimeEpoch",
-              "identity": {
-                "sourceIp": "$context.identity.sourceIp"
-              },
+              "sourceIp": "$context.identity.sourceIp",
               "requestId": "$context.requestId",
               "domainName": "$context.domainName",
               "connectionId": "$context.connectionId",
@@ -129,7 +127,7 @@ Resources:
   Stage:
     Type: AWS::ApiGatewayV2::Stage
     Properties:
-      StageName: slay
+      StageName: stage
       DeploymentId:
         Ref: Deployment
       ApiId:
@@ -211,7 +209,7 @@ Resources:
         Variables:
           TABLE_NAME: !Ref ConnectionsTable
           API_ID: !Ref WebsocketApi
-          STAGE: "slay"
+          STAGE: "stage"
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref ConnectionsTable
@@ -228,6 +226,13 @@ Resources:
     - WebsocketApi
     Properties:
       Action: lambda:InvokeFunction
-      FunctionName:
-        Ref: SendMessageFunction
+      FunctionName: !Ref SendMessageFunction
       Principal: apigateway.amazonaws.com
+
+Outputs:
+  WebSocketCommand:
+    Description: "The WSS command to use to connect"
+    Value: !Join [ '', [ 'wscat --header token:hello -c wss://', !Ref WebSocketApi, '.execute-api.',!Ref 'AWS::Region','.amazonaws.com/',!Ref 'Stage'] ]
+  PayloadJson:
+    Description: "The Json payload you can send to try the sendmessage route"
+    Value: '{"action": "sendmessage","message" : "hey queen"}'

--- a/apigw-websocket-mapping-template-authorizer/template.yaml
+++ b/apigw-websocket-mapping-template-authorizer/template.yaml
@@ -43,7 +43,7 @@ Resources:
   ConnectInteg:
     Type: AWS::ApiGatewayV2::Integration
     Properties:
-      ApiId: Ref! WebsocketApi
+      ApiId: !Ref WebsocketApi
       IntegrationType: AWS_PROXY
       IntegrationUri:
         Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${OnConnectFunction.Arn}/invocations
@@ -232,7 +232,7 @@ Resources:
 Outputs:
   WebSocketCommand:
     Description: "The WSS command to use to connect"
-    Value: !Join [ '', [ 'wscat --header token:hello -c wss://', !Ref WebSocketApi, '.execute-api.',!Ref 'AWS::Region','.amazonaws.com/',!Ref 'Stage'] ]
+    Value: !Join [ '', [ 'wscat --header token:hello -c wss://', !Ref WebsocketApi, '.execute-api.',!Ref 'AWS::Region','.amazonaws.com/',!Ref 'Stage'] ]
   PayloadJson:
     Description: "The Json payload you can send to try the sendmessage route"
     Value: '{"action": "sendmessage","message" : "hey queen"}'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This projects demonstrates how to use a WebSocket API with a Lambda Authorizer. The WebSocket API does not have a Proxy integration with the back-end Lambda written NodeJs 22, instead it is using a mapping template that forwards the main information of the request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
