### PR TITLE
Fix framework field for lambda-microvms-claude-code-agent

### DIFF
--- a/lambda-microvms-claude-code-agent/example-pattern.json
+++ b/lambda-microvms-claude-code-agent/example-pattern.json
@@ -3,7 +3,7 @@
   "description": "Deploy an AWS Lambda MicroVM with the Claude Code CLI, powered by Amazon Bedrock and reachable through an interactive shell.",
   "language": "Python",
   "level": "200",
-  "framework": "AWS CLI",
+  "framework": "AWS CloudFormation",
   "introBox": {
     "headline": "How it works",
     "text": [


### PR DESCRIPTION
## Summary
- Change `"framework": "AWS CLI"` to `"framework": "CloudFormation"` in `example-pattern.json`
- The pattern deploys via CloudFormation (`template.yaml`), not raw AWS CLI
- This fix ensures Serverless Land displays the correct "CloudFormation" chip

## Test plan
- [ ] Verify the pattern page at serverlessland.com shows "CloudFormation" chip after merge