### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -1,4 +1,6 @@
 name: "Schema Validation"
+permissions:
+  contents: read
 
 on: [pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/aws-samples/serverless-patterns/security/code-scanning/6](https://github.com/aws-samples/serverless-patterns/security/code-scanning/6)

To fix this problem, a `permissions` block should be added to limit the permissions of the `GITHUB_TOKEN` to the minimum necessary for the workflow's operation. In this particular workflow, the job does not write to the repository or interact with issues or pull requests; it simply checks out code, installs dependencies, determines changed files, and runs a validation script. Therefore, the job only needs read-only access to repository contents.

The best and most minimal fix is to add `permissions: { contents: read }` at either the top level of the workflow (so it applies to all jobs) or specifically under the `validate-pattern` job. To maintain clarity, adding it at the top level (right after the `name:` block) is preferable and idiomatic for a single-job workflow. No changes are needed to imports, methods, or definitions: the change is isolated to a single YAML line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
