### PR TITLE
lambda-durable-scheduled-tasks-sam: Fix empty taskId in async API Gateway response

### DIFF
--- a/lambda-durable-scheduled-tasks-sam/template.yaml
+++ b/lambda-durable-scheduled-tasks-sam/template.yaml
@@ -145,8 +145,9 @@ Resources:
                     statusCode: 202
                     responseTemplates:
                       application/json: |
+                        #set($taskId = "TASK-$context.requestTimeEpoch")
                         {
-                          "taskId": "$input.path('$.taskId')",
+                          "taskId": "$taskId",
                           "status": "INITIALIZED",
                           "message": "Task started successfully"
                         }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

While testing **lambda-durable-scheduled-tasks-sam**, the API response returns blank `taskId`. Because Lambda functions with asynchronous invoke does not return response directly.
https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-integration-async.html

```sh
$ curl -X POST ${API_ENDPOINT}/tasks \
  -H "Content-Type: application/json" \
  -d '{
    "config": {
      "reportType": "weekly",
      "dataSource": "analytics",
      "notifyEmail": "admin@example.com"
    }
  }'
{
  "taskId": "",
  "status": "INITIALIZED",
  "message": "Task started successfully"
}
```

But README is mentioned with `taskId` response.

https://github.com/aws-samples/serverless-patterns/blob/a56877aa261bf72e24fa932c6880c39eb2c76de1/lambda-durable-scheduled-tasks-sam/README.md?plain=1#L90-L97

## Check

I fixed mapping template and it works good.

```sh
$ curl -X POST ${API_ENDPOINT}/tasks \
  -H "Content-Type: application/json" \
  -d '{
    "config": {
      "reportType": "weekly",
      "dataSource": "analytics",
      "notifyEmail": "admin@example.com"
    }
  }'
{
  "taskId": "TASK-1769224879385",
  "status": "INITIALIZED",
  "message": "Task started successfully"
}
```

<img width="952" height="305" alt="image" src="https://github.com/user-attachments/assets/dbaea91e-2e47-4294-997f-eeba11200d4e" />

Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.