### PR TITLE
terraform-ecs-efs-integration: Update AWS Provider to v6

### DIFF
--- a/terraform-ecs-efs-integration/Readme.md
+++ b/terraform-ecs-efs-integration/Readme.md
@@ -45,7 +45,7 @@ aws ecs run-task \
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.24 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | >= 2.3 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2 |
 
@@ -53,7 +53,7 @@ aws ecs run-task \
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.24 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
 | <a name="provider_external"></a> [external](#provider\_external) | >= 2.3 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 3.2 |
 

--- a/terraform-ecs-efs-integration/Readme.md
+++ b/terraform-ecs-efs-integration/Readme.md
@@ -1,6 +1,6 @@
-## Amazon EFS and Amazon ECS Integration
+# Amazon EFS and Amazon ECS Integration
 
-This pattern creates an Amazon EFS file system and integrates with ECS for a persisent file storage in a containerized environment.
+This pattern creates an Amazon EFS file system and integrates with ECS for a persistent file storage in a containerized environment.
 
 You will build a container as part of the build, publish it into ECR, and then publish it as an ECS Task in the end. A sample file will be created in the EFS (persistent file system) after the task has been completed. The security component is likewise handled by KMS Keys and IAM Roles.
 
@@ -21,10 +21,10 @@ Optionally, you can also specify env and organization (tagging purposes) and tas
 terraform init
 
 # terraform plan with sample values for vpc and subnet
-terraform plan  -var="aws_vpc_id=vpc-xxxx" -var='aws_subnets=["subnet-xxxx","subnet-xxxx","subnet-xxxx"]' 
+terraform plan -var="aws_vpc_id=vpc-xxxx" -var='aws_subnets=["subnet-xxxx","subnet-xxxx","subnet-xxxx"]'
 
 # terraform apply
-terraform apply -var="aws_vpc_id=vpc-xxxx" -var='aws_subnets=["subnet-xxxx","subnet-xxxx","subnet-xxxx"]' 
+terraform apply -var="aws_vpc_id=vpc-xxxx" -var='aws_subnets=["subnet-xxxx","subnet-xxxx","subnet-xxxx"]'
 ```
 
 Once deployed you can run the ECS task from the ECS Console or via AWS CLI which will create a sample file on the persistent storage using Amazon EFS

--- a/terraform-ecs-efs-integration/main.tf
+++ b/terraform-ecs-efs-integration/main.tf
@@ -14,7 +14,7 @@ locals {
     organization = var.organization
     env          = var.env
   }
-  region                 = data.aws_region.current.name
+  region                 = data.aws_region.current.region
   account_id             = data.aws_caller_identity.current.account_id
   standard_resource_name = "${var.env}-${var.organization}"
   ecr_base_arn           = "${local.account_id}.dkr.ecr.${local.region}.amazonaws.com"

--- a/terraform-ecs-efs-integration/templates/ecs-role.json
+++ b/terraform-ecs-efs-integration/templates/ecs-role.json
@@ -45,7 +45,7 @@
         "ecr:BatchGetImage",
         "ecr:GetDownloadUrlForLayer"
       ],
-      "Resource": "arn:aws:ecr:*:*:repository/${standard_resource_name}"
+      "Resource": "arn:aws:ecr:*:*:repository/${standard_resource_name}-efs-updater"
     },
     {
       "Sid": "ECSGrants",

--- a/terraform-ecs-efs-integration/versions.tf
+++ b/terraform-ecs-efs-integration/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.24"
+      version = "~> 6.0"
     }
     external = {
       source  = "hashicorp/external"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

To keep this pattern maintainable, I updated the AWS Provider to v6.

## Check

`terraform apply` completed successfully and works good.

```sh
$ aws ecs run-task \
    --cluster testing-serverlessland-efs-updater \
    --task-definition testing-serverlessland-efs-updater:1 \
    --network-configuration "awsvpcConfiguration={subnets=[subnet-xxxxxxxxxxxxxxxxx],securityGroups=[sg-xxxxxxxxxxxxxxxxx],assignPublicIp=DISABLED}" \
    --count 1 \
    --launch-type FARGATE \
    --region us-east-1
```

<img width="1920" height="863" alt="image" src="https://github.com/user-attachments/assets/982e79c9-8061-47b3-9b42-e483afd3ec03" />


Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.