### PR TITLE
terraform-s3-object-lambda: Update runtime to nodejs22.x

### DIFF
--- a/terraform-s3-object-lambda/README.md
+++ b/terraform-s3-object-lambda/README.md
@@ -28,6 +28,8 @@ aws s3 cp ./images/sample.jpg s3://<bucket-name>
 Download a thumbnail version of the uploaded image from the S3 Object Lambda Access Point using this command (replace `<lambda-access-point>` with the value returned in `s3_lambda_access_point`):
 
 ```shell
+mkdir ./thumbs
+
 aws s3api get-object --bucket <lambda-access-point> --key sample.jpg ./thumbs/sample-thumbnail.jpg
 
 open ./thumbs/sample-thumbnail.jpg

--- a/terraform-s3-object-lambda/main.tf
+++ b/terraform-s3-object-lambda/main.tf
@@ -19,7 +19,7 @@ module "lambda_function" {
   function_name = "${random_pet.this.id}-lambda"
   description   = "My awesome lambda function"
   handler       = "app.handler"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs22.x"
   publish       = true
 
   architectures = ["arm64"] # Set to "arm64" if you are running this from ARM, else use "x86_64"

--- a/terraform-s3-object-lambda/src/app.js
+++ b/terraform-s3-object-lambda/src/app.js
@@ -2,11 +2,11 @@
  *  SPDX-License-Identifier: MIT-0
  */
 
-const { S3 } = require("aws-sdk");
+const { S3Client, WriteGetObjectResponseCommand } = require("@aws-sdk/client-s3");
 const axios = require("axios").default;  // Promise-based HTTP requests
 const sharp = require("sharp"); // Used for image resizing
 
-const s3 = new S3();
+const s3 = new S3Client();
 
 exports.handler = async (event) => {
   // Output the event details to CloudWatch Logs.
@@ -30,9 +30,9 @@ exports.handler = async (event) => {
   const params = {
     RequestRoute: outputRoute,
     RequestToken: outputToken,
-    Body: resized,
+    Body: await resized.toBuffer(),
   };
-  await s3.writeGetObjectResponse(params).promise();
+  await s3.send(new WriteGetObjectResponseCommand(params));
 
   // Exit the Lambda function.
   return { statusCode: 200 };


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

To prevent future deployment issues, I updated the Lambda Node.js runtime version to `nodejs22.x`.

While testing `terraform-s3-object-lambda`, I noticed that the Lambda runtime version `nodejs16.x` was deprecated. Although it's still deployable at the moment, it will not be allowed after **October 1, 2025**.
https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

## Check

`terraform apply` completed successfully and works good.

```sh
$ aws s3 cp ./images/sample.jpg s3://decent-raccoon-bucket --region eu-west-1
upload: images/sample.jpg to s3://decent-raccoon-bucket/sample.jpg

$ mkdir ./thumbs

$ aws s3api get-object --bucket resize-olap-i4x6dzs1zybd5unxx14qx7freuw1a--ol-s3 --key sample.jpg ./thumbs/sample-thumbnail.jpg --region eu-west-1
{
    "ContentLength": 31891,
    "ContentType": "text/plain",
    "Metadata": {}
}
```

<img width="100" height="100" alt="image" src="https://github.com/user-attachments/assets/c0ec5b0e-58a2-4d42-a109-42d0d5c33c24" />

Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.