### PR TITLE
alb-lambda-terraform: Update runtime to nodejs22.x

### DIFF
--- a/alb-lambda-terraform/main.tf
+++ b/alb-lambda-terraform/main.tf
@@ -172,6 +172,7 @@ resource "aws_lb_target_group" "target_group" {
 resource "aws_lb_target_group_attachment" "target_group_attachment" {
   target_group_arn = aws_lb_target_group.target_group.arn
   target_id        = aws_lambda_function.lambda_function.arn
+  depends_on       = [aws_lambda_permission.with_lb]
 }
 
 # Create the Lambda Function

--- a/alb-lambda-terraform/main.tf
+++ b/alb-lambda-terraform/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~>4.52.0"
+      version = "~> 5.0"
     }
   }
 
@@ -177,7 +177,7 @@ resource "aws_lb_target_group_attachment" "target_group_attachment" {
 # Create the Lambda Function
 resource "aws_lambda_function" "lambda_function" {
   function_name = "lambdaFunction"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs22.x"
   handler       = "index.handler"
   filename      = "lambda.zip"
   role          = aws_iam_role.lambda_role.arn


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

To prevent future deployment issues, I updated the Lambda Node.js runtime version to `nodejs22.x`.

While testing `alb-lambda-terraform`, I noticed that the Lambda runtime version `nodejs16.x` was deprecated. Although it's still deployable at the moment, it will not be allowed after **October 1, 2025**.
https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

## Check

`terraform apply` completed successfully and works good.

```sh
$ curl http://myLoadBalancer-1909689483.us-east-1.elb.amazonaws.com
"Hello World!"%
```

Thank you😀

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.