### PR TITLE
Fixed hardcoded API Gateway URL in the lambda-durable-human-approval-sam pattern.

### DIFF
--- a/lambda-durable-human-approval-sam/src/lambda_function.py
+++ b/lambda-durable-human-approval-sam/src/lambda_function.py
@@ -28,9 +28,10 @@ def lambda_handler(event, context: DurableContext):
     amount = body.get('amount', 0)
     description = body.get('description', 'No description')
     
-    # Get API Gateway URL from environment or construct it
-    region = os.environ.get('AWS_REGION', 'us-east-2')
-    api_base_url = f"https://w8a9tempjb.execute-api.{region}.amazonaws.com/prod"
+    # Get API Gateway URL from environment variable
+    api_base_url = os.environ.get('API_BASE_URL')
+    if not api_base_url:
+        raise ValueError("API_BASE_URL environment variable is not set")
     
     print(f"Starting approval workflow for request: {request_id}")
     print(f"API Base URL: {api_base_url}")

--- a/lambda-durable-human-approval-sam/template.yaml
+++ b/lambda-durable-human-approval-sam/template.yaml
@@ -68,6 +68,7 @@ Resources:
         Variables:
           APPROVAL_TOPIC_ARN: !Ref ApprovalTopic
           CALLBACK_TABLE_NAME: !Ref CallbackTable
+          API_BASE_URL: !Sub 'https://${ApprovalApi}.execute-api.${AWS::Region}.amazonaws.com/prod'
       Policies:
         - SNSPublishMessagePolicy:
             TopicName: !GetAtt ApprovalTopic.TopicName


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
## Changes Made
- Added `API_BASE_URL` environment variable to the CloudFormation template
- Updated the Lambda function to read the API Gateway URL from environment variable instead of using hardcoded value
- Added error handling for missing environment variable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
