### PR TITLE
Fix framework field for lambda-microvms-from-ecr

### DIFF
--- a/lambda-microvms-from-ecr/example-pattern.json
+++ b/lambda-microvms-from-ecr/example-pattern.json
@@ -3,7 +3,7 @@
   "description": "Deploy an AWS Lambda MicroVM from a pre-built Docker image stored in Amazon ECR.",
   "language": "Python",
   "level": "200",
-  "framework": "AWS CLI",
+  "framework": "AWS CloudFormation",
   "introBox": {
     "headline": "How it works",
     "text": [


### PR DESCRIPTION
## Summary
- Change `"framework": "AWS CLI"` to `"framework": "CloudFormation"` in `example-pattern.json`
- The pattern deploys via CloudFormation (`template.yaml`), not raw AWS CLI
- This fix ensures Serverless Land displays the correct "CloudFormation" chip

## Test plan
- [ ] Verify the pattern page at serverlessland.com shows "CloudFormation" chip after merge