### PR TITLE
lambda-sqs-terraform: Update AWS Provider to v6 for nodejs24.x

### DIFF
--- a/lambda-sqs-terraform/main.tf
+++ b/lambda-sqs-terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

This commit forces the Lambda nodejs24.x runtime, but it seems the update was made without verifying that it actually works.

- https://github.com/aws-samples/serverless-patterns/commit/44b98a0060a5164376764241ec3dbd63e0b2c987

As a result, I get the following error:

```
╷
│ Error: expected runtime to be one of ["nodejs" "nodejs4.3" "nodejs6.10" "nodejs8.10" "nodejs10.x" "nodejs12.x" "nodejs14.x" "nodejs16.x" "java8" "java8.al2" "java11" "python2.7" "python3.6" "python3.7" "python3.8" "python3.9" "dotnetcore1.0" "dotnetcore2.0" "dotnetcore2.1" "dotnetcore3.1" "dotnet6" "dotnet8" "nodejs4.3-edge" "go1.x" "ruby2.5" "ruby2.7" "provided" "provided.al2" "nodejs18.x" "python3.10" "java17" "ruby3.2" "ruby3.3" "ruby3.4" "python3.11" "nodejs20.x" "provided.al2023" "python3.12" "java21" "python3.13" "nodejs22.x"], got nodejs24.x
│ 
│   with aws_lambda_function.lambda_function,
│   on main.tf line 25, in resource "aws_lambda_function" "lambda_function":
│   25:   runtime          = "nodejs24.x"
│ 
╵
```

So I fixed it.

## Check

`terraform apply` completed successfully and works good.

```sh
$ aws lambda invoke --function-name QueuePublisherFunction response.json --region us-east-1
$ aws sqs receive-message --queue-url https://sqs.us-east-1.amazonaws.com/000000000000/terraform-20260113135716734100000003 --region us-east-1
{
    "Messages": [
        {
            "MessageId": "e6d6b936-ea9d-4f4f-af7c-8e1f35ee303a",
            "ReceiptHandle": "AQEB7d3dk8SiH3h29hOIlvWIfqHHJcDgcTvf9JqvxocSjf/4KWgCPlaVXZ7IddmoymWdrCoTvOIWXQvQQJEC3tqNJCxD4GkVONfoblOQ/myUdJMOpFYYia06xMBsfuRBad5bzo9TC9bW7uHU+QU4TzWbQTK97yLZRkBsFGOqaRVCR4tyS2fipMnU2wyRVVc5rWiWneA7mVCLMtIwJbFff2aRSoVb3CA0DZ7/qHPZ/1khWcBq0buYU1NaUAQL59e3KcrPaNNHLCLNjFlsYOi0xElLm5WG93oK71Pnu+x+hGAvT/udElZq76ufOEIWjS6MysizsNw0aEiE8rayV5R+61WyRgQRP6dcVgo0TteDRbBU5QdnTyD/sPuhtK9wIUWx7JkRJxYElfAXNTK1+bi2LShnQXKSzfALxE9Fdb+ZxyXmyKs=",
            "MD5OfBody": "140a512452e7463e71199303a7df401b",
            "Body": "Message at Tue Jan 13 2026 13:59:11 GMT+0000 (Coordinated Universal Time)"
        }
    ]
}
```

Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.