### PR TITLE
eventbridge-sqs-terraform: Update AWS Provider to v6

### DIFF
--- a/eventbridge-sqs-terraform/main.tf
+++ b/eventbridge-sqs-terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.27"
+      version = "~> 6.0"
     }
   }
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

To keep this pattern maintainable, I updated the AWS Provider to v6.

## Check

`terraform apply` completed successfully and works good.

```sh
$ aws events put-events --entries file://event.json --region us-east-1
{
    "FailedEntryCount": 0,
    "Entries": [
        {
            "EventId": "fa9d9a3d-ad0e-826e-b4b0-670d6c70eb90"
        }
    ]
}

$ aws sqs receive-message --queue-url https://sqs.us-east-1.amazonaws.com/000000000000/terraform-20260420020027556600000003 --region us-east-1
{
    "Messages": [
        {
            "MessageId": "aef85609-bebe-4eaf-9e66-ffcc4a906d76",
            "ReceiptHandle": "AQEB8z/9LLJoWv7DHWR0RO249NZOWv/Mn3zz9rh2CSgdGJiXdSdnfLQ4Up1XFcM8l7AkviiLPjwwjR7/k4yibgLuKpHd79fAF5Ia23sG5LzUzpfYOh90ZMj8raP1PzUewXcQAdBW6w3zKkFcZ5+OxWIAENf0Ku1MJ31eWIvFQJ0hqxljUN82y5DiWh7Hrwk+hQG9/1BZm5iWwuo5i+1xTlpEfuducdHDpoEXMKIGMikL+v72SJCuuKUmtkTvy2p0AXbvMJcQKMlpsP41z3NFoa7sVy7y6Mqq3wE/lAG7e1JX9fIkcL1SexXmVPcn5GBW8+Hpn+h9f5lh+gsvjl5NoPxjfk3qVhUbD4FypsopgbeAJyLLY4r6AXrzpJoXZMDKaGq+0ViHqE5i14KPhq4nctJrj02uQ89M/AH7Z9yZdPfIzaQ=",
            "MD5OfBody": "fad80236135f1ec40b06628b7c1dd94c",
            "Body": "{\"version\":\"0\",\"id\":\"fa9d9a3d-ad0e-826e-b4b0-670d6c70eb90\",\"detail-type\":\"message\",\"source\":\"demo.sqs\",\"account\":\"000000000000\",\"time\":\"2026-04-20T02:02:22Z\",\"region\":\"us-east-1\",\"resources\":[],\"detail\":{\"message\":\"Hello From EventBridge!\"}}"
        }
    ]
}
```

Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.