### PR TITLE
sfn-manage-container-task-tf: Update AWS Provider to v6 and remove leftover AWS Batch references

### DIFF
--- a/sfn-manage-container-task-tf/README.md
+++ b/sfn-manage-container-task-tf/README.md
@@ -38,9 +38,9 @@ Important: this application uses various AWS services and there are costs associ
 
 ## How it works
 
-This sample project demonstrates how to submit an AWS Batch job, and then send an Amazon SNS notification based on whether that job succeeds or fails. Deploying this sample project creates an AWS Step Functions state machine, an AWS Batch job, and an Amazon SNS topic.
+This sample project demonstrates how to run an AWS Fargate task, and then send an Amazon SNS notification based on whether that task succeeds or fails.
 
-In this project, Step Functions uses a state machine to call the AWS Batch job synchronously. It then waits for the job to succeed or fail, and it sends an Amazon SNS topic with a message about whether the job succeeded or failed.
+The state machine runs the Fargate task synchronously and waits for it to complete. The task simply runs an `echo` command in a container and exits. Based on the result, the state machine publishes a message to the Amazon SNS topic to notify whether the task succeeded or failed.
 
 ## Image
 

--- a/sfn-manage-container-task-tf/README.md
+++ b/sfn-manage-container-task-tf/README.md
@@ -5,7 +5,7 @@ This sample project demonstrates how to run an AWS Fargate task, and then send a
 In this project, Step Functions uses a state machine to call the Fargate task synchronously. It then waits for the task to succeed or fail, and it sends an Amazon SNS topic with a message about whether the job succeeded or failed.
 * A Fargate task
 * An Amazon SNS topic
-* AWS Step Function
+* AWS Step Functions
 * Related AWS Identity and Access Management (IAM) roles
 
 Learn more about this workflow at Step Functions workflows collection: https://docs.aws.amazon.com/step-functions/latest/dg/sample-project-container-task-notification.html
