### PR TITLE
sns-sqs-terraform: Update AWS Provider to v6

### DIFF
--- a/sns-sqs-terraform/README.md
+++ b/sns-sqs-terraform/README.md
@@ -2,7 +2,7 @@
 
 The Terraform stack deploys a SNS topic and an SQS queue. The SQS queue is subscribed to the SNS topic. SNS invokes the SQS queue when new messages are available. When messages are sent to the SNS topic, they are delivered as a JSON event payload to the SQS queue.
 
-Learn more about this pattern at Serverless Land Patterns: [serverlessland.com/patterns/sqs-lambda-terraform](https://serverlessland.com/patterns/sns-sqs-terraform)
+Learn more about this pattern at Serverless Land Patterns: [serverlessland.com/patterns/sns-sqs-terraform](https://serverlessland.com/patterns/sns-sqs-terraform)
 
 Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
 
@@ -58,14 +58,13 @@ When a message is received by the SNS topic, the message is sent to the SQS queu
 Use the [AWS CLI](https://aws.amazon.com/cli/) to send a message to the SNS topic and observe the message received by SQS (using values from Terraform output):
 
 1. Send a message to SNS:
-```bash
-aws sns publish --topic-arn ENTER_YOUR_SNS_TOPIC_ARN --subject testSubject --message testMessage
-```
+    ```bash
+    aws sns publish --topic-arn ENTER_YOUR_SNS_TOPIC_ARN --subject testSubject --message testMessage
+    ```
 1. Retrieve the message from SQS queue:
-```bash
-aws sqs receive-message --queue-url ENTER_YOUR_SQS_QUEUE_URL
-```
-
+    ```bash
+    aws sqs receive-message --queue-url ENTER_YOUR_SQS_QUEUE_URL
+    ```
 
 ## Cleanup
 

--- a/sns-sqs-terraform/main.tf
+++ b/sns-sqs-terraform/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
   }
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

To keep this pattern maintainable, I updated the AWS Provider to v6.

## Check

`terraform apply` completed successfully and works good.

```sh
$ aws sns publish --topic-arn arn:aws:sns:us-east-1:000000000000:sns-sqs-demo-000000000000 --subject testSubject --message testMessage --region us-east-1
{
    "MessageId": "a234ba7a-20a6-56ae-b908-d8fef0ded902"
}

$ aws sqs receive-message --queue-url sns-sqs-demo-000000000000 --region us-east-1
{
    "Messages": [
        {
            "MessageId": "7060461f-4264-41f5-bcdd-3889f98ec5bf",
            "ReceiptHandle": "xxx",
            "MD5OfBody": "37546b0ac9dc24506d4d1a4f05f35414",
            "Body": "xxx"
        }
    ]
}
```

Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.