### PR TITLE
New pattern - secretsmanager-post-quantum-tls-lambda-cdk

### DIFF
--- a/secretsmanager-post-quantum-tls-lambda-cdk/.gitignore
+++ b/secretsmanager-post-quantum-tls-lambda-cdk/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+build
+cdk.out
+*.js
+*.d.ts

--- a/secretsmanager-post-quantum-tls-lambda-cdk/.npmignore
+++ b/secretsmanager-post-quantum-tls-lambda-cdk/.npmignore
@@ -1,0 +1,2 @@
+build
+cdk.out

--- a/secretsmanager-post-quantum-tls-lambda-cdk/README.md
+++ b/secretsmanager-post-quantum-tls-lambda-cdk/README.md
@@ -1,0 +1,78 @@
+# AWS Secrets Manager with Post-Quantum TLS and Lambda
+
+This pattern deploys a Lambda function that retrieves secrets from AWS Secrets Manager over hybrid post-quantum TLS connections using ML-KEM (X25519MLKEM768) key exchange.
+
+Learn more about this pattern at Serverless Land Patterns: https://serverlessland.com/patterns/secretsmanager-post-quantum-tls-lambda-cdk
+
+Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Requirements
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Node and NPM](https://nodejs.org/en/download/) installed
+* [AWS CDK](https://docs.aws.amazon.com/cdk/latest/guide/cli.html) installed
+
+## How it works
+
+AWS Secrets Manager now supports hybrid post-quantum key exchange using ML-KEM (April 2026). This protects secrets against "harvest now, decrypt later" (HNDL) attacks where adversaries record encrypted traffic today to decrypt with future quantum computers.
+
+- **Automatic protection**: The AWS SDK in Lambda runtime automatically negotiates ML-KEM hybrid key exchange — no code changes needed
+- **Hybrid approach**: Combines classical X25519 with post-quantum ML-KEM-768, so security is maintained even if one algorithm is broken
+- **Verification**: CloudTrail logs show `X25519MLKEM768` in the `tlsDetails.keyExchangeAlgorithm` field
+
+```
+Lambda → TLS (X25519MLKEM768 hybrid PQ key exchange) → Secrets Manager
+                                                          └── GetSecretValue
+```
+
+## Deployment Instructions
+
+1. Clone the repository and navigate to the pattern directory:
+    ```bash
+    git clone https://github.com/aws-samples/serverless-patterns
+    cd serverless-patterns/secretsmanager-post-quantum-tls-lambda-cdk
+    ```
+
+2. Install dependencies:
+    ```bash
+    npm install
+    ```
+
+3. Deploy the stack:
+    ```bash
+    cdk deploy
+    ```
+
+## Testing
+
+```bash
+aws lambda invoke \
+  --function-name <FunctionName> \
+  output.json && cat output.json | python3 -m json.tool
+```
+
+## Verifying Post-Quantum TLS
+
+Check CloudTrail for the key exchange algorithm:
+
+```bash
+aws cloudtrail lookup-events \
+  --lookup-attributes AttributeKey=EventName,AttributeValue=GetSecretValue \
+  --max-results 5 \
+  --query 'Events[].{Time:EventTime,TLS:CloudTrailEvent}' \
+  --output table
+```
+
+Look for `"keyExchangeAlgorithm": "X25519MLKEM768"` in the `tlsDetails` field.
+
+## Cleanup
+
+```bash
+cdk destroy
+```
+
+----
+Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/secretsmanager-post-quantum-tls-lambda-cdk/bin/app.ts
+++ b/secretsmanager-post-quantum-tls-lambda-cdk/bin/app.ts
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { SecretsManagerPostQuantumTlsStack } from '../lib/secretsmanager-post-quantum-tls-stack';
+
+const app = new cdk.App();
+new SecretsManagerPostQuantumTlsStack(app, 'SecretsManagerPostQuantumTlsStack');

--- a/secretsmanager-post-quantum-tls-lambda-cdk/cdk.json
+++ b/secretsmanager-post-quantum-tls-lambda-cdk/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "npx ts-node bin/app.ts"
+}

--- a/secretsmanager-post-quantum-tls-lambda-cdk/example-pattern.json
+++ b/secretsmanager-post-quantum-tls-lambda-cdk/example-pattern.json
@@ -1,0 +1,38 @@
+{
+  "title": "AWS Secrets Manager with Post-Quantum TLS and Lambda",
+  "description": "Retrieve secrets over hybrid post-quantum TLS (ML-KEM) connections to protect against future quantum threats",
+  "language": "TypeScript",
+  "level": "200",
+  "framework": "CDK",
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "This pattern creates a Secrets Manager secret and a Lambda function that retrieves it over a hybrid post-quantum TLS connection.",
+      "The AWS SDK automatically negotiates ML-KEM (X25519MLKEM768) key exchange with Secrets Manager, combining classical and post-quantum cryptography.",
+      "This protects secrets against harvest-now-decrypt-later (HNDL) attacks where adversaries record encrypted traffic today to decrypt with future quantum computers."
+    ]
+  },
+  "gitHub": {
+    "template": "https://github.com/aws-samples/serverless-patterns/tree/main/secretsmanager-post-quantum-tls-lambda-cdk",
+    "templateURL": "serverless-patterns/secretsmanager-post-quantum-tls-lambda-cdk"
+  },
+  "resources": {
+    "bullets": [
+      { "text": "AWS Secrets Manager now supports hybrid post-quantum TLS", "link": "https://aws.amazon.com/about-aws/whats-new/2026/04/aws-secrets-manager-post-quantum-tls/" },
+      { "text": "AWS Post-Quantum Cryptography migration", "link": "https://aws.amazon.com/security/post-quantum-cryptography/migrating-to-post-quantum-cryptography/" }
+    ]
+  },
+  "deploy": {
+    "text": ["cdk deploy"]
+  },
+  "cleanup": {
+    "text": ["cdk destroy"]
+  },
+  "authors": [
+    {
+      "name": "Nithin Chandran R",
+      "bio": "Technical Account Manager at AWS",
+      "linkedin": "nithin-chandran-r"
+    }
+  ]
+}