@@ -17,17 +17,17 @@ Important: this application uses various AWS services and there are costs associ
 * [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
 * [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
 * [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+* [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli) with version 1.x installed (this pattern has been tested with version 1.15)
 
 ## Deployment Instructions
 
 1. Create a new directory, navigate to that directory in a terminal and clone the GitHub repository:
     ``` 
-    git clone https://github.com/aws-samples/step-functions-workflows-collection
+    git clone https://github.com/aws-samples/serverless-patterns
     ```
 1. Change directory to the pattern directory:
     ```
-    cd sfn-manage-container-task-tf
+    cd serverless-patterns/sfn-manage-container-task-tf
     ```
 1. From the command line, use Terraform to deploy the AWS resources for the workflow as specified in the ```main.tf``` file:
     ```

--- a/sfn-manage-container-task-tf/main.tf
+++ b/sfn-manage-container-task-tf/main.tf
@@ -112,19 +112,6 @@ resource "aws_ecs_cluster" "fargate_cluster" {
   name = "FargateTaskNotification-${random_string.random.result}"
 }
 
-resource "aws_ecs_service" "example" {
-  name            = "example-service"
-  cluster         = aws_ecs_cluster.fargate_cluster.id
-  task_definition = aws_ecs_task_definition.fargate_task.arn
-  launch_type     = "FARGATE"
-  desired_count   = 1
-
-  network_configuration {
-    security_groups = [aws_security_group.fargate_sg.id]
-    subnets         = [module.vpc.public_subnet_1_id, module.vpc.public_subnet_2_id]
-  }
-}
-
 # Define SNS topic
 resource "aws_sns_topic" "sns_topic" {
   name = "FargateTaskNotification-${random_string.random.result}"

--- a/sfn-manage-container-task-tf/main.tf
+++ b/sfn-manage-container-task-tf/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~>4.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/sfn-manage-container-task-tf/main.tf
+++ b/sfn-manage-container-task-tf/main.tf
@@ -132,7 +132,7 @@ resource "aws_sns_topic" "sns_topic" {
 
 #SFN
 resource "aws_iam_role" "sfn_container_task_role" {
-  name = "start-batch-job-${random_string.random.result}"
+  name = "sfn-container-task-role-${random_string.random.result}"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -149,7 +149,7 @@ resource "aws_iam_role" "sfn_container_task_role" {
 }
 
 resource "aws_iam_policy" "sfn_container_task_policy" {
-  name = "sfn-conteiner-task-policy-${random_string.random.result}"
+  name = "sfn-container-task-policy-${random_string.random.result}"
 
   policy = jsonencode({
     "Version" : "2012-10-17",

--- a/sfn-manage-container-task-tf/main.tf
+++ b/sfn-manage-container-task-tf/main.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 provider "aws" {
-  region  = var.region
+  region = var.region
 }
 
 locals {
@@ -21,9 +21,9 @@ data "aws_partition" "partition" {}
 
 
 resource "random_string" "random" {
-  length           = 16
-  special          = false
-  upper            = false
+  length  = 16
+  special = false
+  upper   = false
 }
 
 # VPC
@@ -32,10 +32,10 @@ resource "random_string" "random" {
 module "vpc" {
   source = "./vpc"
 
-  vpc_name = "example-vpc"
-  cidr_block = "10.0.0.0/16"
+  vpc_name                  = "example-vpc"
+  cidr_block                = "10.0.0.0/16"
   public_subnet_cidr_blocks = ["10.0.1.0/24", "10.0.2.0/24"]
-  availability_zones = ["us-east-1a", "us-east-1b"]
+  availability_zones        = ["us-east-1a", "us-east-1b"]
 }
 
 # Security Group
@@ -87,15 +87,15 @@ resource "aws_ecs_task_definition" "fargate_task" {
   memory                   = 512
   execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
   requires_compatibilities = ["FARGATE"]
-  container_definitions    = jsonencode(
+  container_definitions = jsonencode(
     [
       {
         "cpu" : 256,
         "image" : "nginx",
         "memory" : 512,
         "name" : "my_container",
-        "command": ["echo", "Task succeeded!"],
-        "essential": true,
+        "command" : ["echo", "Task succeeded!"],
+        "essential" : true,
         "portMappings" : [
           {
             "containerPort" : 80,
@@ -103,7 +103,7 @@ resource "aws_ecs_task_definition" "fargate_task" {
           }
         ]
       }
-    ])
+  ])
 }
 
 
@@ -152,49 +152,49 @@ resource "aws_iam_policy" "sfn_container_task_policy" {
   name = "sfn-conteiner-task-policy-${random_string.random.result}"
 
   policy = jsonencode({
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Action": [
-                "sns:Publish"
-            ],
-            "Resource": [
-                aws_sns_topic.sns_topic.arn
-            ],
-            "Effect": "Allow"
-        },
-        {
-            "Action": [
-                "ecs:RunTask"
-            ],
-            "Resource": [
-                aws_ecs_task_definition.fargate_task.arn
-            ],
-            "Effect": "Allow"
-        },
-        {
-            "Action": [
-                "ecs:StopTask",
-                "ecs:DescribeTasks"
-            ],
-            "Resource": "*",
-            "Effect": "Allow"
-        },
-        {
-            "Action": [
-                "events:PutTargets",
-                "events:PutRule",
-                "events:DescribeRule",
-                "iam:PassRole"
-            ],
-            "Resource": [
-                "*"
-            ],
-            "Effect": "Allow"
-        }
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Action" : [
+          "sns:Publish"
+        ],
+        "Resource" : [
+          aws_sns_topic.sns_topic.arn
+        ],
+        "Effect" : "Allow"
+      },
+      {
+        "Action" : [
+          "ecs:RunTask"
+        ],
+        "Resource" : [
+          aws_ecs_task_definition.fargate_task.arn
+        ],
+        "Effect" : "Allow"
+      },
+      {
+        "Action" : [
+          "ecs:StopTask",
+          "ecs:DescribeTasks"
+        ],
+        "Resource" : "*",
+        "Effect" : "Allow"
+      },
+      {
+        "Action" : [
+          "events:PutTargets",
+          "events:PutRule",
+          "events:DescribeRule",
+          "iam:PassRole"
+        ],
+        "Resource" : [
+          "*"
+        ],
+        "Effect" : "Allow"
+      }
     ]
-}
-   )
+    }
+  )
 }
 
 resource "aws_iam_role_policy_attachment" "state_machine_custom_policy_attachment" {
@@ -203,13 +203,13 @@ resource "aws_iam_role_policy_attachment" "state_machine_custom_policy_attachmen
 }
 
 resource "aws_sfn_state_machine" "sfn_container_task" {
-  name       = "state-machine-container-task-${random_string.random.result}"
-  role_arn   = aws_iam_role.sfn_container_task_role.arn
+  name     = "state-machine-container-task-${random_string.random.result}"
+  role_arn = aws_iam_role.sfn_container_task_role.arn
   definition = templatefile("${path.module}/statemachine/statemachine.asl.json", {
-    sns_topic            = aws_sns_topic.sns_topic.arn,
-    ecs_cluster          = aws_ecs_cluster.fargate_cluster.arn,
-    task_definition      = aws_ecs_task_definition.fargate_task.arn,
-    subnet_a             = module.vpc.public_subnet_1_id,
-    subnet_b             = module.vpc.public_subnet_2_id
+    sns_topic       = aws_sns_topic.sns_topic.arn,
+    ecs_cluster     = aws_ecs_cluster.fargate_cluster.arn,
+    task_definition = aws_ecs_task_definition.fargate_task.arn,
+    subnet_a        = module.vpc.public_subnet_1_id,
+    subnet_b        = module.vpc.public_subnet_2_id
   })
 }

--- a/sfn-manage-container-task-tf/variables.tf
+++ b/sfn-manage-container-task-tf/variables.tf
@@ -1,25 +1,25 @@
 variable "region" {
-    type=string
-    description = "AWS Region where deploying resources"
-    default = "us-east-1"
+  type        = string
+  description = "AWS Region where deploying resources"
+  default     = "us-east-1"
 }
 
 variable "aws_profile_name" {
-    type=string
-    description = "AWS CLI credentials profile name"
-    default="default"
+  type        = string
+  description = "AWS CLI credentials profile name"
+  default     = "default"
 }
 
 variable "vpc_cidr" {
-    type=string
-    description = "CIDR block for Batch VPC"
-    default = "10.0.0.0/16"
+  type        = string
+  description = "CIDR block for Batch VPC"
+  default     = "10.0.0.0/16"
 }
 
 variable "subnet_cidr" {
-    type=string
-    description = "CIDR block for the Batch subnet"
-    default = "10.0.0.0/24"
+  type        = string
+  description = "CIDR block for the Batch subnet"
+  default     = "10.0.0.0/24"
 }
 
 variable "remote_cidr_blocks" {

--- a/sfn-manage-container-task-tf/variables.tf
+++ b/sfn-manage-container-task-tf/variables.tf
@@ -12,13 +12,13 @@ variable "aws_profile_name" {
 
 variable "vpc_cidr" {
   type        = string
-  description = "CIDR block for Batch VPC"
+  description = "CIDR block for the VPC"
   default     = "10.0.0.0/16"
 }
 
 variable "subnet_cidr" {
   type        = string
-  description = "CIDR block for the Batch subnet"
+  description = "CIDR block for the subnet"
   default     = "10.0.0.0/24"
 }
 

--- a/sfn-manage-container-task-tf/vpc/main.tf
+++ b/sfn-manage-container-task-tf/vpc/main.tf
@@ -22,12 +22,12 @@ resource "aws_internet_gateway" "main" {
 resource "aws_subnet" "public" {
   count = 2
 
-  vpc_id = aws_vpc.main.id
-  cidr_block = var.public_subnet_cidr_blocks[count.index]
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.public_subnet_cidr_blocks[count.index]
   availability_zone = var.availability_zones[count.index]
 
   tags = {
-    Name = "${var.vpc_name}-public-${count.index+1}"
+    Name = "${var.vpc_name}-public-${count.index + 1}"
   }
 }
 
@@ -42,16 +42,16 @@ resource "aws_route_table" "public" {
 
 # Create route for public subnets to internet gateway
 resource "aws_route" "public_igw" {
-  route_table_id = aws_route_table.public.id
+  route_table_id         = aws_route_table.public.id
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id = aws_internet_gateway.main.id
+  gateway_id             = aws_internet_gateway.main.id
 }
 
 # Associate public subnets with public route table
 resource "aws_route_table_association" "public" {
   count = 2
 
-  subnet_id = aws_subnet.public[count.index].id
+  subnet_id      = aws_subnet.public[count.index].id
   route_table_id = aws_route_table.public.id
 }
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

To keep this pattern maintainable, I updated the AWS Provider to v6.

I also found that this pattern mentioned AWS Batch in `README.md`, `main.tf` and `variables.tf`, even though it does not use AWS Batch at all. These mentions were probably copied from another AWS Batch based pattern. I fixed them to match the actual implementation. I also removed the unnecessary `aws_ecs_service` resource because the state machine runs the Fargate task directly with `ecs:runTask.sync`.

## Check

`terraform apply` completed successfully and works good.

<img width="464" height="366" alt="image" src="https://github.com/user-attachments/assets/0bc6d119-7e1a-4912-b44e-390206e8ffa5" />
<img width="463" height="321" alt="image" src="https://github.com/user-attachments/assets/a232f8da-88db-4be4-9f1b-64ec4395287d" />

Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.