### PR TITLE
apigw-data-validation-tf: Update AWS provider and remove duplicate body validation resource

### DIFF
--- a/apigw-data-validation-tf/main.tf
+++ b/apigw-data-validation-tf/main.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
     archive = {
       source  = "hashicorp/archive"
@@ -31,38 +31,6 @@ data "archive_file" "lambda_zip" {
 resource "aws_api_gateway_rest_api" "main_api" {
   name = "validation-api"
   description = "API Gateway with data validation"
-
-  body = jsonencode({
-    openapi = "3.0.1"
-    info = {
-      title = "validation-api"
-      version = "1.0"
-    }
-    components = {
-      schemas = {
-        Vehicle = {
-          type = "object"
-          required = ["make", "model", "year"]
-          properties = {
-            make = {
-              type = "string"
-            }
-            model = {
-              type = "string"
-            }
-            year = {
-              type = "integer"
-              minimum = 2010
-            }
-            color = {
-              type = "string"
-              enum = ["green", "red", "blue"]
-            }
-          }
-        }
-      }
-    }
-  })
 }
 
 # Lambda Function


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
While trying to deploy the `apigw-data-validation-tf` sample, I've noticed that the Lambda Runtime has been updated to Python 3.13, but the Terraform AWS provider has been pinned to the `4.x` version. Python 3.13 is not a valid value for this older runtime, and this makes Terraform reject and fail. I've updated it to `5.x`. 

It also did not deploy because the `Model` resource was declared both in the OpenAPI body of the REST API as well as its own Terraform resource, leading to an exception:
```bash
╷
│ Error: creating API Gateway Model (Vehicle): operation error API Gateway: CreateModel, https response error StatusCode: 409, RequestID: c2af2518-04d1-4455-baf7-b53fc718c8ac, ConflictException: Model name already exists for this REST API
│ 
│   with aws_api_gateway_model.vehicle_model,
│   on main.tf line 142, in resource "aws_api_gateway_model" "vehicle_model":
│  142: resource "aws_api_gateway_model" "vehicle_model" {
│ 
╵
```

So I've deleted the OpenAPI body to make sure the `Model` was declared in Terraform and could be accessed in the `aws_api_gateway_method`. 

The sample now deploys correctly against AWS. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
