### PR TITLE
Fix circular dependency from previous gateway url fix and introduce parameter store

### DIFF
--- a/lambda-durable-human-approval-sam/src/lambda_function.py
+++ b/lambda-durable-human-approval-sam/src/lambda_function.py
@@ -28,10 +28,18 @@ def lambda_handler(event, context: DurableContext):
     amount = body.get('amount', 0)
     description = body.get('description', 'No description')
     
-    # Get API Gateway URL from environment variable
-    api_base_url = os.environ.get('API_BASE_URL')
-    if not api_base_url:
-        raise ValueError("API_BASE_URL environment variable is not set")
+    # Get API Gateway URL from Parameter Store
+    param_name = os.environ.get('API_GATEWAY_PARAM')
+    if not param_name:
+        raise ValueError("API_GATEWAY_PARAM environment variable is not set")
+    
+    try:
+        import boto3
+        ssm = boto3.client('ssm')
+        response = ssm.get_parameter(Name=param_name)
+        api_base_url = response['Parameter']['Value']
+    except Exception as e:
+        raise ValueError(f"Could not get API Gateway URL from Parameter Store: {e}")
     
     print(f"Starting approval workflow for request: {request_id}")
     print(f"API Base URL: {api_base_url}")

--- a/lambda-durable-human-approval-sam/template.yaml
+++ b/lambda-durable-human-approval-sam/template.yaml
@@ -68,7 +68,7 @@ Resources:
         Variables:
           APPROVAL_TOPIC_ARN: !Ref ApprovalTopic
           CALLBACK_TABLE_NAME: !Ref CallbackTable
-          API_BASE_URL: !Sub 'https://${ApprovalApi}.execute-api.${AWS::Region}.amazonaws.com/prod'
+          API_GATEWAY_PARAM: !Sub '/${AWS::StackName}/api-gateway-url'
       Policies:
         - SNSPublishMessagePolicy:
             TopicName: !GetAtt ApprovalTopic.TopicName
@@ -79,6 +79,10 @@ Resources:
             Action:
               - lambda:CheckpointDurableExecution
             Resource: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${AWS::StackName}-ApprovalFunction-*'
+          - Effect: Allow
+            Action:
+              - ssm:GetParameter
+            Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/api-gateway-url'
 
   # IAM Role for API Gateway to call Lambda service API
   ApiGatewayRole:
@@ -166,6 +170,16 @@ Resources:
                 httpMethod: POST
                 uri: !Sub 'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${CallbackHandlerFunction.Arn}/invocations'
                 passthroughBehavior: when_no_match
+
+  # Store API Gateway URL in Parameter Store
+  ApiGatewayUrlParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub '/${AWS::StackName}/api-gateway-url'
+      Type: String
+      Value: !Sub 'https://${ApprovalApi}.execute-api.${AWS::Region}.amazonaws.com/prod'
+      Description: 'API Gateway URL for the approval workflow'
+    DependsOn: ApprovalApi
 
 Outputs:
   ApiEndpoint:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Previous fix of hardcoded gateway URL introduced a circular dependency (gateway <-> lambda).
To avoid any weird workarounds, I introduced a parameter store to make it as simple as possible.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
