### PR TITLE
terraform-sqs-lambda: Update runtime to python3.12

### DIFF
--- a/terraform-sqs-lambda/main.tf
+++ b/terraform-sqs-lambda/main.tf
@@ -13,7 +13,7 @@ module "lambda_function" {
   function_name = "${random_pet.this.id}-lambda"
   description   = "My awesome lambda function"
   handler       = "index.lambda_handler"
-  runtime       = "python3.8"
+  runtime       = "python3.12"
   publish       = true
 
   source_path = "${path.module}/../terraform-fixtures/python"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

I updated the Lambda Python runtime version to `python3.12`.

While testing `terraform-sqs-lambda`, I noticed that the Lambda runtime version `python3.8` was deprecated. Although it's still deployable at the moment, it will not be allowed after **October 1, 2025**.
https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

To prevent future deployment issues, I updated the runtime to `python3.12`.
https://github.com/terraform-aws-modules/terraform-aws-lambda

## Check

`terraform apply` completed successfully.

> [!WARNING]
> Warning is likely caused by the fact that the AWS provider version is currently at v6 (due to `>= 4.9` constraint), and `data.aws_region.current.name` is now a deprecated attribute. There is no functional impact at this time👍 

```sh
$ terraform apply

╷
│ Warning: Deprecated attribute
│ 
│   on .terraform/modules/lambda_function/outputs.tf line 9, in output "lambda_function_arn_static":
│    9:   value       = local.create && var.create_function && !var.create_layer ? "arn:aws:lambda:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:function:${var.function_name}" : ""
│ 
│ The attribute "name" is deprecated. Refer to the provider documentation for details.
╵

Apply complete! Resources: 14 added, 0 changed, 0 destroyed.
```

Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.