### PR TITLE
eventbridge-sfn-terraform: Update AWS Provider to v6

### DIFF
--- a/eventbridge-sfn-terraform/README.md
+++ b/eventbridge-sfn-terraform/README.md
@@ -1,8 +1,8 @@
-# EventBridge to Step Function
+# EventBridge to Step Functions
 
-This pattern demonstrates executing a Step Function using an EventBridge rule.
+This pattern demonstrates executing a Step Functions using an EventBridge rule.
 
-In this example, the EventBridge rule specified in `main.tf` filters the events based upon the criteria in the `aws_cloudwatch_event_rule` block. When matching events are sent to EventBridge that trigger the rule, they are delivered as a JSON event payload (see "Example event payload from EventBridge to SQS" in the README) to the Step Function as an Input.
+In this example, the EventBridge rule specified in `main.tf` filters the events based upon the criteria in the `aws_cloudwatch_event_rule` block. When matching events are sent to EventBridge that trigger the rule, they are delivered as a JSON event payload (see "Example event payload from EventBridge to SQS" in the README) to the Step Functions as an Input.
 
 Learn more about this pattern at Serverless Land Patterns: https://serverlessland.com/patterns/eventbridge-sfn
 
@@ -39,7 +39,7 @@ Important: this application uses various AWS services and there are costs associ
 
 ## How it works
 
-The template creates a shell Step Function, with a CloudWatch log group for log reporting of all events, that triggers based upon the criteria in the `aws_cloudwatch_event_rule` block and branches based on the value.
+The template creates a shell Step Functions, with a CloudWatch log group for log reporting of all events, that triggers based upon the criteria in the `aws_cloudwatch_event_rule` block and branches based on the value.
 
 ## Testing
 
@@ -51,16 +51,16 @@ The template creates a shell Step Function, with a CloudWatch log group for log 
     ```bash
     aws events put-events --entries file://event-B.json
     ```
-1. Send an event for Path C to EventBridge, which should cause the Step Function to fail:
+1. Send an event for Path C to EventBridge, which should cause the Step Functions to fail:
     ```bash
     aws events put-events --entries file://event-Fail.json
     ```
 
-Go to the Step Function created by this template to view the new execution that ran.
+Go to the Step Functions created by this template to view the new execution that ran.
 
 ![](./images/stepfunctions_graph.png)
 
-You can also go to the CloudWatch Logs stream in the Log Group displayed in the output of the terraform deployment to check the results of the three events that triggered the Step Function.
+You can also go to the CloudWatch Logs stream in the Log Group displayed in the output of the terraform deployment to check the results of the three events that triggered the Step Functions.
 ## Cleanup
  
 1. Change directory to the pattern directory:

--- a/eventbridge-sfn-terraform/main.tf
+++ b/eventbridge-sfn-terraform/main.tf
@@ -52,7 +52,7 @@ resource "aws_iam_role" "StateMachineRole" {
 POLICY2
 }
 
-# Create an IAM policy for Eventbridge to be able to start a Step Function execution
+# Create an IAM policy for Eventbridge to be able to start a Step Functions execution
 resource "aws_iam_policy" "EventBridgePolicy" {
   policy = <<POLICY3
 {
@@ -70,7 +70,7 @@ resource "aws_iam_policy" "EventBridgePolicy" {
 POLICY3
 }
 
-# Create an IAM policy to enable Step Function State Machine to push logs to CloudWatch logs
+# Create an IAM policy to enable Step Functions State Machine to push logs to CloudWatch logs
 resource "aws_iam_policy" "StateMachineLogDeliveryPolicy" {
   policy = <<POLICY4
 {
@@ -106,12 +106,12 @@ resource "aws_iam_role_policy_attachment" "StateMachinePolicyAttachment" {
   policy_arn = aws_iam_policy.StateMachineLogDeliveryPolicy.arn
 }
 
-# Create an Log group for the Step Function
+# Create an Log group for the Step Functions
 resource "aws_cloudwatch_log_group" "MyLogGroup" {
   name_prefix = "/aws/vendedlogs/states/StateMachine-terraform-"
 }
 
-# Create a Step Function State Machine
+# Create a Step Functions State Machine
 resource "aws_sfn_state_machine" "sfn_state_machine" {
   name     = "eventbridge-state-machine-demo-${data.aws_caller_identity.current.account_id}"
   role_arn = aws_iam_role.StateMachineRole.arn
@@ -169,7 +169,7 @@ resource "aws_cloudwatch_event_rule" "MyEventRule" {
 PATTERN
 }
 
-# Set the Step Function as target to the Eventbridge rule
+# Set the Step Functions as target to the Eventbridge rule
 resource "aws_cloudwatch_event_target" "SFNTarget" {
   rule     = aws_cloudwatch_event_rule.MyEventRule.name
   arn      = aws_sfn_state_machine.sfn_state_machine.arn
@@ -184,5 +184,5 @@ output "CW-Logs-Stream-Name" {
 
 output "StepFunction-Name" {
   value       = aws_sfn_state_machine.sfn_state_machine.name
-  description = "The Step Function Name"
+  description = "The Step Functions Name"
 }

--- a/eventbridge-sfn-terraform/main.tf
+++ b/eventbridge-sfn-terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.27"
+      version = "~> 6.0"
     }
   }
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

To keep this pattern maintainable, I updated the AWS Provider to v6.

## Check

`terraform apply` completed successfully and works good.

```sh
$ terraform --version
Terraform v1.14.9
on darwin_arm64
+ provider registry.terraform.io/hashicorp/aws v6.41.0

$ terraform apply

#
# snip
#

Apply complete! Resources: 10 added, 0 changed, 0 destroyed.

Outputs:

CW-Logs-Stream-Name = "/aws/vendedlogs/states/StateMachine-terraform-20260607045750885100000005"
StepFunction-Name = "eventbridge-state-machine-demo-000000000000"
```

```sh
$ aws events put-events --entries file://event-A.json --region us-east-1
{
    "FailedEntryCount": 0,
    "Entries": [
        {
            "EventId": "c50fee9c-1316-0d0d-b8e1-e53d12c1289f"
        }
    ]
}

$ aws events put-events --entries file://event-B.json --region us-east-1
{
    "FailedEntryCount": 0,
    "Entries": [
        {
            "EventId": "5369ae64-7800-6347-1b6a-7a36d89b6c2a"
        }
    ]
}

$ aws events put-events --entries file://event-Fail.json --region us-east-1
{
    "FailedEntryCount": 0,
    "Entries": [
        {
            "EventId": "9710a0b6-a0bc-1471-28d6-1324da7c5bf5"
        }
    ]
}
```

Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.