### PR TITLE
eventbridge-sns-terraform: Update AWS Provider to v6

### DIFF
--- a/eventbridge-sns-terraform/README.md
+++ b/eventbridge-sns-terraform/README.md
@@ -1,6 +1,6 @@
 # Amazon EventBridge to Amazon SNS
 
-The AWS SAM template deploys an SNS topic that is triggered by an EventBridge rule. The SNS topic policy provides the permission for EventBridge to invoke the SNS topic.
+This pattern creates an SNS topic that is triggered by an EventBridge rule. The SNS topic policy provides the permission for EventBridge to invoke the SNS topic.
 
 In this example, the EventBridge rule specified in `main.tf` filters the events based upon the criteria in the `aws_cloudwatch_event_rule` block. When matching events are sent to EventBridge that trigger the rule, they are delivered as a JSON event payload (see Example event payload from EventBridge to SNS in the README) to the SNS topic.
 

--- a/eventbridge-sns-terraform/main.tf
+++ b/eventbridge-sns-terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.27"
+      version = "~> 6.0"
     }
   }
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

To keep this pattern maintainable, I updated the AWS Provider to v6.

## Check

`terraform apply` completed successfully and works good.

```sh
$ aws events put-events --entries file://event.json --region us-east-1
{
    "FailedEntryCount": 0,
    "Entries": [
        {
            "EventId": "18fba94a-f229-7b5f-0de3-e8ed1a0454ae"
        }
    ]
}
```

<img width="1552" height="356" alt="image" src="https://github.com/user-attachments/assets/6a08b88d-da1f-476f-9e29-76538c8b6329" />

Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.