### PR TITLE
terraform-sqs-lambda: Update AWS Lambda Terraform module for Python 3.14

### DIFF
--- a/terraform-sqs-lambda/main.tf
+++ b/terraform-sqs-lambda/main.tf
@@ -8,7 +8,7 @@ provider "aws" {
 
 module "lambda_function" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "~> 4.0"
+  version = "~> 8.0"
 
   function_name = "${random_pet.this.id}-lambda"
   description   = "My awesome lambda function"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

This commit forces the Lambda Python runtime to 3.14, but it seems the update was made without verifying that it actually works.

- https://github.com/aws-samples/serverless-patterns/commit/795504a01d32ccb2a35465f5f10072bd4143932e

As a result, I get the following error:

```
╷
│ Error: expected runtime to be one of ["nodejs" "nodejs4.3" "nodejs6.10" "nodejs8.10" "nodejs10.x" "nodejs12.x" "nodejs14.x" "nodejs16.x" "java8" "java8.al2" "java11" "python2.7" "python3.6" "python3.7" "python3.8" "python3.9" "dotnetcore1.0" "dotnetcore2.0" "dotnetcore2.1" "dotnetcore3.1" "dotnet6" "dotnet8" "nodejs4.3-edge" "go1.x" "ruby2.5" "ruby2.7" "provided" "provided.al2" "nodejs18.x" "python3.10" "java17" "ruby3.2" "ruby3.3" "ruby3.4" "python3.11" "nodejs20.x" "provided.al2023" "python3.12" "java21" "python3.13" "nodejs22.x"], got python3.14
│ 
│   with module.lambda_function.aws_lambda_function.this[0],
│   on .terraform/modules/lambda_function/main.tf line 33, in resource "aws_lambda_function" "this":
│   33:   runtime                            = var.package_type != "Zip" ? null : var.runtime
│ 
╵
```

So I fixed it.

## Check

```sh
$ terraform apply

Apply complete! Resources: 5 added, 0 changed, 1 destroyed.

$ aws sqs send-message --queue-url https://sqs.eu-west-1.amazonaws.com/000000000000/brief-mule --message-body "Test message" --region eu-west-1
{
    "MD5OfMessageBody": "82dfa5549ebc9afc168eb7931ebece5f",
    "MessageId": "84233713-e129-45cb-9e4b-678cc0467ee4"
}
```

<img width="3420" height="1042" alt="image" src="https://github.com/user-attachments/assets/86ca1419-b84d-46eb-83f7-11656534d699" />

Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.