### PR TITLE
lambda-sns-sms-cdk: Update runtime to NODEJS_24_X

### DIFF
--- a/lambda-sns-sms-cdk/lambda_sns_sms_cdk/lambda_sns_sms_cdk_stack.py
+++ b/lambda-sns-sms-cdk/lambda_sns_sms_cdk/lambda_sns_sms_cdk_stack.py
@@ -35,7 +35,7 @@ class LambdaSnsSmsCdkStack(Stack):
                                                    code=aws_lambda.Code.from_asset('src'),
                                                    function_name='SMSPublisherFunction',
                                                    handler='app.handler',
-                                                   runtime=aws_lambda.Runtime.NODEJS_12_X,
+                                                   runtime=aws_lambda.Runtime.NODEJS_24_X,
                                                    timeout=Duration.seconds(3),
                                                    memory_size=128,
                                                    environment={'phoneNumber': phoneNumber.value_as_string,

--- a/lambda-sns-sms-cdk/requirements.txt
+++ b/lambda-sns-sms-cdk/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib==2.13.0
+aws-cdk-lib==2.260.0
 constructs>=10.0.0,<11.0.0

--- a/lambda-sns-sms-cdk/src/app.js
+++ b/lambda-sns-sms-cdk/src/app.js
@@ -1,9 +1,8 @@
 /*! Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  SPDX-License-Identifier: MIT-0
  */
-const AWS = require('aws-sdk')
-AWS.config.region = process.env.AWS_REGION 
-const sns = new AWS.SNS({apiVersion: '2012-11-05'})
+const { SNSClient, PublishCommand } = require('@aws-sdk/client-sns')
+const sns = new SNSClient()
 
 // The Lambda handler
 exports.handler = async (event) => {
@@ -19,8 +18,8 @@ exports.handler = async (event) => {
       }
     }
   }
-  
+
   // Send to SNS
-  const result = await sns.publish(params).promise()
+  const result = await sns.send(new PublishCommand(params))
   console.log(result)
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

To prevent future deployment issues, I updated the deprecated Lambda Node.js runtime nodejs12.x to nodejs24.x.
See https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

## Check

Since I don't have a US phone number, I commented out the `MessageAttributes (10DLC origination number)` and tested SMS delivery to a Japanese phone number.

```sh
$ cdk deploy --parameters phoneNumber=+8190xxxxxxxx --parameters tenDLC=dummy
$ aws lambda invoke --function-name SMSPublisherFunction response.json
{
    "StatusCode": 200,
    "ExecutedVersion": "$LATEST"
}
```

It works good!

```
Message at Fri Jun 26 2026 03:40:06 GMT+0000 (Coordinated Universal Time)
```

Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.