### PR TITLE
apigw-lambda-rekognition: Update for "Error: Unsupported argument"

### DIFF
--- a/apigw-lambda-rekognition/README.md
+++ b/apigw-lambda-rekognition/README.md
@@ -48,10 +48,10 @@ Important: this application uses various AWS services and there are costs associ
 1. Make a POST request to the API using the following cURL command:
 
     ```
-    curl --location 'https://<api-id>.execute-api.<region>.amazonaws.com/dev/generate-presigned-url' --header 'Content-Type: text/plain' --data '{"object_name": "image.png", "content_type": "image/png"}'
+    curl --location "$(terraform output -raw api_gateway_endpoint_url)" --header 'Content-Type: text/plain' --data '{"object_name": "image.png", "content_type": "image/png"}'
     ```
 
-    Note: Replace 'api-id' with the generated API ID from Terraform, 'region' with the region where the API is deployed (refer to the Terraform Outputs section) 'object_name' with your desired name for the S3 object and 'content_type' with the content type of the image, for ex, png or jpeg
+    Note: Replace 'object_name' with your desired name for the S3 object and 'content_type' with the content type of the image, for ex, png or jpeg
 
 1. Get the pre-signed URL from the previous step and use the following cURL command to upload the object in S3:
 

--- a/apigw-lambda-rekognition/main.tf
+++ b/apigw-lambda-rekognition/main.tf
@@ -187,3 +187,7 @@ output "lambda_process_s3_event_log_group" {
   description = "The name of the CloudWatch log group for the process_s3_event Lambda function"
   value       = aws_cloudwatch_log_group.lambda_log_group[1].name
 }
+output "api_gateway_endpoint_url" {
+  description = "The URL of the API Gateway endpoint for generating presigned URLs"
+  value       = "${aws_api_gateway_stage.stage.invoke_url}/${aws_api_gateway_resource.resource.path_part}"
+}


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

While testing `apigw-lambda-rekognition`, I noticed that the `Error: Unsupported argument` error occurred. Because [aws_api_gateway_deployment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_deployment) does NOT have `stage_name` argument in latest Terraform AWS Provider. We should use [aws_api_gateway_stage](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_stage).

```
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 148, in resource "aws_api_gateway_deployment" "deployment":
│  148:   stage_name  = "dev"
│ 
│ An argument named "stage_name" is not expected here.
╵
```

## Check

```sh
$ curl --location 'https://6rylrmtfw6.execute-api.ap-northeast-1.amazonaws.com/dev/generate-presigned-url' --header 'Content-Type: text/plain' --data '{"object_name": "image.png", "content_type": "image/png"}'
{"presigned_url": "https://s3.ap-northeast-1.amazonaws.com/xxxxxxxxxxx&Expires=1766540977"}%

$ curl -v --location --request PUT 'https://s3.ap-northeast-1.amazonaws.com/xxxxxxxxxxx&Expires=1766540977' --header 'Content-Type: image/png' --data 'image.png'
* Host s3.ap-northeast-1.amazonaws.com:443 was resolved.
(snip)
< HTTP/1.1 200 OK
(snip)
```

And more the `generate-presigned-url` Lambda function call Amazon Rekognition correctly.

<img width="3420" height="592" alt="image" src="https://github.com/user-attachments/assets/124e8e5d-4248-4941-9ab2-1f37e7418f57" />

Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.