### PR TITLE
eventbridge-cloudwatch-terraform: Update AWS Provider to v6

### DIFF
--- a/eventbridge-cloudwatch-terraform/README.md
+++ b/eventbridge-cloudwatch-terraform/README.md
@@ -37,8 +37,6 @@ Important: this application uses various AWS services and there are costs associ
 
 ## How it works
 
-The AWS SAM template deploys the resources and the IAM permissions required to run the application.
-
 The EventBridge rule specified in `main.tf` filters the events based upon the criteria in the `aws_cloudwatch_event_rule` block. When matching events are sent to EventBridge that trigger the rule, they are delivered as a JSON event payload to CloudWatch Logs.
 
 ## Testing

--- a/eventbridge-cloudwatch-terraform/main.tf
+++ b/eventbridge-cloudwatch-terraform/main.tf
@@ -41,7 +41,7 @@ resource "aws_cloudwatch_log_resource_policy" "MyCloudWatchLogPolicy" {
         "logs:CreateLogStream",
         "logs:PutLogEvents"
         ],
-      "Resource": "${aws_cloudwatch_log_group.MyLogGroup.arn}",
+      "Resource": "${aws_cloudwatch_log_group.MyLogGroup.arn}:*",
       "Condition": {
         "ArnEquals": {
           "aws:SourceArn": "${aws_cloudwatch_event_rule.MyEventRule.arn}"

--- a/eventbridge-cloudwatch-terraform/main.tf
+++ b/eventbridge-cloudwatch-terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.27"
+      version = "~> 6.0"
     }
   }
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

To keep this pattern maintainable, I updated the AWS Provider to v6 and fixed the CloudWatch Logs resource policy and README that were broken due to the outdated provider version.

## Check

`terraform apply` completed successfully and works good.

```sh
$ aws events put-events --entries file://event.json --region us-east-1
{
    "FailedEntryCount": 0,
    "Entries": [
        {
            "EventId": "a4225bec-15eb-d539-4a8f-8e383e0d6237"
        }
    ]
}
```

<img width="1267" height="692" alt="image" src="https://github.com/user-attachments/assets/0698a399-cd16-4d5f-939f-6bec480f962e" />

Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.