### PR TITLE
eventbridge-lambda-terraform: Update runtime to nodejs22.x

### DIFF
--- a/eventbridge-lambda-terraform/.gitignore
+++ b/eventbridge-lambda-terraform/.gitignore
@@ -1,0 +1,1 @@
+lambda.zip

--- a/eventbridge-lambda-terraform/main.tf
+++ b/eventbridge-lambda-terraform/main.tf
@@ -35,7 +35,6 @@ data "aws_iam_policy" "lambda_basic_execution_role_policy" {
 
 resource "aws_iam_role" "lambda_iam_role" {
   name_prefix         = "EventBridgeLambdaRole-"
-  managed_policy_arns = [data.aws_iam_policy.lambda_basic_execution_role_policy.arn]
 
   assume_role_policy = <<EOF
 {
@@ -52,6 +51,11 @@ resource "aws_iam_role" "lambda_iam_role" {
   ]
 }
 EOF
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
+  role       = aws_iam_role.lambda_iam_role.name
+  policy_arn = data.aws_iam_policy.lambda_basic_execution_role_policy.arn
 }
 
 resource "aws_cloudwatch_event_rule" "event_rule" {

--- a/eventbridge-lambda-terraform/main.tf
+++ b/eventbridge-lambda-terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
 	aws = {
 	  source  = "hashicorp/aws"
-	  version = "~> 4.22"
+	  version = "~> 5.0"
 	}
   }
 
@@ -20,7 +20,7 @@ resource "aws_lambda_function" "lambda_function" {
   source_code_hash = data.archive_file.lambda_zip_file.output_base64sha256
   handler          = "app.handler"
   role             = aws_iam_role.lambda_iam_role.arn
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs22.x"
 }
 
 data "archive_file" "lambda_zip_file" {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

To prevent future deployment issues, I updated the Lambda Node.js runtime version to `nodejs22.x`.

While testing `eventbridge-lambda-terraform`, I noticed that the Lambda runtime version `nodejs16.x` was deprecated. Although it's still deployable at the moment, it will not be allowed after **October 1, 2025**.
https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

## Check

`terraform apply` completed successfully and works good.

```sh
$ aws events put-events --entries file://event.json --region us-east-1
{
    "FailedEntryCount": 0,
    "Entries": [
        {
            "EventId": "d51b5dd2-c12f-70f1-cd71-fc0ab611cbf1"
        }
    ]
}
```

<img width="1677" height="428" alt="image" src="https://github.com/user-attachments/assets/9143203c-9d19-438c-8738-5ca34547ca68" />

Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.