### PR TITLE
apigw-websocket-api-sns-terraform: Update AWS Provider to v6

### DIFF
--- a/apigw-websocket-api-sns-terraform/README.md
+++ b/apigw-websocket-api-sns-terraform/README.md
@@ -37,7 +37,7 @@ Important: this application uses various AWS services and there are costs associ
 
 ## How it works
 
-This sample project demonstrates how to use WebSocket API to integrate with Amazon Simple Notification service (SNS) to send notifications. This pattern also implements data validation in WebSocket API using model in API Gateway. This template does not implement Authentication in WebSocket API to keep it simple. However, it is recommended to implement Authentication on WebSocket API.
+This sample project demonstrates how to use WebSocket API to integrate with Amazon Simple Notification Service (SNS) to send notifications. This pattern also implements data validation in WebSocket API using model in Amazon API Gateway. This template does not implement Authentication in WebSocket API to keep it simple. However, it is recommended to implement Authentication on WebSocket API.
 This pattern is utilizing native AWS Integration between WebSocket API Gateway and SNS. Request template is used in WebSocket integration to map the input to SNS payload.
 This pattern is also a workaround to invoke AWS services in WebSocket API which requires Content-Type header to be application/x-www-form-urlencoded. By default, WebSocket APIs do not support overriding headers from AWS console and supports application/json in Content-Type header.
 

--- a/apigw-websocket-api-sns-terraform/main.tf
+++ b/apigw-websocket-api-sns-terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0.0"
+      version = "~> 6.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/apigw-websocket-api-sns-terraform/main.tf
+++ b/apigw-websocket-api-sns-terraform/main.tf
@@ -158,7 +158,7 @@ resource "aws_apigatewayv2_integration_response" "disconnect_route_integration_r
 resource "aws_apigatewayv2_integration" "send_order_route_integration" {
   api_id                    = aws_apigatewayv2_api.web_socket_api.id
   integration_type          = "AWS"
-  integration_uri           = "arn:aws:apigateway:${data.aws_region.current.name}:sns:action/Publish"
+  integration_uri           = "arn:aws:apigateway:${data.aws_region.current.region}:sns:action/Publish"
   credentials_arn           = aws_iam_role.apigw_sns_demo_functionrole.arn
   integration_method        = "POST"
   content_handling_strategy = "CONVERT_TO_TEXT"
@@ -206,5 +206,5 @@ resource "aws_apigatewayv2_integration_response" "send_order_route_integration_r
 
 output "api_endpoint" {
   description = "API Gateway endpoint URL"
-  value       = "wss://${aws_apigatewayv2_api.web_socket_api.id}.execute-api.${data.aws_region.current.name}.amazonaws.com/${var.api_stage_name}"
+  value       = "wss://${aws_apigatewayv2_api.web_socket_api.id}.execute-api.${data.aws_region.current.region}.amazonaws.com/${var.api_stage_name}"
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hi😀 Thanks for the useful patterns!

To keep this pattern maintainable, I updated the AWS Provider to v6.

## Check
`terraform apply` completed successfully and works good.

```sh
$ terraform apply

(snip)

Apply complete! Resources: 18 added, 0 changed, 0 destroyed.

Outputs:

api_endpoint = "wss://bv8ja5rlhh.execute-api.eu-west-1.amazonaws.com/production"
```

```sh
$ wscat -c wss://bv8ja5rlhh.execute-api.eu-west-1.amazonaws.com/production
Connected (press CTRL+C to quit)
> {"action":"sendOrder","Name":"Jon","SirName":"Doe","Number":"123"}
< {"PublishResponse":{"PublishResult":{"MessageId":"0b1c70b8-bf06-5ea5-8dba-13bb8edcfc97","SequenceNumber":null},"ResponseMetadata":{"RequestId":"02f83580-f7f5-5e8c-a7f3-5683c62f8cbe"}}}
```

Thank you😀

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.