### PR TITLE
s3-lambda-terraform: Update runtime to nodejs22.x

### DIFF
--- a/s3-lambda-terraform/.gitignore
+++ b/s3-lambda-terraform/.gitignore
@@ -1,0 +1,1 @@
+lambda.zip

--- a/s3-lambda-terraform/README.md
+++ b/s3-lambda-terraform/README.md
@@ -1,4 +1,4 @@
-# AWS S3 to AWS Lambda
+# Amazon S3 to AWS Lambda
 
 The Terraform template deploys a Lambda function, an S3 bucket and the IAM resources required to run the application. A Lambda function consumes <code>ObjectCreated</code> events from an Amazon S3 bucket. The Lambda code checks the uploaded file and console log the event.
 
@@ -57,7 +57,7 @@ After deployment, upload an object to the S3. Go to the CloudWatch Logs for the 
     ```bash
     terraform show
     ```
-    ```
+
 ----
 Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 

--- a/s3-lambda-terraform/main.tf
+++ b/s3-lambda-terraform/main.tf
@@ -59,9 +59,13 @@ resource "aws_iam_role" "iam_for_lambda" {
   ]
 }
 EOF
-  inline_policy {
-    name   = "lambda_logs_policy"
-    policy = <<EOF
+}
+
+resource "aws_iam_role_policy" "lambda_logs" {
+  name = "lambda_logs_policy"
+  role = aws_iam_role.iam_for_lambda.id
+
+  policy = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -78,7 +82,6 @@ EOF
   ]
 }
 EOF
-  }
 }
 
 resource "aws_lambda_permission" "allow_bucket_invoke_lambda" {

--- a/s3-lambda-terraform/main.tf
+++ b/s3-lambda-terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.27"
+      version = "~> 5.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -32,7 +32,7 @@ resource "aws_lambda_function" "lambda_s3_handler" {
   source_code_hash = data.archive_file.lambda_zip_file.output_base64sha256
   handler          = "index.handler"
   role             = aws_iam_role.iam_for_lambda.arn
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs22.x"
 }
 
 data "archive_file" "lambda_zip_file" {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

To prevent future deployment issues, I updated the Lambda Node.js runtime version to `nodejs22.x`.

While testing `s3-lambda-terraform`, I noticed that the Lambda runtime version `nodejs16.x` was deprecated. Although it's still deployable at the moment, it will not be allowed after **October 1, 2025**.
https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

## Check

`terraform apply` completed successfully and works good.

<img width="1920" height="1192" alt="image" src="https://github.com/user-attachments/assets/595ab0a4-a425-4d20-9201-bbe2927ed96a" />

Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.