### PR TITLE
sfn-glue-terraform: Update AWS Provider to v6

### DIFF
--- a/sfn-glue-terraform/README.md
+++ b/sfn-glue-terraform/README.md
@@ -1,6 +1,6 @@
-# AWS Step Functions to start a AWS Glue Job Through a Cloudwatch event rule
+# AWS Step Functions to start a AWS Glue Job Through a CloudWatch event rule
 
-The Terraform template deploys a AWS Step Function, a AWS Glue Job, a Cloudwatch Event Rule, a Amazon S3 bucket and the minimum IAM resources required to run the application.
+The Terraform template deploys a AWS Step Functions, a AWS Glue Job, a CloudWatch Event Rule, a Amazon S3 bucket and the minimum IAM resources required to run the application.
 
 ## Architecture
 ![Alt](./resources/architecture.png)
@@ -8,13 +8,13 @@ The Terraform template deploys a AWS Step Function, a AWS Glue Job, a Cloudwatch
 This pattern demonstrates the use of Terraform modules and deploys the below resources:
 * Amazon S3 bucket and load the sample Python script as an object 
 * Sample AWS Glue Job which executes the script in the S3 bucket
-* AWS Step Function to invoke the AWS Glue Job synchronously. The Function will wait until the Job is completed
-* Cloudwatch Event Rule which is configured to start the AWS Step Function evey 10 minutes
+* AWS Step Functions to invoke the AWS Glue Job synchronously. The Function will wait until the Job is completed
+* CloudWatch Event Rule which is configured to start the AWS Step Functions evey 10 minutes
 
 
 ## How it works
 
-The AWS Cloudwatch rule is configured to start a Step Function execution every 10 minutes. The Step function then invokes a AWS Glue Job with some default arguments and a test message.
+The AWS CloudWatch rule is configured to start a Step Functions execution every 10 minutes. The Step function then invokes a AWS Glue Job with some default arguments and a test message.
 The Arguments to the AWS Glue Job, the Python script and the CloudWatch event rule can be modified as per requirement.
 
 
@@ -71,7 +71,7 @@ After deployment, go to the cloudwatch logs to check the event details.
     ```bash
     terraform show
     ```
-    ```
+
 ----
 Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 

--- a/sfn-glue-terraform/README.md
+++ b/sfn-glue-terraform/README.md
@@ -54,7 +54,17 @@ Important: this application uses various AWS services and there are costs associ
 
 ## Testing
 
-After deployment, go to the cloudwatch logs to check the event details.
+After deployment, the Amazon EventBridge rule automatically triggers the AWS Step Functions state machine every 10 minutes. Wait for at least 10 minutes, then verify that the execution completed successfully.
+
+1. Verify the AWS Step Functions state machine execution `status` is `SUCCEEDED`.
+    ```sh
+    aws stepfunctions list-executions --state-machine-arn $(terraform output -raw aws_step_function_arn)
+    ```
+1. Verify the AWS Glue job run `JobRunState` is `SUCCEEDED`.
+    ```sh
+    aws glue get-job-runs --job-name sample-glue-job-terraform
+    ```
+
 ## Cleanup
 
 1. Change directory to the pattern directory:

--- a/sfn-glue-terraform/README.md
+++ b/sfn-glue-terraform/README.md
@@ -73,7 +73,7 @@ After deployment, the Amazon EventBridge rule automatically triggers the AWS Ste
     ```
 1. Delete all created resources
     ```bash
-    terraform apply -destroy
+    terraform apply --destroy
     ```
 1. During the prompts:
     * Enter yes

--- a/sfn-glue-terraform/README.md
+++ b/sfn-glue-terraform/README.md
@@ -1,6 +1,6 @@
 # AWS Step Functions to start a AWS Glue Job Through a CloudWatch event rule
 
-The Terraform template deploys a AWS Step Functions, a AWS Glue Job, a CloudWatch Event Rule, a Amazon S3 bucket and the minimum IAM resources required to run the application.
+The Terraform template deploys a AWS Step Functions state machine, a AWS Glue Job, a CloudWatch Event Rule, a Amazon S3 bucket and the minimum IAM resources required to run the application.
 
 ## Architecture
 ![Alt](./resources/architecture.png)

