### PR TITLE
lambda-eventbridge-terraform: Update runtime to nodejs22.x

### DIFF
--- a/lambda-eventbridge-terraform/.gitignore
+++ b/lambda-eventbridge-terraform/.gitignore
@@ -1,0 +1,1 @@
+lambda.zip

--- a/lambda-eventbridge-terraform/main.tf
+++ b/lambda-eventbridge-terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.22"
+      version = "~> 5.0"
     }
   }
 
@@ -29,7 +29,7 @@ resource "aws_lambda_function" "publisher_function" {
   source_code_hash = data.archive_file.lambda_zip_file.output_base64sha256
   handler          = "app.handler"
   role             = aws_iam_role.iam_for_lambda.arn
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs22.x"
 }
 
 data "archive_file" "lambda_zip_file" {

--- a/lambda-eventbridge-terraform/main.tf
+++ b/lambda-eventbridge-terraform/main.tf
@@ -43,11 +43,7 @@ data "aws_iam_policy" "lambda_basic_execution_role_policy" {
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
-  name_prefix         = "PublisherFunctionRole-"
-  managed_policy_arns = [
-    data.aws_iam_policy.lambda_basic_execution_role_policy.arn,
-    aws_iam_policy.event_bridge_put_events_policy.arn
-  ]
+  name_prefix = "PublisherFunctionRole-"
 
   assume_role_policy = <<EOF
 {
@@ -64,6 +60,16 @@ resource "aws_iam_role" "iam_for_lambda" {
   ]
 }
 EOF
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
+  role       = aws_iam_role.iam_for_lambda.name
+  policy_arn = data.aws_iam_policy.lambda_basic_execution_role_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_eventbridge" {
+  role       = aws_iam_role.iam_for_lambda.name
+  policy_arn = aws_iam_policy.event_bridge_put_events_policy.arn
 }
 
 data "aws_iam_policy_document" "event_bridge_put_events_policy_document" {

--- a/lambda-eventbridge-terraform/src/app.js
+++ b/lambda-eventbridge-terraform/src/app.js
@@ -4,9 +4,8 @@
 
 'use strict'
 
-const AWS = require('aws-sdk')
-AWS.config.update({ region: process.env.AWS_REGION })
-const eventbridge = new AWS.EventBridge()
+const { EventBridgeClient, PutEventsCommand } = require('@aws-sdk/client-eventbridge')
+const eventbridge = new EventBridgeClient({ region: process.env.AWS_REGION })
 
 exports.handler = async (event) => {
   const params = {
@@ -23,7 +22,8 @@ exports.handler = async (event) => {
       }
     ]
   }
+
   // Publish to EventBridge
-  const result = await eventbridge.putEvents(params).promise()
+  const result = await eventbridge.send(new PutEventsCommand(params))
   console.log(result)
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

To prevent future deployment issues, I updated the Lambda Node.js runtime version to `nodejs22.x`.

While testing `lambda-eventbridge-terraform`, I noticed that the Lambda runtime version `nodejs16.x` was deprecated. Although it's still deployable at the moment, it will not be allowed after **October 1, 2025**.
https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

## Check

`terraform apply` completed successfully and works good.

```sh
$ aws lambda invoke --function-name PublisherFunction response.json --region us-east-1
{
    "StatusCode": 200,
    "ExecutedVersion": "$LATEST"
}
```

<img width="1652" height="423" alt="image" src="https://github.com/user-attachments/assets/270ab97f-41ab-400d-a98b-1f7d114ae47f" />

Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.