### PR TITLE
lambda-sns-terraform: Update runtime to nodejs22.x

### DIFF
--- a/lambda-sns-terraform/.gitignore
+++ b/lambda-sns-terraform/.gitignore
@@ -1,0 +1,1 @@
+lambda.zip

--- a/lambda-sns-terraform/main.tf
+++ b/lambda-sns-terraform/main.tf
@@ -41,11 +41,7 @@ data "aws_iam_policy" "lambda_basic_execution_role_policy" {
 }
 
 resource "aws_iam_role" "lambda_iam_role" {
-  name_prefix         = "LambdaSNSRole-"
-  managed_policy_arns = [
-    data.aws_iam_policy.lambda_basic_execution_role_policy.arn,
-    aws_iam_policy.lambda_policy.arn
-  ]
+  name_prefix = "LambdaSNSRole-"
 
   assume_role_policy = <<EOF
 {
@@ -64,11 +60,21 @@ resource "aws_iam_role" "lambda_iam_role" {
 EOF
 }
 
+resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
+  role       = aws_iam_role.lambda_iam_role.name
+  policy_arn = data.aws_iam_policy.lambda_basic_execution_role_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_sqs" {
+  role       = aws_iam_role.lambda_iam_role.name
+  policy_arn = aws_iam_policy.lambda_policy.arn
+}
+
 data "aws_iam_policy_document" "lambda_policy_document" {
   statement {
-  
+
     effect = "Allow"
-  
+
     actions = [
       "sns:Publish"
     ]

--- a/lambda-sns-terraform/main.tf
+++ b/lambda-sns-terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.22"
+      version = "~> 5.0"
     }
   }
 
@@ -22,7 +22,7 @@ resource "aws_lambda_function" "lambda_function" {
   source_code_hash = data.archive_file.lambda_zip_file.output_base64sha256
   handler          = "app.handler"
   role             = aws_iam_role.lambda_iam_role.arn
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs22.x"
   environment {
     variables = {
       SNStopic = aws_sns_topic.sns_topic.arn

--- a/lambda-sns-terraform/src/app.js
+++ b/lambda-sns-terraform/src/app.js
@@ -2,9 +2,11 @@
  *  SPDX-License-Identifier: MIT-0
  */
 
-const AWS = require('aws-sdk')
-AWS.config.region = process.env.AWS_REGION 
-const sns = new AWS.SNS({apiVersion: '2012-11-05'})
+const { SNSClient, PublishCommand } = require('@aws-sdk/client-sns')
+
+const snsClient = new SNSClient({
+  region: process.env.AWS_REGION
+})
 
 // The Lambda handler
 exports.handler = async (event) => {
@@ -16,6 +18,6 @@ exports.handler = async (event) => {
   }
   
   // Send to SNS
-  const result = await sns.publish(params).promise()
+  const result = await snsClient.send(new PublishCommand(params))
   console.log(result)
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

To prevent future deployment issues, I updated the Lambda Node.js runtime version to `nodejs22.x`.

While testing `lambda-sns-terraform`, I noticed that the Lambda runtime version `nodejs16.x` was deprecated. Although it's still deployable at the moment, it will not be allowed after **October 1, 2025**.
https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

## Check

`terraform apply` completed successfully and works good.

```sh
$ aws lambda invoke --function-name TopicPublisherFunction response.json
{
    "StatusCode": 200,
    "ExecutedVersion": "$LATEST"
}
```

Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.