### PR TITLE
apigw-dynamodb-terraform: Update AWS Provider to v6

### DIFF
--- a/apigw-dynamodb-terraform/README.md
+++ b/apigw-dynamodb-terraform/README.md
@@ -54,15 +54,15 @@ Once the application is deployed, you can test it using the following instructio
 	```
 	* Repeate the process as many times as you can, try doing it with different Pet Types
 1. Invoke the DynamoDB **Query** action to query items by PetType in the DynamoDB table:
-	* Run the below command after you replace <KEY> and <URL> with the terraform output from earlier.
+	* Run the below command after you replace <KEY> and <URL> with the terraform output from earlier. Append the PetType to the URL (e.g. `/dog`).
 	```
-	curl -H 'x-api-key: <KEY>' --request GET '<URL>'
+	curl -H 'x-api-key: <KEY>' --request GET '<URL>/dog'
 	```
 	* Repeate the process as many times as you can with different Pet Types
 	* You should receive a "200 OK" response with a list of the matching results. Example: 
 	```
 	{
-		"music": [
+		"pets": [
 			{
 				"id": "45b33352-fea0-4e8b-8c7a-6be11ec4ff80",
 				"PetType": "dog",

--- a/apigw-dynamodb-terraform/main.tf
+++ b/apigw-dynamodb-terraform/main.tf
@@ -122,7 +122,7 @@ resource "aws_api_gateway_rest_api" "MyApiGatewayRestApi" {
             "type" : "aws",
             "credentials" : "${aws_iam_role.APIGWRole.arn}",
             "httpMethod" : "POST",
-            "uri" : "arn:aws:apigateway:${data.aws_region.current.name}:dynamodb:action/PutItem",
+            "uri" : "arn:aws:apigateway:${data.aws_region.current.id}:dynamodb:action/PutItem",
             "responses" : {
               "default" : {
                 "statusCode" : "200",
@@ -160,7 +160,7 @@ resource "aws_api_gateway_rest_api" "MyApiGatewayRestApi" {
             "type" : "aws",
             "credentials" : "${aws_iam_role.APIGWRole.arn}",
             "httpMethod" : "POST",
-            "uri" : "arn:aws:apigateway:${data.aws_region.current.name}:dynamodb:action/Query",
+            "uri" : "arn:aws:apigateway:${data.aws_region.current.id}:dynamodb:action/Query",
             "responses" : {
               "default" : {
                 "statusCode" : "200",

--- a/apigw-dynamodb-terraform/main.tf
+++ b/apigw-dynamodb-terraform/main.tf
@@ -81,8 +81,11 @@ resource "aws_dynamodb_table" "MyDynamoDBTable" {
   }
 
   global_secondary_index {
-    name               = "PetType-index"
-    hash_key           = "PetType"
+    name = "PetType-index"
+    key_schema {
+      attribute_name = "PetType"
+      key_type       = "HASH"
+    }
     write_capacity     = 5
     read_capacity      = 5
     projection_type    = "INCLUDE"

--- a/apigw-dynamodb-terraform/main.tf
+++ b/apigw-dynamodb-terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.27"
+      version = "~> 6.0"
     }
   }
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

To keep this pattern maintainable, I updated the AWS Provider to v6 and replaced deprecated HCL code. I also fixed incorrect instructions in the README.

## Check

`terraform apply` completed successfully and works good.

```sh
$ curl -H 'x-api-key: xxx' -H 'Content-Type: application/json' --request POST 'https://kl1vikew8a.execute-api.us-east-1.amazonaws.com/v1/pets' --data-raw '{ "PetType": "dog", "PetName": "tito", "PetPrice": 250 }'
{}

$ curl -H 'x-api-key: xxx' --request GET 'https://kl1vikew8a.execute-api.us-east-1.amazonaws.com/v1/pets/dog' | jq .
{
  "pets": [
    {
      "id": "f3667862-28d8-44cb-b4b6-c876a8991df9",
      "PetType": "dog",
      "PetName": "tito",
      "PetPrice": "250"
    }
  ]
}
```

Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.