### PR TITLE
New serverless pattern - apigw-websocket-api-vpclink

### DIFF
--- a/apigw-websocket-api-vpclink/README.md
+++ b/apigw-websocket-api-vpclink/README.md
@@ -1,0 +1,72 @@
+# Amazon API Gateway Websocket API with VPC Link integration
+
+The SAM template deploys an Amazon API Gateway Websocket API endpoint with a VPC Link integration.
+
+Since Websocket APIs only support VPC Links associated with NLBs (Network Load Balancers), this pattern assumes that an internal NLB already exists in a VPC in the same Region.
+
+=======
+Learn more about this pattern at Serverless Land Patterns: https://serverlessland.com/patterns/apigw-rest-api-vpclink
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the AWS Pricing page for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+
+## Deployment Instructions
+
+1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
+    ``` 
+    git clone https://github.com/aws-samples/serverless-patterns
+    ```
+2. Change directory to the pattern directory:
+    ```
+    cd apigw-websocket-api-vpclink
+    ```
+
+3. From the command line, use AWS SAM to deploy the AWS resources for the pattern as specified in the template.yml file:
+    ```
+    sam deploy -g
+    ```
+4. During the prompts:
+    * Enter a stack name
+    * Select the desired AWS Region
+    * Enter the DNS name for the internal NLB (NlbInternalDns)
+    * Enter the ARN for the internal NLB (NlbInternalArn)
+    * Allow SAM to create roles with the required permissions if needed.
+
+    Once you have run guided mode once, you can use `sam deploy` in future to use these defaults.
+
+1. Note the outputs from the SAM deployment process. These contain the resource names and/or ARNs which are used for testing.
+
+## Testing
+
+Once the application is deployed, retrieve the WebSocketURL value from CloudFormation Outputs. To test the WebSocket API, you can use [wscat](https://github.com/websockets/wscat) which is an open-source command line tool.
+
+1. [Install NPM](https://www.npmjs.com/get-npm).
+
+2. Install wscat:
+    ```
+    $ npm install -g wscat
+    ```
+
+3. Connect to your WebSocketURL by executing the following command:
+    ```
+    $ wscat -c <YOUR WEBSOCKET URL>
+    ```
+
+## Cleanup
+
+1. Delete the stack
+    ```
+    aws cloudformation delete-stack --stack-name <YOUR STACK NAME>
+    ```
+
+2. Confirm the stack has been deleted
+    ```
+    aws cloudformation list-stacks --query "StackSummaries[?contains(StackName,'<YOUR STACK NAME>')].StackStatus"
+    ```
+

--- a/apigw-websocket-api-vpclink/README.md
+++ b/apigw-websocket-api-vpclink/README.md
@@ -62,7 +62,7 @@ Once the application is deployed, retrieve the WebSocketURL value from CloudForm
 
 1. Delete the stack
     ```
-    aws cloudformation delete-stack --stack-name <YOUR STACK NAME>
+sam delete
     ```
 
 2. Confirm the stack has been deleted

--- a/apigw-websocket-api-vpclink/apigw-websocket-api-vpclink.json
+++ b/apigw-websocket-api-vpclink/apigw-websocket-api-vpclink.json
@@ -1,0 +1,79 @@
+{
+    "title": "Amazon API Gateway Websocket API with VPC Link integration",
+    "description": "The SAM template deploys an Amazon API Gateway Websocket API endpoint with a VPC Link integration.",
+    "introBox": {
+        "headline": "How it works",
+        "text": [
+            "This pattern deploys an Amazon API Gateway WebSocket API endpoint with a VPC Link integration to an internal Network Load Balancer (NLB).",
+            "WebSocket APIs with VPC Links allow bidirectional communication between clients and backend services hosted in private VPCs."
+        ]
+    },
+    "language": "Python",
+    "level": "200",
+    "framework": "AWS SAM",
+    "gitHub": {
+        "template": {
+            "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/apigw-websocket-api-vpclink",
+            "templateURL": "serverless-patterns/apigw-websocket-api-vpclink",
+            "projectFolder": "apigw-websocket-api-vpclink",
+            "templateFile": "template.yml"
+        }
+    },
+    "deploy": {
+        "text": [
+            "sam deploy"
+        ]
+    },
+    "testing": {
+        "text": [
+            "See the GitHub repo for detailed testing instructions."
+        ]
+    },
+    "cleanup": {
+        "text": [
+            "Delete the stack: <code>sam delete</code>."
+        ]
+    },
+    "authors": [
+        {
+            "name": "Manasvi Jain",
+            "image": "https://avatars.githubusercontent.com/u/56217984?v=4",
+            "bio": "Associate Partner Solutions Architect at AWS",
+            "linkedin": "https://www.linkedin.com/in/manasvi-jain-36b9941a3/"
+        },
+        {
+            "name": "Umang Aggarwal",
+            "image": "https://avatars.githubusercontent.com/Umang071",
+            "bio": "Technical Account Manager @ AWS",
+            "linkedin": "https://www.linkedin.com/in/umangaggarwal"
+        }
+    ],
+    "patternArch": {
+        "icon1": {
+            "x": 20,
+            "y": 50,
+            "service": "apigw",
+            "label": "API Gateway WebSocket"
+        },
+        "icon2": {
+            "x": 50,
+            "y": 50,
+            "service": "vpc",
+            "label": "VPC Link"
+        },
+        "icon3": {
+            "x": 80,
+            "y": 50,
+            "service": "alb",
+            "label": "NLB"
+        },
+        "line1": {
+            "from": "icon1",
+            "to": "icon2"
+        },
+        "line2": {
+            "from": "icon2",
+            "to": "icon3"
+        }
+    }
+}

--- a/apigw-websocket-api-vpclink/apigw-websocket-api-vpclink.json
+++ b/apigw-websocket-api-vpclink/apigw-websocket-api-vpclink.json
@@ -64,8 +64,8 @@
         "icon3": {
             "x": 80,
             "y": 50,
-            "service": "alb",
-            "label": "NLB"
+            "service": "nlb",
+            "label": "Network Load Balancer"
         },
         "line1": {
             "from": "icon1",

--- a/apigw-websocket-api-vpclink/example-pattern.json
+++ b/apigw-websocket-api-vpclink/example-pattern.json
@@ -1,0 +1,46 @@
+{
+  "title": "Amazon API Gateway Websocket API with VPC Link integration",
+  "description": "The SAM template deploys an Amazon API Gateway Websocket API endpoint with a VPC Link integration.",
+  "language": "Python",
+  "level": "200",
+  "framework": "SAM",
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-patterns/tree/main/apigw-websocket-api-vpclink",
+      "templateURL": "serverless-patterns/apigw-websocket-api-vpclink",
+      "projectFolder": "apigw-websocket-api-vpclink",
+      "templateFile": "template.yaml"
+    }
+  },
+  "deploy": {
+    "text": [
+      "sam deploy"
+    ]
+  },
+  "testing": {
+    "text": [
+      "See the GitHub repo for detailed testing instructions."
+    ]
+  },
+  "cleanup": {
+    "text": [
+      "Delete the stack: <code>sam delete</code>."
+    ]
+  },
+  "authors": [
+    {
+      "name": "Manasvi Jain",
+      "image": "https://avatars.githubusercontent.com/u/56217984?v=4",
+      "bio": "Associate Partner Solutions Architect at AWS",
+
+      "linkedin": "https://www.linkedin.com/in/manasvi-jain-36b9941a3/"
+    },
+    {
+      "name": "Umang Aggarwal",
+      "image": "https://avatars.githubusercontent.com/Umang071",
+      "bio": "Technical Account Manager @ AWS",
+
+      "linkedin": "https://www.linkedin.com/in/umangaggarwal"
+    }
+  ]
+}

--- a/apigw-websocket-api-vpclink/template.yml
+++ b/apigw-websocket-api-vpclink/template.yml
@@ -1,0 +1,101 @@
+AWSTemplateFormatVersion: 2010-09-09
+Transform: AWS::Serverless-2016-10-31
+Description: An Amazon API Gateway WebSocket API with a VPC link.
+
+Parameters:
+  NlbInternalDns:
+    Type: String
+  NlbInternalArn:
+    Type: String
+
+Resources:
+  # API Gateway WebSocket API
+  MyWebSocketApi:
+    Type: AWS::ApiGatewayV2::Api
+    Properties:
+      Name: !Ref AWS::StackName
+      Description: An Amazon API Gateway WebSocket API with a VPC link.
+      ProtocolType: WEBSOCKET
+      RouteSelectionExpression: $request.body.action
+
+  ConnectRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref MyWebSocketApi
+      RouteKey: $connect
+      Target: !Sub integrations/${ConnectIntegration}
+
+  MessageRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref MyWebSocketApi
+      RouteKey: $default
+      Target: !Sub integrations/${MessageIntegration}
+
+  DisconnectRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref MyWebSocketApi
+      RouteKey: $disconnect
+      Target: !Sub integrations/${DisconnectIntegration}
+
+  ConnectIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref MyWebSocketApi
+      IntegrationType: HTTP_PROXY
+      IntegrationMethod: ANY
+      IntegrationUri: !Sub http://${NlbInternalDns}/connect
+      ConnectionType: VPC_LINK
+      ConnectionId: !Ref VPCLinkRestNlbInternal
+
+  MessageIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref MyWebSocketApi
+      IntegrationType: HTTP_PROXY
+      IntegrationMethod: ANY
+      IntegrationUri: !Sub http://${NlbInternalDns}/message
+      ConnectionType: VPC_LINK
+      ConnectionId: !Ref VPCLinkRestNlbInternal
+
+  DisconnectIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref MyWebSocketApi
+      IntegrationType: HTTP_PROXY
+      IntegrationMethod: ANY
+      IntegrationUri: !Sub http://${NlbInternalDns}/disconnect
+      ConnectionType: VPC_LINK
+      ConnectionId: !Ref VPCLinkRestNlbInternal
+
+  Deployment:
+    Type: AWS::ApiGatewayV2::Deployment
+    DependsOn:
+      - ConnectRoute
+      - DisconnectRoute
+      - MessageRoute
+    Properties:
+      ApiId: !Ref MyWebSocketApi
+
+  Stage:
+    Type: AWS::ApiGatewayV2::Stage
+    Properties:
+      StageName: Prod
+      ApiId: !Ref MyWebSocketApi
+      DeploymentId: !Ref Deployment
+
+  VPCLinkRestNlbInternal:
+    Type: AWS::ApiGateway::VpcLink
+    Properties:
+      Name: VPCLinkRestNlbInternal
+      TargetArns:
+        - !Ref NlbInternalArn
+
+Outputs:
+
+  # API Gateway endpoint to be used during tests
+  AppApiEndpoint:
+    Description: API Endpoint
+    Value: !Sub https://${MyWebSocketApi}.execute-api.${AWS::Region}.amazonaws.com/Prod
+

--- a/apigw-websocket-api-vpclink/template.yml
+++ b/apigw-websocket-api-vpclink/template.yml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Transform: AWS::Serverless-2016-10-31
-Description: An Amazon API Gateway WebSocket API with a VPC link.
+Description: An Amazon API Gateway WebSocket API with a VPC link.(uksb-1tthgi812)(tag:apigw-websocket-api-vpclink)
 
 Parameters:
   NlbInternalDns:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The SAM template deploys an Amazon API Gateway Websocket API endpoint with a VPC Link integration.

Since Websocket APIs only support VPC Links associated with NLBs (Network Load Balancers), this pattern assumes that an internal NLB already exists in a VPC in the same Region.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
