### PR TITLE
docs: fix Bedrock Lambda comments

### DIFF
--- a/lambda-bedrock-cdk/lambda-layer/resources/lambda/lambda_function.py
+++ b/lambda-bedrock-cdk/lambda-layer/resources/lambda/lambda_function.py
@@ -2,7 +2,7 @@ import json
 import boto3
 
 # Get list of available foundational models using the 'bedrock' client.
-# This allows the application to interact with the service configuratoin.
+# This allows the application to interact with the service configuration.
 bedrock = boto3.client('bedrock')
 models = str(bedrock.list_foundation_models())
 
@@ -25,7 +25,7 @@ def handler(event, context):
             "models":models
         }
         statusCode = 500
-    # Bedrock invocation sucessful, alongside the modela response, return model_id and execution time to help evaluate models performances
+    # Bedrock invocation successful; alongside the model response, return model_id and execution time to help evaluate model performance
     return {
         'statusCode': statusCode,
         'model_id': model_id,


### PR DESCRIPTION
## Summary
- fix spelling in comments for the Bedrock Lambda sample
- clarify the response/performance wording without changing runtime behavior

## Validation
- python3 -m py_compile lambda-bedrock-cdk/lambda-layer/resources/lambda/lambda_function.py
- git diff --check

Confidence: 85/100 (docs/comment typo)