### PR TITLE
apigw-lambda-bedrock-sam: Update runtime to python3.13

### DIFF
--- a/apigw-lambda-bedrock-sam/template.yaml
+++ b/apigw-lambda-bedrock-sam/template.yaml
@@ -18,7 +18,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: bedrock_integration.lambda_handler
-      Runtime: python3.9
+      Runtime: python3.13
       Architectures:
         - arm64
       Policies:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

To prevent future deployment issues, I updated the Lambda runtime `python3.9` to `python3.13`.
The `python3.9` runtime is scheduled to be deprecated in December.
See https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

## Check

`sam deploy` completed successfully and works good.

```sh
$ curl -d '{"prompt": "Please write 5 lines on Solar Systems"}' -H 'Content-Type: application/json' https://azqggdherf.execute-api.ap-northeast-1.amazonaws.com/dev/generate_content/
{"generated-text": {"completion": "Here are 5 lines on Solar Systems:\n\n1. A solar system is a collection of celestial bodies orbiting a central star, held together by gravity.\n\n2. Our Solar System consists of the Sun, eight planets, dwarf planets, moons, asteroids, comets, and other small bodies.\n\n3. Solar systems can vary greatly in size, composition, and structure, with some containing multiple stars or different types of planets.\n\n4. The formation of a solar system typically begins with the collapse of a giant molecular cloud of gas and dust in space.\n\n5. Studying other solar systems helps astronomers better understand the formation and evolution of our own, as well as the potential for life elsewhere in the universe.", "stop_reason": "end_turn"}}%
```

Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.