### PR TITLE
s3-eventbridge-terraform: Update AWS Provider to v6

### DIFF
--- a/s3-eventbridge-terraform/main.tf
+++ b/s3-eventbridge-terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.27"
+      version = "~> 6.0"
     }
   }
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

To keep this pattern maintainable, I updated the AWS Provider to v6.

## Check

`terraform apply` completed successfully and works good.

```sh
$ terraform --version
Terraform v1.14.9
on darwin_arm64
+ provider registry.terraform.io/hashicorp/aws v6.41.0

$ terraform apply

#
# snip
#

Apply complete! Resources: 6 added, 0 changed, 0 destroyed.

Outputs:

EventBridge-Rule-Name = "terraform-20260607050737359000000003"
S3-Bucket = "serverlessland-terraform-s3-eventbridge-000000000000"
SNS-Topic-ARN = "arn:aws:sns:us-east-1:000000000000:terraform-20260607050733168600000002"
```

```sh
$ aws s3 cp README.md s3://serverlessland-terraform-s3-eventbridge-000000000000 --region us-east-1
upload: ./README.md to s3://serverlessland-terraform-s3-eventbridge-000000000000/README.md
```

<img width="2692" height="1012" alt="image" src="https://github.com/user-attachments/assets/45509d89-6e89-4ff7-851d-ad37bce8c98f" />

Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.