### PR TITLE
eventbridge-schedule-to-ec2-terraform: Fix "Most Recent Image Not Filtered" error

### DIFF
--- a/eventbridge-schedule-to-ec2-terraform/main.tf
+++ b/eventbridge-schedule-to-ec2-terraform/main.tf
@@ -34,14 +34,10 @@ resource "aws_subnet" "subnet" {
 
 data "aws_ami" "amazon-linux-2" {
   most_recent = true
+  owners      = ["amazon"]
 
   filter {
-    name = "owner-alias"
-    values = ["amazon"]
-  }
-  
-  filter {
-    name = "name"
+    name   = "name"
     values = ["amzn2-ami-hvm*"]
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

While testing **eventbridge-schedule-to-ec2-terraform**, I occurred `Most Recent Image Not Filtered` error. And more I noticed that the `managed_policy_arns` argument is already deprecated.

```
╷
│ Error: Most Recent Image Not Filtered
│ 
│   with data.aws_ami.amazon-linux-2,
│   on main.tf line 35, in data "aws_ami" "amazon-linux-2":
│   35: data "aws_ami" "amazon-linux-2" {
│ 
│ "most_recent" is set to "true" and results are not filtered by owner or image ID. With this configuration, a third party may introduce a new image which will be returned by this data source. Filter by owner or image
│ ID to avoid this possibility.
╵
```

```
"managed_policy_arns" is deprecated
```

## Check

`terraform apply` completed successfully and it works good with updating cron schedule for quick testing.

<img width="3420" height="650" alt="image" src="https://github.com/user-attachments/assets/b97c22b3-96af-49ba-883e-5d7585abd196" />

<img width="3420" height="650" alt="image" src="https://github.com/user-attachments/assets/181dbf7e-4560-4b84-9ffd-9cfb481f8144" />

Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.