### PR TITLE
s3-sns-terraform: Update AWS Provider to v6

### DIFF
--- a/s3-sns-terraform/main.tf
+++ b/s3-sns-terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.27"
+      version = "~> 6.0"
     }
   }
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

To keep this pattern maintainable, I updated the AWS Provider to v6.

## Check

`terraform apply` completed successfully and works good.

```sh
$ aws s3 cp README.md s3://serverlessland-terraform-s3-sns-000000000000 --region us-east-1
upload: ./README.md to s3://serverlessland-terraform-s3-sns-000000000000/README.md
```

Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.