### PR TITLE
Add new pattern: API Gateway to SQS with Priority-Based Routing

### DIFF
--- a/apigw-priority-sqs-routing/README.md
+++ b/apigw-priority-sqs-routing/README.md
@@ -1,0 +1,99 @@
+# API Gateway to SQS with Priority-Based Message Routing
+
+This pattern demonstrates how to implement direct integration between API Gateway and multiple SQS queues using mapping templates, enabling dynamic message routing based on request parameters without using Lambda functions.
+
+## Architecture
+
+[The ServerlessLand team will create this diagram]
+
+## Description
+
+The pattern creates:
+- An API Gateway REST API with a POST method
+- Three SQS queues (high-priority, default, and low-priority)
+- IAM roles and policies for API Gateway to send messages to SQS
+- A VTL mapping template for dynamic queue routing
+
+The solution enables:
+- Dynamic routing of messages to different queues based on a priority parameter
+- Direct integration between API Gateway and SQS without Lambda
+- Request transformation using mapping templates
+
+## Important note
+
+Deploying this pattern may incur costs. Be sure to delete the resources after testing to avoid ongoing charges.
+
+## Prerequisites
+
+* AWS CLI installed and configured
+* Git
+
+## Deployment Instructions
+
+1. Deploy the AWS CloudFormation template:
+```bash
+aws cloudformation deploy \
+  --template-file template.yaml \
+  --stack-name api-priority-sqs \
+  --capabilities CAPABILITY_IAM
+
+2. Retrieve the API Gateway endpoint URL from CloudFormation outputs:
+```bash
+aws cloudformation describe-stacks \
+  --stack-name api-priority-sqs \
+  --query 'Stacks[0].Outputs[?OutputKey==`ApiEndpoint`].OutputValue' \
+  --output text
+
+3. Send a message to the default queue (no priority parameter):
+```bash
+curl --location --request POST 'YOUR_API_ENDPOINT' \
+--header 'Content-Type: application/json' \
+--data-raw '{"message": "default priority message"}'
+
+Expected success response:
+```bash
+{
+    "message": "Message sent successfully"
+}
+
+You can verify message delivery by checking the respective SQS queues in the AWS Console.
+## Example Event
+```bash
+{
+    "message": "test message",
+    "timestamp": "2025-01-27T13:20:58Z"
+}
+
+## Mapping Template
+The following VTL mapping template is used to route messages based on the priority parameter:
+```bash
+#set($priority = "default-queue")
+#if($input.params('priority') == "low")
+    #set($priority = "low-queue")
+#elseif($input.params('priority') == "high")
+    #set($priority = "high-queue")
+#end
+
+{
+    "QueueUrl": "https://sqs.${context.region}.amazonaws.com/${context.accountId}/$priority",
+    "MessageBody": "$util.escapeJavaScript($input.json('$'))"
+}
+
+## Cleanup
+1. Delete the CloudFormation stack:
+```bash
+aws cloudformation delete-stack --stack-name api-priority-sqs
+
+2. Confirm the stack has been deleted:
+```bash
+aws cloudformation list-stacks --query 'StackSummaries[?contains(StackName,`api-priority-sqs`)]'
+
+## Resources
+
+* [API Gateway documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/welcome.html)
+* [Amazon SQS documentation](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/welcome.html)
+* [API Gateway Mapping Template Reference](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html)
+* [SQS SendMessage API Reference](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html)
+
+
+

--- a/apigw-priority-sqs-routing/example-pattern.json
+++ b/apigw-priority-sqs-routing/example-pattern.json
@@ -1,0 +1,59 @@
+{
+  "title": "Step Functions to Athena",
+  "description": "Create a Step Functions workflow to query Amazon Athena.",
+  "language": "Python",
+  "level": "200",
+  "framework": "CDK",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "This sample project demonstrates how to use an AWS Step Functions state machine to query Athena and get the results. This pattern is leveraging the native integration between these 2 services which means only JSON-based, structured language is used to define the implementation.",
+      "With Amazon Athena you can get up to 1000 results per invocation of the GetQueryResults method and this is the reason why the Step Function has a loop to get more results. The results are sent to a Map which can be configured to handle (the DoSomething state) the items in parallel or one by one by modifying the max_concurrency parameter.",
+      "This pattern deploys one Step Functions, two S3 Buckets, one Glue table and one Glue database."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/sfn-athena-cdk-python",
+      "templateURL": "serverless-patterns/sfn-athena-cdk-python",
+      "projectFolder": "sfn-athena-cdk-python",
+      "templateFile": "sfn_athena_cdk_python_stack.py"
+    }
+  },
+  "resources": {
+    "bullets": [
+      {
+        "text": "Call Athena with Step Functions",
+        "link": "https://docs.aws.amazon.com/step-functions/latest/dg/connect-athena.html"
+      },
+      {
+        "text": "Amazon Athena - Serverless Interactive Query Service",
+        "link": "https://aws.amazon.com/athena/"
+      }
+    ]
+  },
+  "deploy": {
+    "text": [
+      "sam deploy"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the GitHub repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>cdk delete</code>."
+    ]
+  },
+  "authors": [
+    {
+      "name": "Your name",
+      "image": "link-to-your-photo.jpg",
+      "bio": "Your bio.",
+      "linkedin": "linked-in-ID",
+      "twitter": "twitter-handle"
+    }
+  ]
+}

