### PR TITLE
Update deploy.sh to remove LocationConstraint parameter

### DIFF
--- a/lambda-microvms-kiro-code-reviewer/scripts/deploy.sh
+++ b/lambda-microvms-kiro-code-reviewer/scripts/deploy.sh
@@ -65,8 +65,7 @@ if ! aws s3api head-bucket --bucket "$STAGING_BUCKET" --region "$REGION" 2>/dev/
   echo "Creating staging bucket: $STAGING_BUCKET"
   aws s3api create-bucket \
     --bucket "$STAGING_BUCKET" \
-    --region "$REGION" \
-    --create-bucket-configuration LocationConstraint="$REGION"
+    --region "$REGION" 
   aws s3api put-public-access-block \
     --bucket "$STAGING_BUCKET" \
     --region "$REGION" \
@@ -166,7 +165,7 @@ echo "============================================"
 echo "Deployment Complete!"
 echo "============================================"
 echo ""
-echo "The following environment variables are now exported:"
+echo "Export the following environment variables:"
 echo ""
 echo "  export IMAGE_ARN=\"$IMAGE_ARN\""
 echo "  export EXECUTION_ROLE_ARN=\"$EXECUTION_ROLE_ARN\""


### PR DESCRIPTION
Removing regions constraint from the S3 bucket creation command. This command was used during preview and now it's preventing to create buckets in us-east-1.

*Issue #, if available:*

*Description of changes: Removing the LocationConstraint parameter from S3 bucket creation command. This parameter was used during preview phase. Now it's preventing the creation of buckets in us-east-1


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
