### PR TITLE
apigw-sqs-terraform: Fix service name correctly

### DIFF
--- a/apigw-sqs-terraform/README.md
+++ b/apigw-sqs-terraform/README.md
@@ -1,4 +1,4 @@
-# AWS API Gateway HTTP APIs to Amazon SQS for buffering
+# Amazon API Gateway REST APIs to Amazon SQS for buffering
 
 In this pattern, called "Queue based leveling", a serverless queue is introduced between your API Gateway and your workers, which can be a Lambda function for example. 
 

--- a/apigw-sqs-terraform/README.md
+++ b/apigw-sqs-terraform/README.md
@@ -58,9 +58,9 @@ The API Gateway handles incoming requests, but instead of invoking for example a
 
 ## Testing
 
-1. Run the following command to send an HTTP `POST` request to the HTTP APIs endpoint. Note, you must edit the {MyHttpAPI} placeholder with the URL of the deployed HTTP APIs endpoint. This is provided in the terraform outputs. You can also find the same command automatically generated in the terraform output.
+1. Run the following command to send an HTTP `POST` request to the Rest APIs endpoint. Note, you must edit the {MyRestAPI} placeholder with the URL of the deployed Rest APIs endpoint. This is provided in the terraform outputs. You can also find the same command automatically generated in the terraform output.
     ```bash
-    curl --location --request POST '{MyHttpAPI}/submit'
+    curl --location --request POST '{MyRestAPI}/submit'
     > --header 'Content-Type: application/json' \
     > --data-raw '{ "isMessageReceived": "Yes" }'
     ```


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

I tried the pattern and  works good.

One thing I noticed. This pattern uses the [aws_api_gateway_rest_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_rest_api) resource in Terraform, but the README mentions `API Gateway HTTP APIs`. As you may know, Amazon API Gateway provides [two types](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-vs-rest.html). This pattern is actually using **REST APIs**, not HTTP APIs.

It might be better to clarify this in the README to avoid confusion.
Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.