--- a/sfn-glue-terraform/main.tf
+++ b/sfn-glue-terraform/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.27"
+      version = "~> 6.0"
     }
   }
 

--- a/sfn-glue-terraform/main.tf
+++ b/sfn-glue-terraform/main.tf
@@ -55,7 +55,7 @@ output "aws_cloudwatch_event_rule_arn" {
 }
 
 output "aws_step_function_arn" {
-  value = module.aws_sfn_state_machine.stf_role_arn
+  value = module.aws_sfn_state_machine.stf_arn
 }
 
 output "aws_glue_job_arn" {

--- a/sfn-glue-terraform/modules/terraform-amazon-s3/main.tf
+++ b/sfn-glue-terraform/modules/terraform-amazon-s3/main.tf
@@ -12,9 +12,9 @@ resource "aws_s3_bucket" "s3_sample_glue_bucket" {
 resource "aws_s3_bucket_public_access_block" "s3_glue_bucket_block_public_access" {
   bucket = aws_s3_bucket.s3_sample_glue_bucket.id
 
-  block_public_acls   = true
-  block_public_policy = true
-  ignore_public_acls = true
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
   restrict_public_buckets = true
 }
 
@@ -23,7 +23,7 @@ resource "aws_s3_object" "glue_script_object" {
   bucket = aws_s3_bucket.s3_sample_glue_bucket.bucket
   key    = "glue_script.py"
   source = "./resources/glue_script.py"
-  acl = "private"
+  acl    = "private"
 }
 
 ## IAM Resources

--- a/sfn-glue-terraform/modules/terraform-amazon-s3/main.tf
+++ b/sfn-glue-terraform/modules/terraform-amazon-s3/main.tf
@@ -19,7 +19,7 @@ resource "aws_s3_bucket_public_access_block" "s3_glue_bucket_block_public_access
 }
 
 # upload the AWS Glue script to the bucket
-resource "aws_s3_bucket_object" "glue_script_object" {
+resource "aws_s3_object" "glue_script_object" {
   bucket = aws_s3_bucket.s3_sample_glue_bucket.bucket
   key    = "glue_script.py"
   source = "./resources/glue_script.py"
@@ -39,5 +39,5 @@ output "bucket_arn" {
 }
 
 output "glue_script_name" {
-  value = aws_s3_bucket_object.glue_script_object.key
+  value = aws_s3_object.glue_script_object.key
 }

--- a/sfn-glue-terraform/modules/terraform-aws-cloudwatch/main.tf
+++ b/sfn-glue-terraform/modules/terraform-aws-cloudwatch/main.tf
@@ -1,5 +1,5 @@
-locals{
-  schedule_expression= "rate(10 minutes)"
+locals {
+  schedule_expression = "rate(10 minutes)"
 }
 
 # Variables
@@ -30,8 +30,8 @@ resource "aws_iam_role" "allow_cloudwatch_to_execute_role" {
 }
 
 resource "aws_iam_role_policy" "state_execution" {
-  name        = "state_execution_policy"
-  role   = aws_iam_role.allow_cloudwatch_to_execute_role.id
+  name = "state_execution_policy"
+  role = aws_iam_role.allow_cloudwatch_to_execute_role.id
 
   policy = <<EOF
 {
@@ -51,14 +51,14 @@ EOF
 }
 
 resource "aws_cloudwatch_event_rule" "stf_trigger_rule" {
-  name = "stf_trigger_rule"
+  name                = "stf_trigger_rule"
   schedule_expression = local.schedule_expression
-  description = "Sample Event for Glue terraform example"
+  description         = "Sample Event for Glue terraform example"
 }
 
 resource "aws_cloudwatch_event_target" "cloudwatch_event_target" {
-  rule = aws_cloudwatch_event_rule.stf_trigger_rule.name
-  arn = var.stf_function_arn
+  rule     = aws_cloudwatch_event_rule.stf_trigger_rule.name
+  arn      = var.stf_function_arn
   role_arn = aws_iam_role.allow_cloudwatch_to_execute_role.arn
 }
 

--- a/sfn-glue-terraform/modules/terraform-aws-glue/main.tf
+++ b/sfn-glue-terraform/modules/terraform-aws-glue/main.tf
@@ -31,13 +31,13 @@ data "aws_iam_policy_document" "policy_document" {
 }
 
 resource "aws_iam_policy" "s3_access_iam_policy" {
-  name = "sample-glue-s3-access-policy"
+  name   = "sample-glue-s3-access-policy"
   policy = data.aws_iam_policy_document.policy_document.json
 }
 
 # Glue IAM roles and Policies
 resource "aws_iam_role" "sample_glue_role" {
-  name = "sample-glue-role"
+  name               = "sample-glue-role"
   assume_role_policy = <<EOF
 {
    "Version":"2012-10-17",
@@ -58,7 +58,7 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "glue_service_policy" {
-  role = aws_iam_role.sample_glue_role.name
+  role       = aws_iam_role.sample_glue_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
 }
 
@@ -70,8 +70,8 @@ resource "aws_iam_role_policy_attachment" "platform_metrics_glue_iam_policy" {
 resource "aws_glue_job" "glue_job" {
   count = var.create ? 1 : 0
 
-  name = "sample-glue-job-terraform"
-  description = "AWS Glue Job terraform example"
+  name         = "sample-glue-job-terraform"
+  description  = "AWS Glue Job terraform example"
   role_arn     = aws_iam_role.sample_glue_role.arn
   max_capacity = var.dpu
   glue_version = "3.0"
@@ -81,8 +81,8 @@ resource "aws_glue_job" "glue_job" {
   }
 
   default_arguments = merge(local.default_arguments, var.arguments)
-  max_retries = var.max_retries
-  timeout     = var.timeout
+  max_retries       = var.max_retries
+  timeout           = var.timeout
 
   execution_property {
     max_concurrent_runs = var.max_concurrent

--- a/sfn-glue-terraform/modules/terraform-aws-glue/variables.tf
+++ b/sfn-glue-terraform/modules/terraform-aws-glue/variables.tf
@@ -4,7 +4,7 @@ variable "create" {
 
 
 variable "role_arn" {
-  default =""
+  default = ""
 }
 
 variable "connections" {

--- a/sfn-glue-terraform/modules/terraform-aws-step-function/main.tf
+++ b/sfn-glue-terraform/modules/terraform-aws-step-function/main.tf
@@ -1,11 +1,11 @@
 # variables
 variable "glue_job_arn" {}
 variable "glue_job_name" {}
-variable "glue_message" {default = "This is a message passed by the AWS Step Function"}
+variable "glue_message" { default = "This is a message passed by the AWS Step Function" }
 
 # AWS Step Functions IAM roles and Policies
 resource "aws_iam_role" "aws_stf_role" {
-  name = "aws-stf-role"
+  name               = "aws-stf-role"
   assume_role_policy = <<EOF
 {
    "Version":"2012-10-17",
@@ -27,9 +27,9 @@ EOF
 
 resource "aws_iam_role_policy" "step_function_policy" {
   name = "aws-stf-policy"
-  role    = aws_iam_role.aws_stf_role.id
+  role = aws_iam_role.aws_stf_role.id
 
-  policy  = <<EOF
+  policy = <<EOF
 {
    "Version":"2012-10-17",
    "Statement":[
@@ -51,8 +51,8 @@ EOF
 
 # AWS Step function definition
 resource "aws_sfn_state_machine" "aws_step_function_workflow" {
-  name = "aws-step-function-workflow"
-  role_arn = aws_iam_role.aws_stf_role.arn
+  name       = "aws-step-function-workflow"
+  role_arn   = aws_iam_role.aws_stf_role.arn
   definition = <<EOF
 {
    "Comment":"A description of the sample glue job state machine using Terraform",


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

To keep this pattern maintainable, I updated the AWS Provider to v6 and replaced deprecated HCL code.

## Check

`terraform apply` completed successfully and works good.

<img width="253" height="224" alt="stepfunctions_graph" src="https://github.com/user-attachments/assets/c00cf8a9-583a-44ae-9e7a-0f6b0f49de7a" />

<img width="1794" height="532" alt="image" src="https://github.com/user-attachments/assets/c347f95b-de10-4162-b83d-62bae4765f04" />

Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.