### PR TITLE
eventbridge-schedule-to-cloudwatch-terraform: Fix deprecated `managed_policy_arns` argument

### DIFF
--- a/eventbridge-schedule-to-cloudwatch-terraform/main.tf
+++ b/eventbridge-schedule-to-cloudwatch-terraform/main.tf
@@ -18,8 +18,6 @@ provider "aws" {
 
 data "aws_caller_identity" "current" {}
 
-
-
 # This section creates cron schedules using Amazon EventBridge Scheduler, as well as the required IAM roles to interact with CloudWatch
 
 resource "aws_scheduler_schedule" "cloudwatch-schedule" {
@@ -55,7 +53,6 @@ resource "aws_scheduler_schedule" "cloudwatch-schedule" {
   }
 }
 
-
 resource "aws_iam_policy" "scheduler_cloudwatch_policy" {
   name = "scheduler_cloudwatch_policy"
 
@@ -77,7 +74,6 @@ resource "aws_iam_policy" "scheduler_cloudwatch_policy" {
 
 resource "aws_iam_role" "scheduler-cloudwatch-role" {
   name = "scheduler-cloudwatch-role"
-  managed_policy_arns = [aws_iam_policy.scheduler_cloudwatch_policy.arn]
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -92,4 +88,9 @@ resource "aws_iam_role" "scheduler-cloudwatch-role" {
       },
     ]
   })
+}
+
+resource "aws_iam_role_policy_attachment" "scheduler_cloudwatch_attachment" {
+  role       = aws_iam_role.scheduler-cloudwatch-role.name
+  policy_arn = aws_iam_policy.scheduler_cloudwatch_policy.arn
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

While testing **eventbridge-schedule-to-cloudwatch-terraform**, I noticed that the `managed_policy_arns` argument is already deprecated. And I fixed it.

>"managed_policy_arns" is deprecated

## Check

`terraform apply` completed successfully and it works good.

<img width="1920" height="653" alt="image" src="https://github.com/user-attachments/assets/a97b9252-dd60-469d-ba83-83dc55031817" />

Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.