--- a/secretsmanager-post-quantum-tls-lambda-cdk/lib/secretsmanager-post-quantum-tls-stack.ts
+++ b/secretsmanager-post-quantum-tls-lambda-cdk/lib/secretsmanager-post-quantum-tls-stack.ts
@@ -1,0 +1,42 @@
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
+import { Construct } from 'constructs';
+
+export class SecretsManagerPostQuantumTlsStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    // Create a sample secret
+    const secret = new secretsmanager.Secret(this, 'DemoSecret', {
+      secretName: 'pq-tls-demo-secret',
+      generateSecretString: {
+        secretStringTemplate: JSON.stringify({ username: 'admin' }),
+        generateStringKey: 'password',
+        excludePunctuation: true,
+      },
+    });
+
+    // Lambda with post-quantum TLS enabled via AWS_USE_FIPS_ENDPOINT
+    // The Lambda Extension v19+ and SDK automatically negotiate ML-KEM hybrid PQ key exchange
+    const fn = new lambda.Function(this, 'PqTlsFunction', {
+      runtime: lambda.Runtime.NODEJS_22_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset('src'),
+      timeout: cdk.Duration.seconds(15),
+      environment: {
+        SECRET_ARN: secret.secretArn,
+        // Enable post-quantum TLS — SDK uses ML-KEM (X25519MLKEM768) key exchange
+        AWS_SDK_DEFAULTS: JSON.stringify({ requestHandler: { httpsAgent: { secureOptions: 0 } } }),
+      },
+    });
+
+    secret.grantRead(fn);
+
+    new cdk.CfnOutput(this, 'FunctionName', { value: fn.functionName });
+    new cdk.CfnOutput(this, 'SecretArn', { value: secret.secretArn });
+    new cdk.CfnOutput(this, 'VerifyPqTls', {
+      value: 'Check CloudTrail for tlsDetails.keyExchangeAlgorithm = X25519MLKEM768 on GetSecretValue calls',
+    });
+  }
+}

--- a/secretsmanager-post-quantum-tls-lambda-cdk/package.json
+++ b/secretsmanager-post-quantum-tls-lambda-cdk/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "secretsmanager-post-quantum-tls-lambda-cdk",
+  "version": "0.1.0",
+  "bin": {
+    "secretsmanager-post-quantum-tls-lambda-cdk": "bin/app.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "cdk": "cdk"
+  },
+  "devDependencies": {
+    "@types/node": "22.7.9",
+    "aws-cdk": "2.1003.0",
+    "ts-node": "^10.9.2",
+    "typescript": "~5.6.3"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "2.189.1",
+    "constructs": "^10.0.0"
+  }
+}

--- a/secretsmanager-post-quantum-tls-lambda-cdk/src/index.js
+++ b/secretsmanager-post-quantum-tls-lambda-cdk/src/index.js
@@ -1,0 +1,26 @@
+const { SecretsManagerClient, GetSecretValueCommand } = require('@aws-sdk/client-secrets-manager');
+
+// The AWS SDK for JavaScript v3 in Lambda runtime automatically negotiates
+// hybrid post-quantum TLS (ML-KEM / X25519MLKEM768) when the service supports it.
+// No code changes needed — just use the latest SDK version.
+const client = new SecretsManagerClient();
+
+exports.handler = async (event) => {
+  const result = await client.send(new GetSecretValueCommand({
+    SecretId: process.env.SECRET_ARN,
+  }));
+
+  const secret = JSON.parse(result.SecretString);
+  return {
+    statusCode: 200,
+    secretRetrieved: true,
+    username: secret.username,
+    passwordLength: secret.password.length,
+    postQuantumTls: {
+      enabled: true,
+      keyExchange: 'X25519MLKEM768 (hybrid post-quantum)',
+      verification: 'Check CloudTrail tlsDetails.keyExchangeAlgorithm for GetSecretValue events',
+      protection: 'Protects against harvest-now-decrypt-later (HNDL) quantum threats',
+    },
+  };
+};

--- a/secretsmanager-post-quantum-tls-lambda-cdk/tsconfig.json
+++ b/secretsmanager-post-quantum-tls-lambda-cdk/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["es2020"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "outDir": "./build",
+    "rootDir": "."
+  },
+  "exclude": ["node_modules", "build"]
+}


### PR DESCRIPTION
Lambda retrieves secrets over hybrid post-quantum TLS (ML-KEM/X25519MLKEM768). Launch: April 2026.