--- a/apigw-priority-sqs-routing/template.yaml
+++ b/apigw-priority-sqs-routing/template.yaml
@@ -1,0 +1,128 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'CloudFormation template for API Gateway with SQS Integration'
+
+Resources:
+  # API Gateway Resources
+  MyRestApi:
+    Type: 'AWS::ApiGateway::RestApi'
+    Properties:
+      Name: 'SQS queue mapping template'
+      Description: 'REST API with SQS Integration'
+
+  # IAM Role for API Gateway
+  ApiGatewayRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: apigateway.amazonaws.com
+            Action: 'sts:AssumeRole'
+      Policies:
+        - PolicyName: ApiGatewaySQSAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'sqs:SendMessage'
+                Resource: 
+                  - !GetAtt LowQueue.Arn
+                  - !GetAtt DefaultQueue.Arn
+                  - !GetAtt HighQueue.Arn
+
+  RootPostMethod:
+    Type: 'AWS::ApiGateway::Method'
+    Properties:
+      RestApiId: !Ref MyRestApi
+      ResourceId: !GetAtt MyRestApi.RootResourceId
+      HttpMethod: POST
+      AuthorizationType: NONE
+      Integration:
+        Type: AWS
+        IntegrationHttpMethod: POST
+        Uri: !Sub 'arn:aws:apigateway:${AWS::Region}:sqs:path//'
+        Credentials: !GetAtt ApiGatewayRole.Arn
+        PassthroughBehavior: WHEN_NO_MATCH
+        TimeoutInMillis: 29000
+        RequestParameters:
+          integration.request.header.Content-Type: "'application/x-amz-json-1.0'"
+          integration.request.header.X-Amz-Target: "'AmazonSQS.SendMessage'"
+        RequestTemplates:
+          application/json: |
+            #set($priority = "default-queue")
+            #if($input.params('priority') == "low")
+                #set($priority = "low-queue")
+            #elseif($input.params('priority') == "high")
+                #set($priority = "high-queue")
+            #end
+            
+            {
+            "QueueUrl": "https://sqs.${context.region}.amazonaws.com/${context.accountId}/$priority",
+            "MessageBody":  "$util.escapeJavaScript($input.json('$'))"
+            }
+        IntegrationResponses:
+          - StatusCode: 200
+            ResponseTemplates:
+              application/json: '{"message": "Message sent successfully"}'
+      MethodResponses:
+        - StatusCode: 200
+          ResponseModels:
+            application/json: 'Empty'
+
+  # SQS Queue Resources
+  LowQueue:
+    Type: 'AWS::SQS::Queue'
+    Properties:
+      QueueName: 'low-queue'
+      MessageRetentionPeriod: 345600
+      VisibilityTimeout: 30
+      DelaySeconds: 0
+
+  DefaultQueue:
+    Type: 'AWS::SQS::Queue'
+    Properties:
+      QueueName: 'default-queue'
+      MessageRetentionPeriod: 345600
+      VisibilityTimeout: 30
+      DelaySeconds: 0
+
+  HighQueue:
+    Type: 'AWS::SQS::Queue'
+    Properties:
+      QueueName: 'high-queue'
+      MessageRetentionPeriod: 345600
+      VisibilityTimeout: 30
+      DelaySeconds: 0
+
+  ApiDeployment:
+    Type: 'AWS::ApiGateway::Deployment'
+    DependsOn: RootPostMethod
+    Properties:
+      RestApiId: !Ref MyRestApi
+
+  ApiStage:
+    Type: 'AWS::ApiGateway::Stage'
+    Properties:
+      DeploymentId: !Ref ApiDeployment
+      RestApiId: !Ref MyRestApi
+      StageName: 'prod'
+
+Outputs:
+  ApiEndpoint:
+    Description: 'API Gateway endpoint URL for Prod stage'
+    Value: !Sub 'https://${MyRestApi}.execute-api.${AWS::Region}.amazonaws.com/prod/'
+  
+  LowQueueURL:
+    Description: 'URL of low-queue Queue'
+    Value: !Ref LowQueue
+  
+  DefaultQueueURL:
+    Description: 'URL of default-queue Queue'
+    Value: !Ref DefaultQueue
+  
+  HighQueueURL:
+    Description: 'URL of high-queue Queue'
+    Value: !Ref HighQueue


### PR DESCRIPTION
This pattern demonstrates how to implement priority-based message routing from API Gateway directly to multiple SQS queues without using Lambda functions.

Key features:
- Direct integration between API Gateway and SQS using VTL mapping templates
- Dynamic routing to three different queues (high, default, low) based on a priority query parameter
- Secure IAM role configuration for API Gateway to SQS permissions
- Complete CloudFormation template for infrastructure as code

Example usage:
- High priority messages: /endpoint?priority=high
- Default priority: /endpoint (no parameter needed)
- Low priority messages: /endpoint?priority=low

The pattern includes:
- Detailed testing instructions with curl commands
- Example events and expected responses
- Clean architecture that follows AWS best practices
