### PR TITLE
terraform-lambda-sfn: Update runtime and Powertools to python3.12

### DIFF
--- a/terraform-lambda-sfn/README.md
+++ b/terraform-lambda-sfn/README.md
@@ -2,7 +2,7 @@
 
 The pattern creates a Lambda function, and a Step Functions workflow, a Log group and the IAM resources required to run the application.
 
-A Lambda function uses the AWS SDK to asyncronously invoke the Step Function workflow, passing the event body. The Step Function workflow showcasing the different States.
+A Lambda function uses the AWS SDK to asynchronously invoke the Step Function workflow, passing the event body. The Step Function workflow showcasing the different States.
 
 ![](./images/stepfunctions_graph.png)
 

--- a/terraform-lambda-sfn/example-pattern.json
+++ b/terraform-lambda-sfn/example-pattern.json
@@ -8,7 +8,7 @@
     "headline": "How it works",
     "text": [
       "The pattern creates a Lambda function, and a Step Functions workflow, a Log group and the IAM resources required to run the application.",
-      "A Lambda function uses the AWS SDK to asyncronously invoke the Step Function workflow, passing the event body. The Step Function workflow showcasing the different States."
+      "A Lambda function uses the AWS SDK to asynchronously invoke the Step Function workflow, passing the event body. The Step Function workflow showcasing the different States."
     ]
   },
   "gitHub": {

--- a/terraform-lambda-sfn/main.tf
+++ b/terraform-lambda-sfn/main.tf
@@ -104,7 +104,7 @@ module "lambda_function" {
 
   source_path = "${path.module}/src"
 
-  layers = ["arn:aws:lambda:${data.aws_region.current.name}:017000801446:layer:AWSLambdaPowertoolsPythonV3-python312-x86_64:19"]
+  layers = ["arn:aws:lambda:${data.aws_region.current.region}:017000801446:layer:AWSLambdaPowertoolsPythonV3-python312-x86_64:19"]
 
   environment_variables = {
     SFN_ARN = module.step_function.state_machine_arn

--- a/terraform-lambda-sfn/main.tf
+++ b/terraform-lambda-sfn/main.tf
@@ -99,12 +99,12 @@ module "lambda_function" {
   function_name = "${random_pet.this.id}-lambda"
   description   = "My awesome lambda function"
   handler       = "LambdaFunction.lambda_handler"
-  runtime       = "python3.8"
+  runtime       = "python3.12"
   publish       = true
 
   source_path = "${path.module}/src"
 
-  layers = ["arn:aws:lambda:${data.aws_region.current.name}:017000801446:layer:AWSLambdaPowertoolsPython:15"]
+  layers = ["arn:aws:lambda:${data.aws_region.current.name}:017000801446:layer:AWSLambdaPowertoolsPythonV3-python312-x86_64:19"]
 
   environment_variables = {
     SFN_ARN = module.step_function.state_machine_arn


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

I updated the Lambda Python runtime and Powertools version to `python3.12`.

While testing `terraform-lambda-sfn`, I noticed that the Lambda runtime version `python3.8` was deprecated. Although it's still deployable at the moment, it will not be allowed after **October 1, 2025**.
https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

To prevent future deployment issues, I updated the runtime to `python3.12`.
https://github.com/terraform-aws-modules/terraform-aws-lambda

## Check

`terraform apply` completed successfully and works good.

> [!WARNING]
> Warning is likely caused by the fact that the AWS provider version is currently at v6 (due to `>= 4.9` constraint), and `data.aws_region.current.name` is now a deprecated attribute. There is no functional impact at this time👍 

```sh
$ terraform apply

╷
│ Warning: Deprecated attribute
│ 
│   on .terraform/modules/lambda_function/outputs.tf line 9, in output "lambda_function_arn_static":
│    9:   value       = local.create && var.create_function && !var.create_layer ? "arn:aws:lambda:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:function:${var.function_name}" : ""
│ 
│ The attribute "name" is deprecated. Refer to the provider documentation for details.
│ 
│ (and one more similar warning elsewhere)
╵

Apply complete! Resources: 20 added, 0 changed, 0 destroyed.
```

![stepfunctions_graph](https://github.com/user-attachments/assets/d970e99d-0d67-40e9-aa30-91afba3e8662)

Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.