### PR TITLE
kinesis-lambda-terraform: Update runtime to nodejs22.x

### DIFF
--- a/kinesis-lambda-terraform/.gitignore
+++ b/kinesis-lambda-terraform/.gitignore
@@ -1,0 +1,1 @@
+lambda.zip

--- a/kinesis-lambda-terraform/README.md
+++ b/kinesis-lambda-terraform/README.md
@@ -1,6 +1,6 @@
-# AWS Kinesis Data Streams to AWS Lambda
+# Amazon Kinesis Data Streams to AWS Lambda
 
-This pattern creates an AWS Kinesis Data Stream, a stream consumer, and an AWS Lambda function. When data is added to the stream, the Lambda function is invoked.
+This pattern creates an AWS Kinesis Data Streams, a stream consumer, and an AWS Lambda function. When data is added to the stream, the Lambda function is invoked.
 
 Learn more about this pattern at Serverless Land Patterns: [https://serverlessland.com/patterns/kinesis-to-lambda-terraform](https://serverlessland.com/patterns/kinesis-to-lambda-terraform)
 

--- a/kinesis-lambda-terraform/main.tf
+++ b/kinesis-lambda-terraform/main.tf
@@ -48,6 +48,44 @@ resource "aws_iam_role" "lambda_role" {
   })
 }
 
+resource "aws_iam_policy" "lambda_kinesis_policy" {
+  name = "lambda-kinesis-policy"
+
+  policy = jsonencode(
+    {
+      Version = "2012-10-17",
+      Statement = [
+        {
+          Effect = "Allow",
+          Action = [
+            "kinesis:GetRecords",
+            "kinesis:GetShardIterator",
+            "kinesis:DescribeStream",
+            "kinesis:DescribeStreamSummary",
+            "kinesis:ListShards",
+            "kinesis:ListStreams"
+          ],
+          Resource = aws_kinesis_stream.sample_stream.arn
+        },
+        {
+          Effect = "Allow",
+          Action = [
+            "logs:CreateLogGroup",
+            "logs:CreateLogStream",
+            "logs:PutLogEvents"
+          ],
+          Resource = "arn:aws:logs:*:*:*"
+        }
+      ]
+    }
+  )
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_kinesis_policy_attachment" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = aws_iam_policy.lambda_kinesis_policy.arn
+}
+
 resource "aws_lambda_event_source_mapping" "sample_mapping" {
   event_source_arn = aws_kinesis_stream.sample_stream.arn
   function_name    = aws_lambda_function.sample_lambda.arn

--- a/kinesis-lambda-terraform/main.tf
+++ b/kinesis-lambda-terraform/main.tf
@@ -52,6 +52,6 @@ output "kinesis_data_stream" {
 }
 
 output "consumer_function" {
-  value = aws_lambda_function.sample_function.arn
+  value = aws_lambda_function.sample_lambda.arn
   description = "Consumer Function function name"
 }

--- a/kinesis-lambda-terraform/main.tf
+++ b/kinesis-lambda-terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.22"
+      version = "~> 5.0"
     }
   }
 
@@ -22,7 +22,7 @@ resource "aws_lambda_function" "sample_lambda" {
   function_name    = "sample-lambda"
   role             = aws_iam_role.lambda_role.arn
   handler          = "index.handler"
-  runtime          = "nodejs16.x"  # Change to your preferred runtime
+  runtime          = "nodejs22.x"  # Change to your preferred runtime
 }
 resource "aws_iam_role" "lambda_role" {
   name = "lambda-role"

--- a/kinesis-lambda-terraform/main.tf
+++ b/kinesis-lambda-terraform/main.tf
@@ -17,11 +17,19 @@ resource "aws_kinesis_stream" "sample_stream" {
   shard_count      = 1
   retention_period = 24
 }
+
+data "archive_file" "lambda_zip_file" {
+  type        = "zip"
+  source_file = "${path.module}/src/app.js"
+  output_path = "${path.module}/lambda.zip"
+}
+
 resource "aws_lambda_function" "sample_lambda" {
-  filename         = "sample_lambda.zip"  # Path to your Lambda code ZIP file
+  filename         = data.archive_file.lambda_zip_file.output_path
+  source_code_hash = data.archive_file.lambda_zip_file.output_base64sha256
   function_name    = "sample-lambda"
   role             = aws_iam_role.lambda_role.arn
-  handler          = "index.handler"
+  handler          = "app.handler"
   runtime          = "nodejs22.x"  # Change to your preferred runtime
 }
 resource "aws_iam_role" "lambda_role" {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

To prevent future deployment issues, I updated the Lambda Node.js runtime version to `nodejs22.x`.

While testing `kinesis-lambda-terraform`, I noticed that the Lambda runtime version `nodejs16.x` was deprecated.
https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

## Check

`terraform apply` completed successfully and works good.

<img width="2928" height="638" alt="image" src="https://github.com/user-attachments/assets/0068ca36-4a65-45bc-a629-ce26a1f5368d" />

Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.